### PR TITLE
minor tweaks to get sphinx build to not issue warnings

### DIFF
--- a/doc/LICENSE.rst
+++ b/doc/LICENSE.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Copyright (c) 2011-2013, Eric R. Jeschke
 
 All rights reserved.

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -16,6 +16,10 @@ I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 
 .PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest gettext
 
+#This creates the "_static" directory if it does not exist
+#it is needed  because git doesn't store empty directories
+$(shell [ -d "_static" ] || mkdir -p _static)
+
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
 	@echo "  html       to make standalone HTML files"

--- a/doc/manual/internals.rst
+++ b/doc/manual/internals.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 +++++++++++++++++++++++++++
 Ginga Programming Internals
 +++++++++++++++++++++++++++


### PR DESCRIPTION
I just tried building the new sphinx docs - they look nice, but I noticed it was issuing 3 warnings.  Two were about documents that aren't in the TOC, and the third was about a missing `_static` directory.  This PR fixes those problems - the former by adding the `:orphan:` tag to the files (which tells sphinx that they aren't _supposed_ to be in the TOC), and the latter by adding a tweak in the Makefile that creates an empty `_static` directory if it is missing.
