### PR TITLE
changed cuts to use steps-mid draw style

### DIFF
--- a/ginga/gtkw/Plot.py
+++ b/ginga/gtkw/Plot.py
@@ -44,10 +44,10 @@ class Plot(Callback.Callbacks):
 
     def get_widget(self):
         return self.canvas
-    
+
     def getAxis(self):
         return self.ax
-    
+
     def _sanity_check_window(self):
         pass
 
@@ -77,7 +77,7 @@ class Plot(Callback.Callbacks):
         self._sanity_check_window()
         self.logger.debug('hiding window...')
         pass
-    
+
     def close(self):
         self.logger.debug('closing window....')
         self.canvas.destroy()
@@ -88,19 +88,20 @@ class Plot(Callback.Callbacks):
     def _draw(self):
         self.fig.canvas.draw()
 
-    def plot(self, xarr, yarr, xtitle=None, ytitle=None, title=None,
-             rtitle=None, color=None, alpha=1.0):
-        self.set_titles(xtitle=xtitle, ytitle=ytitle, title=title,
-                        rtitle=rtitle)
-        if not color:
-            self.ax.plot(xarr, yarr, linewidth=1.0, alpha=alpha,
-                         linestyle='-')
-        else:
-            self.ax.plot(xarr, yarr, linewidth=1.0, color=color,
-                         alpha=alpha, linestyle='-')
+    def plot(self, xarr, yarr, **kwargs):
+        self.set_titles(xtitle=kwargs.pop('xtitle', None),
+                        ytitle=kwargs.pop('ytitle', None),
+                        title=kwargs.pop('title', None),
+                        rtitle=kwargs.pop('rtitle', None))
+
+        kwargs.setdefault('color', None)
+        kwargs.setdefault('alpha', 1.0)
+
+        self.ax.plot(xarr, yarr, **kwargs)
+
         self.ax.grid(True)
         self._draw()
-        
+
 
 class Histogram(Plot):
 
@@ -124,17 +125,12 @@ class Histogram(Plot):
 
 class Cuts(Plot):
 
-    def cuts(self, data,
-             xtitle=None, ytitle=None, title=None, rtitle=None,
-             color=None):
+    def cuts(self, data, **kwargs:
         """data: pixel values along a line.
         """
         y = data
         x = numpy.arange(len(data))
-        #self.clear()
-        self.set_titles(xtitle=xtitle, ytitle=ytitle, title=title,
-                        rtitle=rtitle)
-        self.plot(x, y, color=color)
+        self.plot(x, y, **kwargs)
 
 
 #END

--- a/ginga/misc/plugins/CutsBase.py
+++ b/ginga/misc/plugins/CutsBase.py
@@ -1,6 +1,6 @@
 #
 # CutsBase.py -- Cuts plugin base class for Ginga
-# 
+#
 # Eric Jeschke (eric@naoj.org)
 #
 # Copyright (c) Eric R. Jeschke.  All rights reserved.
@@ -32,7 +32,7 @@ class CutsBase(GingaPlugin.LocalPlugin):
         chname = self.fv.get_channelName(self.fitsimage)
         self.fv.stop_operation_channel(chname, str(self))
         return True
-        
+
     def start(self):
         # start line cuts operation
         self.instructions()
@@ -51,7 +51,7 @@ class CutsBase(GingaPlugin.LocalPlugin):
 
     def pause(self):
         self.canvas.ui_setActive(False)
-        
+
     def resume(self):
         self.canvas.ui_setActive(True)
         self.fv.showStatus("Draw a line with the right mouse button")
@@ -75,8 +75,8 @@ class CutsBase(GingaPlugin.LocalPlugin):
                                                    int(line.x2), int(line.y2))
         points = numpy.array(points)
         self.plot.cuts(points, xtitle="Line Index", ytitle="Pixel Value",
-                       color=color)
-        
+                       color=color, drawstyle='steps-mid')
+
     def _redo(self, lines, colors):
         for idx in xrange(len(lines)):
             line, color = lines[idx], colors[idx]
@@ -85,7 +85,7 @@ class CutsBase(GingaPlugin.LocalPlugin):
             #text.color = color
             self._plotpoints(line, color)
         return True
-    
+
     def redo(self):
         self.plot.clear()
         idx = 0
@@ -117,7 +117,7 @@ class CutsBase(GingaPlugin.LocalPlugin):
             res = l[0]
             res.extend(self._append_lists(l[1:]))
             return res
-        
+
     def _getlines(self, obj):
         if obj.kind == 'compound':
             return self._append_lists(map(self._getlines, obj.objects))
@@ -125,10 +125,10 @@ class CutsBase(GingaPlugin.LocalPlugin):
             return [obj]
         else:
             return []
-        
+
     def buttondown_cb(self, canvas, button, data_x, data_y):
         return self.motion_cb(canvas, button, data_x, data_y)
-    
+
     def motion_cb(self, canvas, button, data_x, data_y):
         if not (button == 0x1):
             return
@@ -140,17 +140,17 @@ class CutsBase(GingaPlugin.LocalPlugin):
         self._movecut(obj, data_x, data_y)
 
         canvas.redraw(whence=3)
-    
+
     def buttonup_cb(self, canvas, button, data_x, data_y):
         if not (button == 0x1):
             return
-        
+
         obj = self.canvas.getObjectByTag(self.cutstag)
         lines = self._getlines(obj)
         for line in lines:
             line.linestyle = 'solid'
         self._movecut(obj, data_x, data_y)
-        
+
         self.redo()
 
     def keydown(self, canvas, keyname):
@@ -192,7 +192,7 @@ class CutsBase(GingaPlugin.LocalPlugin):
             self.logger.debug("adding cut position")
             self.count += 1
             count = self.count
-            
+
         tag = "cuts%d" % (count)
         cuts = []
         for (x1, y1, x2, y2) in coords:
@@ -211,7 +211,7 @@ class CutsBase(GingaPlugin.LocalPlugin):
             cut = cuts[0]
         else:
             cut = self._combine_cuts(*cuts)
-            
+
         cut.set_data(count=count)
         self.canvas.add(cut, tag=tag)
         self.addCutsTag(tag, select=True)
@@ -242,7 +242,7 @@ class CutsBase(GingaPlugin.LocalPlugin):
             self.logger.debug("adding cut position")
             self.count += 1
             count = self.count
-            
+
         tag = "cuts%d" % (count)
         if obj.kind == 'line':
             cut = self._create_cut(x, y, count,
@@ -279,5 +279,5 @@ class CutsBase(GingaPlugin.LocalPlugin):
 
         self.logger.debug("redoing cut plots")
         return self.redo()
-    
+
 #END

--- a/ginga/qtw/Plot.py
+++ b/ginga/qtw/Plot.py
@@ -42,7 +42,7 @@ class Plot(Callback.Callbacks):
 
     def get_widget(self):
         return self.canvas
-    
+
     def _sanity_check_window(self):
         pass
 
@@ -83,19 +83,20 @@ class Plot(Callback.Callbacks):
     def _draw(self):
         self.fig.canvas.draw()
 
-    def plot(self, xarr, yarr, xtitle=None, ytitle=None, title=None,
-             rtitle=None, color=None, alpha=1.0):
-        self.set_titles(xtitle=xtitle, ytitle=ytitle, title=title,
-                        rtitle=rtitle)
-        if not color:
-            self.ax.plot(xarr, yarr, linewidth=1.0, alpha=alpha,
-                         linestyle='-')
-        else:
-            self.ax.plot(xarr, yarr, linewidth=1.0, color=color,
-                         alpha=alpha, linestyle='-')
+    def plot(self, xarr, yarr, **kwargs):
+        self.set_titles(xtitle=kwargs.pop('xtitle', None),
+                        ytitle=kwargs.pop('ytitle', None),
+                        title=kwargs.pop('title', None),
+                        rtitle=kwargs.pop('rtitle', None))
+
+        kwargs.setdefault('color', None)
+        kwargs.setdefault('alpha', 1.0)
+
+        self.ax.plot(xarr, yarr, **kwargs)
+
         self.ax.grid(True)
         self._draw()
-        
+
 
 class Histogram(Plot):
 
@@ -119,17 +120,12 @@ class Histogram(Plot):
 
 class Cuts(Plot):
 
-    def cuts(self, data,
-             xtitle=None, ytitle=None, title=None, rtitle=None,
-             color=None):
+    def cuts(self, data, **kwargs):
         """data: pixel values along a line.
         """
         y = data
         x = numpy.arange(len(data))
-        #self.clear()
-        self.set_titles(xtitle=xtitle, ytitle=ytitle, title=title,
-                        rtitle=rtitle)
-        self.plot(x, y, color=color)
+        self.plot(x, y, **kwargs)
 
 
 #END


### PR DESCRIPTION
This changes the cuts plugin to use the matplotlib `drawstyle` called "steps-mid".  That draw style seems more appropriate for pixel data, because the pixels have a fixed value over their index, rather than a continuous linear interpolation.

(Not that I can't test the gtk side of this, but none of it is gtk-specific, and the qt side works fine.)
