### PR TITLE
New Astropy coordinate patches and SunPy coordinate support

### DIFF
--- a/ginga/AstroImage.py
+++ b/ginga/AstroImage.py
@@ -559,10 +559,9 @@ class AstroImage(BaseImage):
                 elif system == 'ecliptic':
                     ra_lbl, dec_lbl = u"\u03BB", u"\u03B2"
                 elif system == 'helioprojective':
-                    lon_wrap = ((lon_deg - 180.) % 360.) - (360. - 180.)
-                    ra_txt = "%+5.3f" % (lon_wrap*3600)
+                    ra_txt = "%+5.3f" % (lon_deg*3600)
                     dec_txt = "%+5.3f" % (lat_deg*3600)
-                    ra_lbl, dec_lbl = u"x-Solar \u2033", u"y-Solar \u2033"
+                    ra_lbl, dec_lbl = u"x-Solar", u"y-Solar"
 
         except Exception, e:
             self.logger.warn("Bad coordinate conversion: %s" % (

--- a/ginga/util/wcsmod.py
+++ b/ginga/util/wcsmod.py
@@ -127,14 +127,13 @@ def use(wcspkg, raise_err=True):
             WCS = AstropyWCS
             
             if hasattr(coordinates, 'SkyCoord'):
-                have_astropy_04 = True
                 try:
                     import sunpy.coordinates
                 except ImportError:
                     pass
                 coord_types = [f.name for f in coordinates.frame_transform_graph.frame_set]
             else:
-                coord_types = ['icrs', 'fk5', 'fk4', 'galactic', 'helioprojective']
+                coord_types = ['icrs', 'fk5', 'fk4', 'galactic']
             
             return True
 
@@ -344,7 +343,6 @@ class AstropyWCS(BaseWCS):
                                          dec_deg * units.degree,
                                          frame=self.coordsys)
             coord = coord.transform_to(system)
-            
         return coord
 
     def _deg(self, coord):
@@ -361,9 +359,8 @@ class AstropyWCS(BaseWCS):
             # older astropy
             return (self._deg(c.lonangle), self._deg(c.latangle))
         else:
-            from astropy.coordinates import SphericalRepresentation
-            rs = c.represent_as(SphericalRepresentation)
-            return (self._deg(rs.lon), self._deg(rs.lat))
+            r = c.frame.data
+            return map(self._deg, [getattr(r, component) for component in r.components[:2]])
 
 
 class AstLibWCS(BaseWCS):


### PR DESCRIPTION
I don't know if you want the SunPy stuff hard coded in Ginga, but it shouldn't cause you any issues.

I have also done some tweaks which make more use of SkyCoord and the new coordinates framework. The list of available WCS coords is now populated from the transform graph. Also in a bit of a weird hack, I removed any Frame dependency on the SkyCoord attribute access.
