### PR TITLE
override matplotlib rcParams to give more consistent plots

### DIFF
--- a/ginga/gtkw/Plot.py
+++ b/ginga/gtkw/Plot.py
@@ -16,6 +16,7 @@ import gtk
 
 import matplotlib
 matplotlib.use('GTKCairo')
+matplotlib.rcParams.update(matplotlib.rcParamsDefault)
 from  matplotlib.backends.backend_gtkcairo import FigureCanvasGTKCairo \
      as FigureCanvas
 import pango

--- a/ginga/qtw/Plot.py
+++ b/ginga/qtw/Plot.py
@@ -17,6 +17,7 @@ from ginga.qtw.QtHelp import QtGui, QtCore
 from ginga.qtw import QtHelp
 
 import matplotlib
+matplotlib.rcParams.update(matplotlib.rcParamsDefault)
 from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigureCanvas
 
 from ginga.misc import Callback


### PR DESCRIPTION
I've noticed that when I do something in ginga that uses matplotlib, the axes labels are often strange sizes, and in general my plots are hard to see (@ejesche, I think I showed this to you in person last month).  I traced this to the fact that ginga is using my `~/.matplotlib/matplotlibrc` when making matplotlib plots, which I have set to have bigger labels in general.  But that's not good for ginga.

So this PR just overrides whatever the user's matplotlibrc file might say, and instead uses the defaults built-in to matplotlib.  Now the plots look much more reasonable and fit inside e.g. the plugin window on the standard ginga layout.

There is a possible downside to this (very simple) implementation, though: it means that on-import (at least of the `Plot` modules), `ginga` will silently override anyone's matplotlibrc.  This means that if they just import ginga for some other reason (e.g. just to have a ginga window), they might unexpectedly see their matplotlibrc file ignored.  I can think of a variety of possible solutions for this, but I figured I should see what @ejesche thinks about this first.
