### PR TITLE
Highlight active image in Contents (Qt)

### DIFF
--- a/ginga/examples/configs/channel_Image.cfg
+++ b/ginga/examples/configs/channel_Image.cfg
@@ -103,6 +103,12 @@ numImages = 10
 follow_focus = True
 
 # ---------------
+# General - Listed here but has nothing to do with general.cfg
+
+# Sort channel history ('loadtime' or 'alpha')
+sort_order = 'alpha'
+
+# ---------------
 # Remember - When set to True, GUI remembers the settings for each image
 
 profile_use_scale = False

--- a/ginga/examples/configs/plugin_Contents.cfg
+++ b/ginga/examples/configs/plugin_Contents.cfg
@@ -10,7 +10,7 @@ columns = [ ('Name', 'NAME'), ('Object', 'OBJECT'), ('Filter', 'FILTER01'), ('Da
 # If set to True, will always expand the tree in Contents when new entries are added
 always_expand = True
 
-# Default is for Contents to highlight images that are displayed in channels.
+# Option to highlight images that are displayed in channels.
 # If set to True this option will only highlight the image that is in the
 # channel with the keyboard focus
 highlight_tracks_keyboard_focus = False
@@ -18,3 +18,6 @@ highlight_tracks_keyboard_focus = False
 # If True, color every other row in alternating shades to improve
 # readability of long tables
 color_alternate_rows = True
+
+# Highlighted row colors (in addition to bold text)
+row_font_color = 'green'

--- a/ginga/examples/configs/plugin_Thumbs.cfg
+++ b/ginga/examples/configs/plugin_Thumbs.cfg
@@ -42,7 +42,7 @@ label_length = 25
 # Cut off long label ('left' or 'right')
 label_cutoff = 'right'
 
-# Default is for Thumbs to highlight images that are displayed in channels.
+# Option to highlight images that are displayed in channels.
 # If set to True this option will only highlight the image that is in the
 # channel with the keyboard focus
 highlight_tracks_keyboard_focus = False


### PR DESCRIPTION
~~Qt~~ solution for `Contents` for #186.

~~If we want to be even more flexible, we can make the font color configurable, but will that be overkill?~~

* Enable user preference to set highlighted text color.
* Highlight active image properly when `highlight_tracks_keyboard_focus = True`. Highlighting logic is now like `Thumbs` (see https://github.com/ejeschke/ginga/compare/1c68ac3...1d6849d).
* Log failed highlighting as error instead of warning.
* Fixed error when image is removed from a channel, or when a channel is deleted.
* Also fixed similar error for `Thumbs` (follow up of #195).
* Added `sort_order` example in `channel_Image.cfg` (follow up of #226).
* Corrected verbiage in both `Contents` and `Thumbs` config examples.
* There is no need to make channel name all lowercase in the lookup keys in both `Contents` and `Thumbs`.