### PR TITLE
Fixed thumbs paths and missing chinfo.readout error messages

### DIFF
--- a/ginga/Control.py
+++ b/ginga/Control.py
@@ -340,6 +340,8 @@ class GingaControl(Callback.Callbacks):
         ColorBar in the Readout (if any).
         """
         chinfo = self.get_channelInfo()
+        if chinfo is None:
+            return
         readout = chinfo.readout
         if readout is None:
             # must be using a shared readout

--- a/ginga/misc/plugins/Mosaic.py
+++ b/ginga/misc/plugins/Mosaic.py
@@ -266,7 +266,10 @@ class Mosaic(GingaPlugin.LocalPlugin):
         imname = img_mosaic.get('name', image.get('name', "NoName"))
 
         # image needs a path for Thumbs plugin
-        img_mosaic.set(path="/dev/null/%s" % (imname))
+        thumbdir = os.path.join(os.curdir, imname)
+        if not os.path.exists(thumbdir):
+            os.makedirs(thumbdir)
+        img_mosaic.set(path=thumbdir)
 
         # avoid making a thumbnail of this if seed image is also that way
         nothumb = not self.settings.get('make_thumbs', False)

--- a/ginga/misc/plugins/ThumbsBase.py
+++ b/ginga/misc/plugins/ThumbsBase.py
@@ -511,7 +511,7 @@ class ThumbsBase(GingaPlugin.GlobalPlugin):
                 return None
 
             try:
-                os.mkdir(thumbdir)
+                os.makedirs(thumbdir)
                 # Write meta file
                 metafile = os.path.join(thumbdir, "meta")
                 with open(metafile, 'w') as out_f:


### PR DESCRIPTION
Fixed thumbs paths and missing `chinfo.readout` error messages.

1. For some reason, sometimes `chinfo` is returned as `None` and this causes an error in `Control.py`. Otherwise, does not seem to affect functionality.
2. Hardcoding thumbs directory to "/dev/null" in `Mosaic.py` is a bad idea. Changed it to working directory. Also, need to create nested directories if necessary.
3. There is a need to create nested directories if thumbnails are saved to `~/.ginga/thumbs` instead of local directory.