### PR TITLE
Python 3 error with matplotlib/example1_mpl.py

### DIFF
--- a/examples/matplotlib/example1_mpl.py
+++ b/examples/matplotlib/example1_mpl.py
@@ -91,7 +91,7 @@ class FitsViewer(QtGui.QMainWindow):
         res = QtGui.QFileDialog.getOpenFileName(self, "Open FITS file",
                                                 ".", "FITS files (*.fits)")
         if isinstance(res, tuple):
-            fileName = res[0].encode('ascii')
+            fileName = res[0]
         else:
             fileName = str(res)
         self.load_file(fileName)

--- a/examples/matplotlib/example2_mpl.py
+++ b/examples/matplotlib/example2_mpl.py
@@ -157,7 +157,7 @@ class FitsViewer(QtGui.QMainWindow):
         res = QtGui.QFileDialog.getOpenFileName(self, "Open FITS file",
                                                      ".", "FITS files (*.fits)")
         if isinstance(res, tuple):
-            fileName = res[0].encode('ascii')
+            fileName = res[0]
         else:
             fileName = str(res)
         self.load_file(fileName)

--- a/examples/matplotlib/example3_mpl.py
+++ b/examples/matplotlib/example3_mpl.py
@@ -252,7 +252,7 @@ class FitsViewer(QtGui.QMainWindow):
         res = QtGui.QFileDialog.getOpenFileName(self, "Open FITS file",
                                                      ".", "FITS files (*.fits)")
         if isinstance(res, tuple):
-            fileName = res[0].encode('ascii')
+            fileName = res[0]
         else:
             fileName = str(res)
         self.load_file(fileName)

--- a/examples/qt/example1_qt.py
+++ b/examples/qt/example1_qt.py
@@ -77,7 +77,7 @@ class FitsViewer(QtGui.QMainWindow):
         res = QtGui.QFileDialog.getOpenFileName(self, "Open FITS file",
                                                 ".", "FITS files (*.fits)")
         if isinstance(res, tuple):
-            fileName = res[0].encode('ascii')
+            fileName = res[0]
         else:
             fileName = str(res)
         self.load_file(fileName)

--- a/examples/qt/example2_qt.py
+++ b/examples/qt/example2_qt.py
@@ -150,7 +150,7 @@ class FitsViewer(QtGui.QMainWindow):
         res = QtGui.QFileDialog.getOpenFileName(self, "Open FITS file",
                                                      ".", "FITS files (*.fits)")
         if isinstance(res, tuple):
-            fileName = res[0].encode('ascii')
+            fileName = res[0]
         else:
             fileName = str(res)
         self.load_file(fileName)

--- a/ginga/qtw/ipg.py
+++ b/ginga/qtw/ipg.py
@@ -267,7 +267,7 @@ class StartMenu(QtGui.QMainWindow):
         res = QtGui.QFileDialog.getOpenFileName(self, "Open FITS file",
                                                 ".", "FITS files (*.fits)")
         if isinstance(res, tuple):
-            fileName = res[0].encode('ascii')
+            fileName = res[0]
         else:
             fileName = str(res)
         self.load_file(fileName, name)

--- a/ginga/util/io_fits.py
+++ b/ginga/util/io_fits.py
@@ -266,7 +266,7 @@ class FitsioFileHandler(BaseFitsFileHandler):
 
 def get_path(fileSpec):
     path = fileSpec
-    if fileSpec.startswith(u'file://'):
+    if fileSpec.startswith('file://'):
         path = fileSpec[7:]
 
     # TODO: handle web references by fetching the file


### PR DESCRIPTION
I tried running `matplotlib/example1_mpl.py` with Python 3.4 on Mac.

First I get this error on startup:

``` python
$ python3.4 ./matplotlib/example1_mpl.py
No method found matching 'kp_edit_del'
No method found matching 'kp_poly_add'
No method found matching 'ms_wheel'
No method found matching 'ms_none'
No method found matching 'kp_poly_del'
No method found matching 'ms_draw'
No method found matching 'ms_edit'
No method found matching 'ms_cursor'
Error redrawing image: Dimensions of actual window are not yet determined
Traceback:
  File "/Users/deil/Library/Python/3.4/lib/python/site-packages/ginga-2.1.20141207082012-py3.4.egg/ginga/ImageView.py", line 608, in redraw_now
    self.redraw_data(whence=whence)
  File "/Users/deil/Library/Python/3.4/lib/python/site-packages/ginga-2.1.20141207082012-py3.4.egg/ginga/mplw/ImageViewCanvasMpl.py", line 46, in redraw_data
    super(ImageViewCanvas, self).redraw_data(whence=whence)
  File "/Users/deil/Library/Python/3.4/lib/python/site-packages/ginga-2.1.20141207082012-py3.4.egg/ginga/ImageView.py", line 634, in redraw_data
    rgbobj = self.get_rgb_object(whence=whence)
  File "/Users/deil/Library/Python/3.4/lib/python/site-packages/ginga-2.1.20141207082012-py3.4.egg/ginga/ImageView.py", line 696, in get_rgb_object
    win_wd, win_ht = self.get_window_size()
  File "/Users/deil/Library/Python/3.4/lib/python/site-packages/ginga-2.1.20141207082012-py3.4.egg/ginga/ImageView.py", line 305, in get_window_size
    raise ImageViewError("Dimensions of actual window are not yet determined")
```

Then when I try to open a file I get this error:

``` bash
Traceback (most recent call last):
  File "./matplotlib/example1_mpl.py", line 97, in open_file
    self.load_file(fileName)
  File "./matplotlib/example1_mpl.py", line 86, in load_file
    image.load_file(filepath)
  File "/Users/deil/Library/Python/3.4/lib/python/site-packages/ginga-2.1.20141207082012-py3.4.egg/ginga/AstroImage.py", line 97, in load_file
    naxispath=naxispath)
  File "/Users/deil/Library/Python/3.4/lib/python/site-packages/ginga-2.1.20141207082012-py3.4.egg/ginga/util/io_fits.py", line 122, in load_file
    filepath = get_path(filespec)
  File "/Users/deil/Library/Python/3.4/lib/python/site-packages/ginga-2.1.20141207082012-py3.4.egg/ginga/util/io_fits.py", line 269, in get_path
    if fileSpec.startswith('file://'):
TypeError: startswith first arg must be bytes or a tuple of bytes, not str
```
