### PR TITLE
Added data directory

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
                      'ginga.doc': ['manual/*.html'],
                      'ginga.web.pgw': ['templates/*.html', 'js/*.js'],
                      'ginga.fonts': ['*/*.ttf', '*/*.txt'],
-                     'ginga': ['examples/*/*'],
+                     'ginga': ['data/*', 'examples/*/*'],
                      },
     scripts = ['scripts/ginga', 'scripts/grc', 'scripts/gris'],
     install_requires = ['numpy>=1.7'],


### PR DESCRIPTION
Added data directory and updated setup script. This is in response to a request in #166.

This directory will be used for Ginga data files, which can be accessed via Astropy as follows. The example below uses a custom local plugin but data file may belong to any sub-module within Ginga, as desired:
```python
from astropy.io import ascii
from astropy.utils.data import get_pkg_data_filename

from ginga import GingaPlugin


class MyLocalPlugin2(GingaPlugin.LocalPlugin):
    def __init__(self, fv, fitsimage):
        super(MyLocalPlugin2, self).__init__(fv, fitsimage)

        # Load associated data file in ginga/data
        # In this example, it is a plain ASCII table.
        # The "package" keyword is optional? I needed it for shared namespace but
        # unsure if it is part of the core distribution.
        datafile = get_pkg_data_filename('data/mylocalplugin2_table.txt', package='ginga')
        self.tab = ascii.read(datafile, ...)       
```