### PR TITLE
Python 3 test fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,8 @@ distribute-*.tar.gz
 # Mac OSX
 .DS_Store
 
+# Eclipse editor project files
+.project
+.pydevproject
+.settings
+

--- a/ginga/misc/Callback.py
+++ b/ginga/misc/Callback.py
@@ -71,7 +71,7 @@ class Callbacks(object):
                 if res:
                     result = True
                 
-            except Exception, e:
+            except Exception as e:
                 # Catch exception because we need to iterate to the other
                 # callbacks
                 try:

--- a/ginga/misc/Settings.py
+++ b/ginga/misc/Settings.py
@@ -158,12 +158,12 @@ class SettingGroup(object):
                         key = line[:i].strip()
                         val = eval(line[i+1:].strip())
                         d[key] = val
-                    except Exception, e:
+                    except Exception as e:
                         # silently skip parse errors, for now
                         continue
                         
             self.setDict(d)
-        except Exception, e:
+        except Exception as e:
             errmsg = "Error opening settings file (%s): %s" % (
                 self.preffile, str(e))
             if onError == 'silent':
@@ -199,7 +199,7 @@ class SettingGroup(object):
                 for key in keys:
                     out_f.write("%s = %s\n" % (key, repr(d[key])))
                         
-        except Exception, e:
+        except Exception as e:
             errmsg = "Error opening settings file (%s): %s" % (
                 self.preffile, str(e))
             self.logger.error(errmsg)


### PR DESCRIPTION
Currently Python 3 tests fail like this:

```
$ python3.4 setup.py test
running test
running egg_info
writing dependency_links to ginga.egg-info/dependency_links.txt
writing ginga.egg-info/PKG-INFO
writing requirements to ginga.egg-info/requires.txt
writing top-level names to ginga.egg-info/top_level.txt
reading manifest file 'ginga.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'ginga.egg-info/SOURCES.txt'
running build_ext
Traceback (most recent call last):
  File "setup.py", line 69, in <module>
    cmdclass={'build_py': build_py}
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/distutils/core.py", line 148, in setup
    dist.run_commands()
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/distutils/dist.py", line 955, in run_commands
    self.run_command(cmd)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/distutils/dist.py", line 974, in run_command
    cmd_obj.run()
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/site-packages/setuptools/command/test.py", line 142, in run
    self.with_project_on_sys_path(self.run_tests)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/site-packages/setuptools/command/test.py", line 122, in with_project_on_sys_path
    func()
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/site-packages/setuptools/command/test.py", line 163, in run_tests
    testRunner=self._resolve_as_ep(self.test_runner),
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/unittest/main.py", line 92, in __init__
    self.parseArgs(argv)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/unittest/main.py", line 139, in parseArgs
    self.createTests()
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/unittest/main.py", line 146, in createTests
    self.module)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/unittest/loader.py", line 146, in loadTestsFromNames
    suites = [self.loadTestsFromName(name, module) for name in names]
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/unittest/loader.py", line 146, in <listcomp>
    suites = [self.loadTestsFromName(name, module) for name in names]
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/unittest/loader.py", line 117, in loadTestsFromName
    return self.loadTestsFromModule(obj)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/site-packages/setuptools/command/test.py", line 37, in loadTestsFromModule
    tests.append(self.loadTestsFromName(submodule))
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/unittest/loader.py", line 105, in loadTestsFromName
    module = __import__('.'.join(parts_copy))
  File "/Users/deil/code/ginga/ginga/tests/test_ImageView.py", line 5, in <module>
    from ginga import ImageView, AstroImage
  File "/Users/deil/code/ginga/ginga/ImageView.py", line 17, in <module>
    from ginga.misc import Callback, Settings
  File "/Users/deil/code/ginga/ginga/misc/Callback.py", line 74
    except Exception, e:
                    ^
SyntaxError: invalid syntax
```
