### PR TITLE
Fix example2_qt to actually draw the objects

### DIFF
--- a/examples/qt/example2_qt.py
+++ b/examples/qt/example2_qt.py
@@ -63,6 +63,7 @@ class FitsViewer(QtGui.QMainWindow):
         #fi.add(canvas)
         fi.get_canvas().add(canvas)
         canvas.ui_setActive(True)
+        canvas.register_for_cursor_drawing(fi)
         self.drawtypes = canvas.get_drawtypes()
         self.drawtypes.sort()
 


### PR DESCRIPTION
Apparently an API change hasn't made it into the example. Adding the
register_for_cursor_drawing call seems to fix it.

Resolves: #163