### PR TITLE
Python 3 issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: python
 
 python:
-    # *** TODO: `python setup.py egg_info` currently doesn't work for `ginga` ... skipping for now
-    #- 2.7
-    #- 3.3
-    #- 3.4
+    - 2.7
+    - 3.3
+    - 3.4
     # This is just for "egg_info".  All other builds are explicitly given in the matrix
 env:
     global:
@@ -15,9 +14,8 @@ env:
         - ASTROPY_VERSION=stable
         - CONDA_INSTALL='conda install -c astropy-ci-extras --yes'
         - PIP_INSTALL='pip install'
-    # *** TODO: `python setup.py egg_info` currently doesn't work for `ginga` ... skipping for now
-    #matrix:
-    #    - SETUP_CMD='egg_info'
+    matrix:
+        - SETUP_CMD='egg_info'
 
 matrix:
     include:
@@ -53,8 +51,6 @@ matrix:
           env: NUMPY_VERSION=1.7 SETUP_CMD='test'
         - python: 2.7
           env: NUMPY_VERSION=1.6 SETUP_CMD='test'
-        - python: 2.7
-          env: NUMPY_VERSION=1.5 SETUP_CMD='test'
 
 before_install:
 


### PR DESCRIPTION
@ejeschke I forgot ... does Ginga support Python 3?

I thought it does, but the tests currently don't pass:
https://travis-ci.org/ejeschke/ginga/jobs/42519643#L263

and I can't start the reference viewer on my machine with Python 3:

``` python
$ ginga
Traceback (most recent call last):
  File "/Users/deil/Library/Python/3.4/bin/ginga", line 4, in <module>
    __import__('pkg_resources').run_script('ginga==2.0.20141130031913', 'ginga')
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/site-packages/pkg_resources.py", line 517, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/site-packages/pkg_resources.py", line 1436, in run_script
    exec(code, namespace, namespace)
  File "/Users/deil/Library/Python/3.4/lib/python/site-packages/ginga-2.0.20141130031913-py3.4.egg/EGG-INFO/scripts/ginga", line 14, in <module>
    main.reference_viewer(sys.argv)
  File "/Users/deil/Library/Python/3.4/lib/python/site-packages/ginga-2.0.20141130031913-py3.4.egg/ginga/main.py", line 475, in reference_viewer
    viewer.main(options, args)
  File "/Users/deil/Library/Python/3.4/lib/python/site-packages/ginga-2.0.20141130031913-py3.4.egg/ginga/main.py", line 260, in main
    from ginga.qtw.GingaQt import GingaView
  File "/Users/deil/Library/Python/3.4/lib/python/site-packages/ginga-2.0.20141130031913-py3.4.egg/ginga/qtw/GingaQt.py", line 32, in <module>
    from ginga.qtw import ImageViewCanvasQt, ColorBar, Readout, PluginManagerQt, \
  File "/Users/deil/Library/Python/3.4/lib/python/site-packages/ginga-2.0.20141130031913-py3.4.egg/ginga/qtw/ImageViewCanvasQt.py", line 12, in <module>
    from ginga.qtw.ImageViewCanvasTypesQt import *
  File "/Users/deil/Library/Python/3.4/lib/python/site-packages/ginga-2.0.20141130031913-py3.4.egg/ginga/qtw/ImageViewCanvasTypesQt.py", line 15, in <module>
    from ginga.canvas.mixins import *
  File "/Users/deil/Library/Python/3.4/lib/python/site-packages/ginga-2.0.20141130031913-py3.4.egg/ginga/canvas/mixins.py", line 4, in <module>
    from CanvasObject import *
ImportError: No module named 'CanvasObject'
```
