### PR TITLE
Add extension only if path is valid

### DIFF
--- a/ginga/qtw/Widgets.py
+++ b/ginga/qtw/Widgets.py
@@ -754,7 +754,7 @@ class SaveDialog(QtGui.QFileDialog):
         self.widget = self.getSaveFileName(self, title, '', selectedfilter)
 
     def get_path(self):
-        if not self.widget.endswith(self.selectedfilter[1:]):
+        if self.widget and not self.widget.endswith(self.selectedfilter[1:]):
             self.widget += self.selectedfilter[1:]
         return self.widget
 


### PR DESCRIPTION
Fixed a bug in the Qt Save dialog code where the extension is added to the file name even if the user has pressed 'Cancel' which creates hidden files instead of dropping the operation.