### PR TITLE
Include README.txt and LICENSE.txt in the source distribution without installing them

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE.txt

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ setup(
                      'ginga.doc': ['manual/*.html'],
                      'ginga.gtkw': ['gtk_rc'],
                      },
-    data_files = [('', ['LICENSE.txt', 'README.txt'])],
     scripts = ['scripts/ginga', 'scripts/grc'],
     classifiers = [
         "License :: OSI Approved :: BSD License",


### PR DESCRIPTION
With the current setup.py file, README.txt and LICENSE.txt are installed under %prefix when the package is installed via "python setup.py install" The default prefix in linux is /usr/local, so these files end up there.

I think this behaviour is not intented (usually README.txt and LICENSE.txt are not installed), so I have created MANIFEST.in and I have added LICENSE.txt to it. 
The MANIFEST file is created from the template MANIFEST.in. README.txt is added to MANIFEST by default and LICENSE.txt is included from MANIFEST.in

I have removed the line in setup.py that mentions REAME and LICENSE.

With these modification, README.txt and LICENSE.txt are included in the source distribution but not installed by python setup.py install
