### PR TITLE
Thumbs preferences to hide labels

### DIFF
--- a/ginga/examples/configs/plugin_Thumbs.cfg
+++ b/ginga/examples/configs/plugin_Thumbs.cfg
@@ -21,6 +21,9 @@ auto_scroll = True
 # Keywords to extract and show if we mouse over the thumbnail
 tt_keywords = ['OBJECT', 'FRAMEID', 'UT', 'DATE-OBS']
 
+# Mandatory unique image identifier in tooltip
+mouseover_name_key = 'NAME'
+
 # How many seconds to wait after an image is altered to begin trying
 # to rebuild a matching thumb.  Usually a few seconds is good in case
 # there is ongoing adjustment of the image
@@ -33,6 +36,8 @@ thumb_length = 150
 #sort_order = 'alpha'
 sort_order = None
 
-# Hide thumbnail labels (recommended for very long image names)
-label_name = False
-mouseover_name_key = 'NAME'
+# Thumbnail label length in num of characters (None = no limit)
+label_length = 25
+
+# Cut off long label ('front' or 'back')
+label_cutoff = 'front'

--- a/ginga/examples/configs/plugin_Thumbs.cfg
+++ b/ginga/examples/configs/plugin_Thumbs.cfg
@@ -7,7 +7,7 @@
 # caching thumbs saves a lot of time when they need to be regenerated
 cache_thumbs = True
 
-# cache location-- "local" puts them in a .thumbs subfolder, otherwise 
+# cache location-- "local" puts them in a .thumbs subfolder, otherwise
 # they are cached in ~/.ginga/thumbs
 cache_location = 'local'
 
@@ -26,6 +26,13 @@ tt_keywords = ['OBJECT', 'FRAMEID', 'UT', 'DATE-OBS']
 # there is ongoing adjustment of the image
 rebuild_wait = 4.0
 
+# Max length of thumb on the long side
+thumb_length = 150
+
 # Sort the thumbs alphabetically
 #sort_order = 'alpha'
 sort_order = None
+
+# Hide thumbnail labels (recommended for very long image names)
+label_name = False
+mouseover_name_key = 'NAME'

--- a/ginga/misc/plugins/ThumbsBase.py
+++ b/ginga/misc/plugins/ThumbsBase.py
@@ -42,7 +42,9 @@ class ThumbsBase(GingaPlugin.GlobalPlugin):
                                   rebuild_wait=4.0,
                                   tt_keywords=tt_keywords,
                                   thumb_length=150,
-                                  sort_order=None)
+                                  sort_order=None,
+                                  label_name=True,
+                                  mouseover_name_key='NAME')
         self.settings.load(onError='silent')
         # max length of thumb on the long side
         self.thumbWidth = self.settings.get('thumb_length', 150)
@@ -126,6 +128,12 @@ class ThumbsBase(GingaPlugin.GlobalPlugin):
             self.copy_attrs(chinfo.fitsimage)
             self.thumb_generator.set_image(image)
             imgwin = self.thumb_generator.get_image_as_widget()
+
+        if not self.settings.get('label_name', True):
+            thumbnamekey = self.settings.get('mouseover_name_key', 'NAME')
+            self.keywords.insert(0, thumbnamekey)
+            metadata[thumbnamekey] = thumbname
+            thumbname = ''
 
         self.insert_thumbnail(imgwin, thumbkey, thumbname, chname, name, path,
                               thumbpath, metadata, future)


### PR DESCRIPTION
This is a proposed solution for #184, as suggested by @hcferguson.

* Added `Thumbs` preferences to shorten labels for very long image names.
* Added image name to tooltip (not configurable).
* Added previously undocumented `thumb_length` setting to `config` example.

To enable shortening of thumbnail labels, add the following to `~/.ginga/plugin_Thumbs.cfg`:
```python
# Mandatory unique image identifier in tooltip
mouseover_name_key = 'NAME'

# Thumbnail label length in num of characters (None = no limit)
label_length = 25

# Cut off long label ('front' or 'back')
#label_cutoff = 'front'
label_cutoff = 'back'
```