### PR TITLE
Make ginga compatible with latest astropy.io.fits/pyfits

### DIFF
--- a/ginga/AstroImage.py
+++ b/ginga/AstroImage.py
@@ -890,8 +890,14 @@ class AstroHeader(Header):
 
     def fromHDU(self, hdu):
         header = hdu.header
-        for card in header.cards:
-            bnch = self.__setitem__(card.key, card.value)
-            bnch.comment = card.comment
+        if hasattr(header, 'cards'):
+            #newer astropy.io.fits don't have ascardlist
+            for card in header.cards:
+                bnch = self.__setitem__(card.key, card.value)
+                bnch.comment = card.comment
+        else:
+            for card in header.ascardlist():
+                bnch = self.__setitem__(card.key, card.value)
+                bnch.comment = card.comment
 
 #END


### PR DESCRIPTION
Sometime in the last couple weeks, ginga became broken when use with the latest astropy.io.fits - I couldn't load any fits files due to an exception with an `ascardlist` function.

The reason is the use of the `Header.ascardlist` method.  Apparently that's been deprecated for some time, and is replaces by the `cards` property. See https://pyfits.readthedocs.org/en/latest/appendix/header_transition.html for more on this topic.

This small change fixes the problem, and makes ginga work again with the latest astropy.io.fits
