### PR TITLE
Turn ginga.*.plugins into namespace packages

### DIFF
--- a/ginga/Control.py
+++ b/ginga/Control.py
@@ -432,7 +432,8 @@ class GingaControl(Callback.Callbacks):
             name = spec.setdefault('name', spec.get('klass', spec.module))
             self.local_plugins[name] = spec
 
-            self.mm.loadModule(spec.module, pfx=pluginconfpfx)
+            pfx = spec.get('pfx', pluginconfpfx)
+            self.mm.loadModule(spec.module, pfx=pfx)
 
             hidden = spec.get('hidden', False)
             if not hidden:
@@ -447,7 +448,8 @@ class GingaControl(Callback.Callbacks):
             name = spec.setdefault('name', spec.get('klass', spec.module))
             self.global_plugins[name] = spec
 
-            self.mm.loadModule(spec.module, pfx=pluginconfpfx)
+            pfx = spec.get('pfx', pluginconfpfx)
+            self.mm.loadModule(spec.module, pfx=pfx)
 
             self.gpmon.loadPlugin(name, spec)
             self.add_plugin_menu(name)

--- a/ginga/__init__.py
+++ b/ginga/__init__.py
@@ -1,7 +1,7 @@
 """
 Ginga is a toolkit designed for building viewers for scientific image
-data in Python, visualizing 2D pixel data in numpy arrays.  
-The Ginga toolkit centers around an image display class which supports 
+data in Python, visualizing 2D pixel data in numpy arrays.
+The Ginga toolkit centers around an image display class which supports
 zooming and panning, color and intensity mapping, a choice of several
 automatic cut levels algorithms and canvases for plotting scalable
 geometric forms.  In addition to this widget, a general purpose
@@ -10,12 +10,23 @@ geometric forms.  In addition to this widget, a general purpose
 Copyright (c) 2011-2015 Eric R. Jeschke. All rights reserved.
 
 Ginga is distributed under an open-source BSD licence. Please see the
-file LICENSE.txt in the top-level directory for details. 
+file LICENSE.txt in the top-level directory for details.
 """
 
 try:
     from .version import version as __version__
 except ImportError:
     __version__ = ''
+
+try:
+    # As long as we're using setuptools/distribute, we need to do this the
+    # setuptools way or else pkg_resources will throw up unncessary and
+    # annoying warnings (even though the namespace mechanism will still
+    # otherwise work without it).
+    # Get rid of this as soon as setuptools/distribute is dead.
+    __import__('pkg_resources').declare_namespace(__name__)
+except ImportError:
+    pass
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)
 
 #END

--- a/ginga/gtkw/__init__.py
+++ b/ginga/gtkw/__init__.py
@@ -1,0 +1,10 @@
+try:
+    # As long as we're using setuptools/distribute, we need to do this the
+    # setuptools way or else pkg_resources will throw up unncessary and
+    # annoying warnings (even though the namespace mechanism will still
+    # otherwise work without it).
+    # Get rid of this as soon as setuptools/distribute is dead.
+    __import__('pkg_resources').declare_namespace(__name__)
+except ImportError:
+    pass
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/ginga/gtkw/plugins/__init__.py
+++ b/ginga/gtkw/plugins/__init__.py
@@ -1,0 +1,10 @@
+try:
+    # As long as we're using setuptools/distribute, we need to do this the
+    # setuptools way or else pkg_resources will throw up unncessary and
+    # annoying warnings (even though the namespace mechanism will still
+    # otherwise work without it).
+    # Get rid of this as soon as setuptools/distribute is dead.
+    __import__('pkg_resources').declare_namespace(__name__)
+except ImportError:
+    pass
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/ginga/main.py
+++ b/ginga/main.py
@@ -128,18 +128,18 @@ class ReferenceViewer(object):
         self.global_plugins = []
         self.layout = layout
 
-    def add_local_plugin(self, module_name, ws_name):
+    def add_local_plugin(self, module_name, ws_name, pfx=None):
         self.local_plugins.append(
-            Bunch(module=module_name, ws=ws_name))
+            Bunch(module=module_name, ws=ws_name, pfx=pfx))
 
     def add_global_plugin(self, module_name, ws_name,
-                          tab_name=None, start_plugin=True):
+                          tab_name=None, start_plugin=True, pfx=None):
         if tab_name is None:
             tab_name = module_name
 
         self.global_plugins.append(
             Bunch(module=module_name, ws=ws_name, tab=tab_name,
-                  start=start_plugin))
+                  start=start_plugin, pfx=pfx))
 
     def add_default_plugins(self):
         """
@@ -149,12 +149,14 @@ class ReferenceViewer(object):
         # add default global plugins
         for bnch in global_plugins:
             start = bnch.get('start', True)
+            pfx = bnch.get('pfx', None)
             self.add_global_plugin(bnch.module, bnch.ws,
-                          tab_name=bnch.tab, start_plugin=start)
+                          tab_name=bnch.tab, start_plugin=start, pfx=pfx)
 
         # add default local plugins
         for bnch in local_plugins:
-            self.add_local_plugin(bnch.module, bnch.ws)
+            pfx = bnch.get('pfx', None)
+            self.add_local_plugin(bnch.module, bnch.ws, pfx=pfx)
 
     def add_default_options(self, optprs):
         """
@@ -398,9 +400,16 @@ class ReferenceViewer(object):
         # Load any custom modules
         if options.modules:
             modules = options.modules.split(',')
-            for pluginName in modules:
+            for longPluginName in modules:
+                if '.' in longPluginName:
+                    tmpstr = longPluginName.split('.')
+                    pluginName = tmpstr[-1]
+                    pfx = '.'.join(tmpstr[:-1])
+                else:
+                    pluginName = longPluginName
+                    pfx = None
                 spec = Bunch(name=pluginName, module=pluginName,
-                             tab=pluginName, ws='right')
+                             tab=pluginName, ws='right', pfx=pfx)
                 ginga.add_global_plugin(spec)
 
         # Load modules for "local" (per-channel) plug ins
@@ -411,9 +420,16 @@ class ReferenceViewer(object):
         # Load any custom plugins
         if options.plugins:
             plugins = options.plugins.split(',')
-            for pluginName in plugins:
+            for longPluginName in plugins:
+                if '.' in longPluginName:
+                    tmpstr = longPluginName.split('.')
+                    pluginName = tmpstr[-1]
+                    pfx = '.'.join(tmpstr[:-1])
+                else:
+                    pluginName = longPluginName
+                    pfx = None
                 spec = Bunch(module=pluginName, ws='dialogs',
-                             hidden=False)
+                             hidden=False, pfx=pfx)
                 ginga.add_local_plugin(spec)
 
         ginga.update_pending()

--- a/ginga/misc/__init__.py
+++ b/ginga/misc/__init__.py
@@ -1,0 +1,10 @@
+try:
+    # As long as we're using setuptools/distribute, we need to do this the
+    # setuptools way or else pkg_resources will throw up unncessary and
+    # annoying warnings (even though the namespace mechanism will still
+    # otherwise work without it).
+    # Get rid of this as soon as setuptools/distribute is dead.
+    __import__('pkg_resources').declare_namespace(__name__)
+except ImportError:
+    pass
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/ginga/misc/plugins/__init__.py
+++ b/ginga/misc/plugins/__init__.py
@@ -1,0 +1,10 @@
+try:
+    # As long as we're using setuptools/distribute, we need to do this the
+    # setuptools way or else pkg_resources will throw up unncessary and
+    # annoying warnings (even though the namespace mechanism will still
+    # otherwise work without it).
+    # Get rid of this as soon as setuptools/distribute is dead.
+    __import__('pkg_resources').declare_namespace(__name__)
+except ImportError:
+    pass
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/ginga/qtw/GingaQt.py
+++ b/ginga/qtw/GingaQt.py
@@ -246,7 +246,7 @@ class GingaView(QtMain.QtMain):
         return menubar
 
     def add_dialogs(self):
-        filesel = QtGui.QFileDialog(self.w.root)
+        filesel = QtGui.QFileDialog(self.w.root, directory=os.curdir)
         filesel.setFileMode(QtGui.QFileDialog.ExistingFile)
         filesel.setViewMode(QtGui.QFileDialog.Detail)
         self.filesel = filesel

--- a/ginga/qtw/__init__.py
+++ b/ginga/qtw/__init__.py
@@ -1,0 +1,10 @@
+try:
+    # As long as we're using setuptools/distribute, we need to do this the
+    # setuptools way or else pkg_resources will throw up unncessary and
+    # annoying warnings (even though the namespace mechanism will still
+    # otherwise work without it).
+    # Get rid of this as soon as setuptools/distribute is dead.
+    __import__('pkg_resources').declare_namespace(__name__)
+except ImportError:
+    pass
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/ginga/qtw/plugins/__init__.py
+++ b/ginga/qtw/plugins/__init__.py
@@ -1,0 +1,10 @@
+try:
+    # As long as we're using setuptools/distribute, we need to do this the
+    # setuptools way or else pkg_resources will throw up unncessary and
+    # annoying warnings (even though the namespace mechanism will still
+    # otherwise work without it).
+    # Get rid of this as soon as setuptools/distribute is dead.
+    __import__('pkg_resources').declare_namespace(__name__)
+except ImportError:
+    pass
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)


### PR DESCRIPTION
Turn `ginga.*.plugins` into namespace packages, as discussed in #92.

With this change, I can add my own custom plugins under the `ginga.qtw.plugins` namespace with this directory structure:
```
+- mygingastuff/
    +- ginga/
    |   +- __init__.py
    |   +- qtw/
    |   |   +- __init__.py
    |   |   +- plugins/
    |   |   |   +- MyGlobalPlugin2.py
    |   |   |   +- MyLocalPlugin2.py
    |   |   |   +- __init__.py
    +- setup.py
```

The contents of each `__init__.py` (as pointed out by @embray):
```python
try:
    # As long as we're using setuptools/distribute, we need to do this the
    # setuptools way or else pkg_resources will throw up unncessary and
    # annoying warnings (even though the namespace mechanism will still
    # otherwise work without it).
    # Get rid of this as soon as setuptools/distribute is dead.
    __import__('pkg_resources').declare_namespace(__name__)
except ImportError:
    pass
__path__ = __import__('pkgutil').extend_path(__path__, __name__)
```

This is an example `setup.py`:
```python
#! /usr/bin/env python
#
try:
    from setuptools import setup
except ImportError:
    from distutils.core import setup

setup(
    version = '0.1.0',
    name = 'mygingastuff',
    namespace_packages = ['ginga'],
    packages = ['ginga', 'ginga.qtw', 'ginga.qtw.plugins'],
    author = 'J. Doe',
    description = 'Ginga Qt plugins',
    long_description = 'Ginga Qt plugins'
)
```

To start Ginga with these plugins from command line (specifying the full path to the custom plugins is a must due to how Ginga finds them via `main.py -> Control.py -> misc/ModuleManager.py`):
```
ginga --loglevel=20 --log=ginga.log --plugins=ginga.qtw.plugins.MyLocalPlugin2 --modules=ginga.qtw.plugins.MyGlobalPlugin2 myimage.fits
```

As far as Python is concerned, it is the same namespace although the plugins reside in two separate actual packages:
```python
>>> from ginga.qtw.plugins import Contents
>>> Contents
<module 'ginga.qtw.plugins.Contents' from '.../ginga-2.5.20151001032930-py2.7.egg/ginga/qtw/plugins/Contents.pyc'>
>>> from ginga.qtw.plugins import MyLocalPlugin2
>>> MyLocalPlugin2
<module 'ginga.qtw.plugins.MyLocalPlugin2' from '.../mygingastuff-0.1.0-py2.7.egg/ginga/qtw/plugins/MyLocalPlugin2.pyc'>
```