### PR TITLE
Added readthedocs link and fix broken install link

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,11 +65,12 @@ Ginga is distributed under an open-source BSD licence.  Please see the file LICE
 
 <p>The program can then be run using the command "ginga"</p>
 	
-<p>For more information on installation, please see the file <a href="https://github.com/ejeschke/ginga/blob/master/ginga/doc/INSTALL.txt">doc/INSTALL.txt</a></p>
+<p>For more information on installation, please see the file <a href="https://github.com/ejeschke/ginga/blob/master/doc/install.rst">doc/install.txt</a></p>
 
-<h3>How do I run this thing?</h3>
+<h3>How do I use this thing?</h3>
 
-<p>PDF versions of the manual and training videos are available in the <a href="https://github.com/ejeschke/ginga/downloads">downloads</a>.  Be sure to also check out the <a href="https://github.com/ejeschke/ginga/wiki">wiki</a> and <a href="https://github.com/ejeschke/ginga/wiki/FAQ">FAQ</a>.</p>
+<p>An up-to-date version of the manual is always <a href ="https://ginga.readthedocs.org/en/latest/index.html"> available on readthedocs</a>.  PDF versions of the manual and training videos are available in the <a href="https://github.com/ejeschke/ginga/downloads">downloads</a>.
+Be sure to also check out the <a href="https://github.com/ejeschke/ginga/wiki">wiki</a> and <a href="https://github.com/ejeschke/ginga/wiki/FAQ">FAQ</a>.</p>
 
 <h3>Bug reports?</h3>
 


### PR DESCRIPTION
This updates the ginga web site to reflect the presence of the readthedocs manual, and also fixes the broken install doc link.  

You can see what it looks like at http://eteq.github.io/ginga/
