### PR TITLE
Added method to compute full mask of a shape

### DIFF
--- a/ginga/BaseImage.py
+++ b/ginga/BaseImage.py
@@ -285,6 +285,16 @@ class BaseImage(Callback.Callbacks):
 
         return (x0, y0, xarr, yarr)
 
+    def get_shape_mask(self, shape_obj):
+        """
+        Return full mask where True marks pixels within the given shape.
+        """
+        wd, ht = self.get_size()
+        yi = numpy.mgrid[:ht].reshape(-1, 1)
+        xi = numpy.mgrid[:wd].reshape(1, -1)
+        contains = shape_obj.contains_arr(xi, yi)
+        return contains
+
     def get_shape_view(self, shape_obj, avoid_oob=True):
         """
         Calculate a bounding box in the data enclosing `shape_obj` and


### PR DESCRIPTION
I need a method to return a boolean mask of a given shape object that is the same size as the image. This cannot be achieved with `image.cutout_shape(shape_obj)` because that trims down to the bounding box of the shape.

Example usage of this new method:
```python
mask = image.get_shape_mask(shape_obj)
data = image.get_data()
data[mask] = my_fill_value
image.set_data(data)
```