### PR TITLE
Attempt to guess cut levels when autocuts is off

### DIFF
--- a/ginga/ImageView.py
+++ b/ginga/ImageView.py
@@ -503,6 +503,10 @@ class ImageViewBase(Callback.Callbacks):
 
             if self.t_['autocuts'] != 'off':
                 self.auto_levels(redraw=False)
+            else:
+                cut_lo, cut_hi = self.get_cut_levels()
+                if cut_lo == cut_hi == 0:
+                    self.auto_levels(redraw=False)
 
         except Exception as e:
             self.logger.error("Failed to initialize image: %s" % (str(e)))


### PR DESCRIPTION
When `autocuts` is off, set initial cut levels to `autolevels` values from the first image. This is my attempt to fix the problem *I* reported in #79 (not the original issue).