### PR TITLE
Hide channel combo boxes

### DIFF
--- a/ginga/gtkw/GingaGtk.py
+++ b/ginga/gtkw/GingaGtk.py
@@ -123,6 +123,7 @@ class GingaView(GtkMain.GtkMain):
         self.w.tooltips.set_tip(cbox, "Select a channel")
         cbox.connect("changed", self.channel_select_cb)
         hbox.pack_start(cbox, fill=False, expand=False, padding=4)
+        cbox.hide()
 
         opmenu = gtk.Menu()
         self.w.operation = opmenu

--- a/ginga/qtw/GingaQt.py
+++ b/ginga/qtw/GingaQt.py
@@ -114,6 +114,7 @@ class GingaView(QtMain.QtMain):
         cbox1.setToolTip("Select a channel")
         cbox1.activated.connect(self.channel_select_cb)
         hbox.addWidget(cbox1, stretch=0)
+        cbox1.hide()
 
         opmenu = QtGui.QMenu()
         self.w.operation = opmenu


### PR DESCRIPTION
Right now I find the combo box below the main image window a bit confusing because it duplicates information that is above the image window (the names of all the channels and a way to switch between them).  It also is confusing because it's next to the button(s) to invoke/switch between the plugins, but it has nothing conceptually to do with the plugins.  

So this PR rectifies the situation by just hiding the combo box.  I originally tried to just remove it, but this lead to errors because it seems that the channels were not getting correctly initialized for some reason.

I also could only test the qt version, because I don't have an easy way to run something with gtk right now.