### PR TITLE
Contents treeview and nameDict access

### DIFF
--- a/ginga/qtw/plugins/Contents.py
+++ b/ginga/qtw/plugins/Contents.py
@@ -66,7 +66,7 @@ class Contents(GingaPlugin.GlobalPlugin):
 
 
     def switch_image(self, chname, imname):
-        fileDict = self.nameDict[chname]
+        fileDict = self.get_contents_by_channel(chname)
         key = imname.lower()
         bnch = fileDict[key]
         path = bnch.path
@@ -121,7 +121,7 @@ class Contents(GingaPlugin.GlobalPlugin):
             chitem.setFirstColumnSpanned(True)
             self.treeview.addTopLevelItem(chitem)
 
-            fileDict = self.nameDict[key]
+            fileDict = self.get_contents_by_channel(key)
             filelist = list(fileDict.keys())
             filelist.remove('_chitem')
             fileDict['_chitem'] = chitem
@@ -136,6 +136,8 @@ class Contents(GingaPlugin.GlobalPlugin):
                 item = QtGui.QTreeWidgetItem(chitem, l)
                 chitem.addChild(item)
 
+        # Always expanded
+        self.treeview.expandAll()
 
     def add_image(self, viewer, chname, image):
         if not self.gui_up:
@@ -158,7 +160,7 @@ class Contents(GingaPlugin.GlobalPlugin):
             self.nameDict[chname] = fileDict
 
         else:
-            fileDict = self.nameDict[chname]
+            fileDict = self.get_contents_by_channel(chname)
             chitem = fileDict['_chitem']
 
         key = name.lower()
@@ -181,7 +183,7 @@ class Contents(GingaPlugin.GlobalPlugin):
         if chname not in self.nameDict:
             return
         else:
-            fileDict = self.nameDict[chname]
+            fileDict = self.get_contents_by_channel(chname)
             chitem = fileDict['_chitem']
 
         key = name.lower()


### PR DESCRIPTION
* Fixed a bug where `Contents` `treeview` in Qt does not expand after being updated.
* Make `fileDict` use a consistent API to access `nameDict` (Qt only).