### PR TITLE
Add new MODIFIED column in Contents

### DIFF
--- a/ginga/BaseImage.py
+++ b/ginga/BaseImage.py
@@ -8,7 +8,6 @@
 # Please see the file LICENSE.txt for details.
 #
 import math
-import time
 import numpy
 import logging
 
@@ -42,7 +41,6 @@ class BaseImage(Callback.Callbacks):
         # but we'd have to fix a lot of code that is currently checking for
         # None
         self.metadata.setdefault('name', None)
-        self.metadata.setdefault('time_modified', None)
 
         self._set_minmax()
 
@@ -156,8 +154,6 @@ class BaseImage(Callback.Callbacks):
 
         if metadata:
             self.update_metadata(metadata)
-        # record modification time
-        self.set(time_modified=time.time())
 
         self._set_minmax()
 

--- a/ginga/Control.py
+++ b/ginga/Control.py
@@ -492,6 +492,11 @@ class GingaControl(Callback.Callbacks):
             #channel.fitsimage.onscreen_message("Failed to load file", delay=1.0)
             raise ControlError(errmsg)
 
+        # Initialize MODIFIED header keyword for image-modified callback.
+        # This is for consistent keyword display in Contents, and used in
+        # 'image-modified' callback.
+        image.metadata['header']['MODIFIED'] = None
+
         self.logger.debug("Successfully loaded file into image object.")
         return image
 

--- a/ginga/Control.py
+++ b/ginga/Control.py
@@ -507,7 +507,7 @@ class GingaControl(Callback.Callbacks):
 
         Returns
         -------
-        res : `~ginga.misc.bunch.Bunch`
+        res : `~ginga.misc.Bunch.Bunch`
 
         """
         if dldir is None:

--- a/ginga/Control.py
+++ b/ginga/Control.py
@@ -24,6 +24,7 @@ import logging
 import mimetypes
 from collections import deque
 import atexit, shutil
+from datetime import datetime
 
 import numpy
 magic_tester = None
@@ -54,11 +55,15 @@ pluginconfpfx = None
 
 packageHome = os.path.split(sys.modules[__name__].__file__)[0]
 
+
 class ControlError(Exception):
     pass
 
-class GingaControl(Callback.Callbacks):
 
+class GingaControl(Callback.Callbacks):
+    """Main Ginga control.
+
+    """
     def __init__(self, logger, threadPool, module_manager, preferences,
                  ev_quit=None):
         Callback.Callbacks.__init__(self)
@@ -81,7 +86,7 @@ class GingaControl(Callback.Callbacks):
         # For callbacks
         for name in ('add-image', 'active-image', 'remove-image',
                      'add-channel', 'delete-channel', 'field-info',
-                     'add-image-info'):
+                     'add-image-info', 'image-modified'):
             self.enable_callback(name)
 
         self.gui_queue = Queue.Queue()
@@ -143,7 +148,6 @@ class GingaControl(Callback.Callbacks):
         # Initialize catalog and image server bank
         self.imgsrv = catalog.ServerBank(self.logger)
 
-
     def get_ServerBank(self):
         return self.imgsrv
 
@@ -176,8 +180,7 @@ class GingaControl(Callback.Callbacks):
             info.y += off
 
         except Exception as e:
-            self.logger.warn("Can't get info under the cursor: %s" % (
-                str(e)))
+            self.logger.warn("Can't get info under the cursor: %s" % (str(e)))
             return
 
         self.make_callback('field-info', fitsimage, info)
@@ -251,8 +254,7 @@ class GingaControl(Callback.Callbacks):
 
     def move_image_by_thumb(self, url, to_chname):
         from_chname, imname, path = url.split('||')
-        self.move_image_by_name(from_chname, imname, to_chname,
-                                impath=path)
+        self.move_image_by_name(from_chname, imname, to_chname, impath=path)
 
     def dragdrop(self, fitsimage, urls):
         """Called when a drop operation is performed on our main window.
@@ -267,8 +269,7 @@ class GingaControl(Callback.Callbacks):
                 continue
 
             #self.load_file(url)
-            self.nongui_do(self.load_file, url, chname=to_chname,
-                           wait=False)
+            self.nongui_do(self.load_file, url, chname=to_chname, wait=False)
         return True
 
     def force_focus_cb(self, fitsimage, event, data_x, data_y):
@@ -277,8 +278,8 @@ class GingaControl(Callback.Callbacks):
         return True
 
     def focus_cb(self, fitsimage, tf, name):
-        """Called when _fitsimage_ gets (tf==True) or loses (tf==False)
-        the focus.
+        """Called when ``fitsimage`` gets ``(tf==True)`` or loses
+        ``(tf==False)`` the focus.
         """
         if not self.channel_follows_focus:
             return True
@@ -426,13 +427,15 @@ class GingaControl(Callback.Callbacks):
                         return ('image', 'fits')
 
             except Exception as e:
-                self.logger.warn("python-magic error: %s; falling back to 'mimetypes'" % (str(e)))
+                self.logger.warn("python-magic error: %s; falling back "
+                                 "to 'mimetypes'" % (str(e)))
 
         if typ is None:
             try:
                 typ, enc = mimetypes.guess_type(filepath)
             except Exception as e:
-                self.logger.warn("mimetypes error: %s; can't determine file type" % (str(e)))
+                self.logger.warn("mimetypes error: %s; can't determine "
+                                 "file type" % (str(e)))
 
         if typ:
             typ, subtyp = typ.split('/')
@@ -454,7 +457,8 @@ class GingaControl(Callback.Callbacks):
             typ, subtyp = self.guess_filetype(filepfx)
 
         except Exception as e:
-            self.logger.warn("error determining file type: %s; assuming 'image/fits'" % (str(e)))
+            self.logger.warn("error determining file type: %s; "
+                             "assuming 'image/fits'" % (str(e)))
             # Can't determine file type: assume and attempt FITS
             typ, subtyp = 'image', 'fits'
 
@@ -491,20 +495,20 @@ class GingaControl(Callback.Callbacks):
         self.logger.debug("Successfully loaded file into image object.")
         return image
 
-
     def get_fileinfo(self, filespec, dldir=None):
-        """
-        Break down a file specification into its components.
+        """Break down a file specification into its components.
 
         Parameters
         ----------
-        `filespec`: string
-            the path of the file to load (can be a URL)
+        filespec : str
+            The path of the file to load (can be a URL).
+
+        dldir
 
         Returns
         -------
-        res:
-            a Bunch object
+        res : `~ginga.misc.bunch.Bunch`
+
         """
         if dldir is None:
             dldir = self.tmpdir
@@ -532,10 +536,8 @@ class GingaControl(Callback.Callbacks):
 
         return info
 
-
     def name_image_from_path(self, path, idx=None):
         return iohelper.name_image_from_path(path, idx=idx)
-
 
     def load_file(self, filepath, chname=None, wait=True,
                   create_channel=True, display_image=True,
@@ -544,21 +546,30 @@ class GingaControl(Callback.Callbacks):
 
         Parameters
         ----------
-        `filepath`: string
-            the path of the file to load (can be a URL)
-        `chname`: string (optional)
-            the name of the channel in which to display the image
-        `display_image`: boolean (optional)
-            if not False, then will load the image
-        `wait`: boolean (optional)
-            if True, then wait for the file to be displayed before returning
-              (synchronous behavior)
-        `image_loader`: function (optional)
-            a special image loader, if provided
+        filepath : str
+            The path of the file to load (can be a URL).
+
+        chname : str, optional
+            The name of the channel in which to display the image.
+
+        wait : bool, optional
+            If `True`, then wait for the file to be displayed before returning
+            (synchronous behavior).
+
+        create_channel : bool, optional
+            Create channel.
+
+        display_image : bool, optional
+            If not `False`, then will load the image.
+
+        image_loader : func, optional
+            A special image loader, if provided.
+
         Returns
         -------
-        image:
-            the image object that was loaded
+        image
+            The image object that was loaded.
+
         """
         if not chname:
             channel = self.get_channelInfo()
@@ -597,7 +608,7 @@ class GingaControl(Callback.Callbacks):
         if image.get('path', None) is None:
             image.set(path=filepath)
 
-        # Assign a name to the image if the loader did not
+        # Assign a name to the image if the loader did not.
         name = image.get('name', None)
         if name is None:
             name = self.name_image_from_path(filepath, idx=idx)
@@ -739,8 +750,14 @@ class GingaControl(Callback.Callbacks):
         if chname is None:
             channel = self.get_channelInfo()
             if channel is None:
-                raise ValueError("Need to provide a channel name to add the image")
+                raise ValueError("Need to provide a channel name to add "
+                                 "the image")
             chname = channel.name
+
+        # Initialize MODIFIED header keyword for image-modified callback.
+        # This is for consistent keyword display in Contents, and used in
+        # 'image-modified' callback.
+        image.metadata['header']['MODIFIED'] = None
 
         # add image to named channel
         channel = self.get_channel_on_demand(chname)
@@ -748,7 +765,7 @@ class GingaControl(Callback.Callbacks):
 
     def advertise_image(self, chname, image):
         channel = self.get_channelInfo(chname)
-        info = channel.get_image_info(image.name)
+        info = channel.get_image_info(image.get('name'))
 
         self.make_callback('add-image', chname, image, info)
 
@@ -792,8 +809,7 @@ class GingaControl(Callback.Callbacks):
                 self.gui_do(obj.redo)
 
             except Exception as e:
-                self.logger.error("Failed to continue operation: %s" % (
-                    str(e)))
+                self.logger.error("Failed to continue operation: %s" % (str(e)))
                 # TODO: log traceback?
 
     def channel_image_updated(self, channel, image):
@@ -901,13 +917,26 @@ class GingaControl(Callback.Callbacks):
 
         Parameters
         ----------
-        `chname`: string
-            the name of the channel to create.
+        chname : str
+            The name of the channel to create.
+
+        workspace
+
+        num_images
+
+        settings
+
+        settings_template
+
+        settings_share
+
+        share_keylist
 
         Returns
         -------
-        channel: bunch
-            the channel info bunch
+        channel : `~ginga.misc.Bunch.Bunch`
+            The channel info bunch.
+
         """
         if self.has_channel(chname):
             return self.get_channelInfo(chname)
@@ -919,8 +948,8 @@ class GingaControl(Callback.Callbacks):
                 settings.load(onError='raise')
 
             except Exception as e:
-                self.logger.warn("no saved preferences found for channel '%s': %s" % (
-                    name, str(e)))
+                self.logger.warn("no saved preferences found for channel "
+                                 "'%s': %s" % (name, str(e)))
 
                 # copy template settings to new channel
                 if settings_template is not None:
@@ -931,8 +960,8 @@ class GingaControl(Callback.Callbacks):
                         # use channel_Image as a template if one was not
                         # provided
                         osettings = self.prefs.getSettings('channel_Image')
-                        self.logger.debug("Copying settings from 'Image' to '%s'" % (
-                            name))
+                        self.logger.debug("Copying settings from 'Image' to "
+                                          "'%s'" % (name))
                         osettings.copySettings(settings)
                     except KeyError:
                         pass
@@ -1070,7 +1099,13 @@ class GingaControl(Callback.Callbacks):
         self.channel_follows_focus = tf
 
     def showStatus(self, text):
-        """Write a message to the status bar.  _text_ is the message.
+        """Write a message to the status bar.
+
+        Parameters
+        ----------
+        text : str
+            The message.
+
         """
         self.statusMsg("%s", text)
 
@@ -1092,20 +1127,16 @@ class GingaControl(Callback.Callbacks):
             hdlr.setLevel(level)
 
     def play_soundfile(self, filepath, format=None, priority=20):
-        self.logger.debug("Subclass could override this to play sound file '%s'" % (
-            filepath))
+        self.logger.debug("Subclass could override this to play sound file "
+                          "'%s'" % (filepath))
 
     def get_color_maps(self):
         """Get the list of named color maps.
 
-        Parameters
-        ----------
-        None
-
         Returns
         -------
-        `names`: list
-            A list of all named colormaps installed
+        names : list
+            A list of all named colormaps installed.
 
         """
         return cmap.get_names()
@@ -1113,14 +1144,10 @@ class GingaControl(Callback.Callbacks):
     def get_intensity_maps(self):
         """Get the list of named intensity maps.
 
-        Parameters
-        ----------
-        None
-
         Returns
         -------
-        `names`: list
-            A list of all named intensity maps installed
+        names : list
+            A list of all named intensity maps installed.
 
         """
         return imap.get_names()
@@ -1141,6 +1168,7 @@ def _rmtmpdir(tmpdir):
     if os.path.isdir(tmpdir):
         shutil.rmtree(tmpdir)
 
+
 class GuiLogHandler(logging.Handler):
     """Logs to a pane in the GUI."""
 
@@ -1154,7 +1182,23 @@ class GuiLogHandler(logging.Handler):
 
 
 class Channel(Callback.Callbacks):
+    """Class to manage a channel.
 
+    Parameters
+    ----------
+    name : str
+        Name of the channel.
+
+    fv
+        Parent viewer.
+
+    settings
+        Channel settings.
+
+    datasrc : `~ginga.misc.Datasrc.Datasrc`
+        Data cache.
+
+    """
     def __init__(self, name, fv, settings, datasrc=None):
         super(Channel, self).__init__()
 
@@ -1183,8 +1227,8 @@ class Channel(Callback.Callbacks):
         self.extdata = Bunch.Bunch()
 
         self._configure_sort()
-        self.settings.getSetting('sort_order').add_callback('set',
-                                               self._sort_changed_ext_cb)
+        self.settings.getSetting('sort_order').add_callback(
+            'set', self._sort_changed_ext_cb)
 
     def connect_viewer(self, viewer):
         self.viewer = viewer
@@ -1227,7 +1271,24 @@ class Channel(Callback.Callbacks):
         return [ info.name for info in self.history ]
 
     def get_loaded_image(self, imname):
-        """Will raise a KeyError if image is not in memory."""
+        """Get an image from memory.
+
+        Parameters
+        ----------
+        imname : str
+            Key, usually image name and extension.
+
+        Returns
+        -------
+        image
+            Image object.
+
+        Raises
+        ------
+        KeyError
+            Image is not in memory.
+
+        """
         image = channel.datasrc[imname]
         return image
 
@@ -1262,7 +1323,6 @@ class Channel(Callback.Callbacks):
             # only update the gui for the latest image, which saves
             # work
             self.fv.gui_do(self._add_image_update, image, info)
-
 
     def add_image_info(self, info):
 
@@ -1300,6 +1360,52 @@ class Channel(Callback.Callbacks):
             channel = self.fv.get_channelInfo()
             if channel != self:
                 self.fv.change_channel(self.name)
+
+    def image_data_modified(self, image, reset=False):
+        """Call this when data in buffer is modified.
+
+        Header metadata, ``MODIFIED``, will be updated with UTC timestamp info.
+        Plugins with ``redo()`` methods will pick this up.
+
+        **Callbacks**
+
+        Both ``'image-modified'`` and ``'modified'`` callbacks will be issued.
+        To use this from a plugin:
+
+        .. code-block:: python
+
+            image = self.fitsimage.get_image()
+            data = image.get_data()
+            new_data = do_something(data)
+            image.set_data(new_data, metadata=image.metadata)
+            chname = self.fv.get_channelName(self.fitsimage)
+            channel = self.fv.get_channelInfo(chname)
+            channel.image_data_modified()
+
+        Parameters
+        ----------
+        image
+            Image object to update.
+
+        reset : bool
+            Set to `True` on init or if image fell out of cache.
+            This will set the modified timestamp to `None`.
+
+        """
+        if reset:
+            timestamp = None
+        else:
+            # Z: Zulu time, GMT, UTC
+            timestamp = datetime.utcnow().strftime('%Y-%m-%d %H:%M:%SZ')
+
+        # Set metadata in header, to be consistent with Contents plugin
+        image.metadata['header']['MODIFIED'] = timestamp
+        self.logger.debug("Modified timestamp for {0} set to '{1}'".format(
+            image.get('name'), timestamp))
+
+        # Issue callbacks
+        self.fv.make_callback('image-modified', self.name, image)
+        self.fv.make_callback('modified', image)  # For redo()
 
     def get_current_image(self):
         return self.fitsimage.get_image()
@@ -1423,7 +1529,6 @@ class Channel(Callback.Callbacks):
             else:
                 self.logger.debug("Apparently no need to set large fits image.")
 
-
     def switch_name(self, imname):
 
         if self.datasrc.has_key(imname):
@@ -1433,8 +1538,7 @@ class Channel(Callback.Callbacks):
             return
 
         if not (imname in self.image_index):
-            errmsg = ("No image by the name '%s' found" % (
-                imname))
+            errmsg = "No image by the name '%s' found" % (imname)
             self.logger.error("Can't switch to image '%s': %s" % (
                 imname, errmsg))
             raise ControlError(errmsg)
@@ -1442,8 +1546,8 @@ class Channel(Callback.Callbacks):
         # Do we have a way to reconstruct this image from a future?
         info = self.image_index[imname]
         if info.image_future is not None:
-            self.logger.info("Image '%s' is no longer in memory; attempting reloader" % (
-                    imname))
+            self.logger.info("Image '%s' is no longer in memory; attempting "
+                             "reloader" % (imname))
             # TODO: recode this--it's a bit messy
             def _switch(image):
                 # this will be executed in the gui thread
@@ -1455,14 +1559,14 @@ class Channel(Callback.Callbacks):
                 # reconstitute the image
                 image = self.fv.error_wrap(image_future.thaw)
                 if isinstance(image, Exception):
-                    errmsg = "Error reconstituting image: %s" % (
-                                                                 str(image))
+                    errmsg = "Error reconstituting image: %s" % (str(image))
                     self.logger.error(errmsg)
                     raise image
 
                 # perpetuate the image_future
-                image.set(image_future=image_future, name=imname,
-                          path=path)
+                image.set(image_future=image_future, name=imname, path=path)
+                # Reset modified timestamp
+                self.fv.gui_do(self.image_data_modified, image, reset=True)
                 self.fv.gui_do(_switch, image)
 
             self.fv.nongui_do(_load_n_switch, imname, info.path,
@@ -1470,16 +1574,14 @@ class Channel(Callback.Callbacks):
 
         elif info.path is not None:
             # Do we have a path? We can try to reload it
-            self.logger.debug("Image '%s' is no longer in memory; attempting to load from %s" % (
-                imname, info.path))
+            self.logger.debug("Image '%s' is no longer in memory; attempting "
+                              "to load from %s" % (imname, info.path))
 
             #self.fv.load_file(path, chname=chname)
-            self.fv.nongui_do(self.load_file, info.path,
-                           chname=self.name)
+            self.fv.nongui_do(self.load_file, info.path, chname=self.name)
 
         else:
-            raise ControlError("No way to recreate image '%s'" % (
-                imname))
+            raise ControlError("No way to recreate image '%s'" % (imname))
 
     def _configure_sort(self):
         self.hist_sort = lambda info: info.time_added
@@ -1493,6 +1595,5 @@ class Channel(Callback.Callbacks):
         self._configure_sort()
 
         self.history.sort(key=self.hist_sort)
-
 
 # END

--- a/ginga/examples/configs/plugin_Contents.cfg
+++ b/ginga/examples/configs/plugin_Contents.cfg
@@ -3,9 +3,9 @@
 #
 # Place this in file under ~/.ginga with the name "plugin_Contents.cfg"
 
-# columns to show from metadata
+# columns to show from metadata -- NAME and MODIFIED recommended
 # format: [(col header, keyword1), ... ]
-columns = [ ('Name', 'NAME'), ('Object', 'OBJECT'), ('Filter', 'FILTER01'), ('Date', 'DATE-OBS'), ('Time UT', 'UT'), ]
+columns = [ ('Name', 'NAME'), ('Object', 'OBJECT'), ('Filter', 'FILTER01'), ('Date', 'DATE-OBS'), ('Time UT', 'UT'), ('Modified', 'MODIFIED')]
 
 # If set to True, will always expand the tree in Contents when new entries are added
 always_expand = True


### PR DESCRIPTION
Proposed solution for #215.

As @ejeschke said, "AFAIK, the modified callback comes from the image directly, with no information about which channel it is in, so that might complicate figuring out which contents entries to modify." ~~That is something I am not sure how to address yet.~~

Changes in `Control.py`:

* Added new `image-modified` callback, as @ejeschke suggested.
* Added `Channel.image_data_modified()` method to handle this new callback. (L1482, L1687)
* ~~Added new `MODIFIED` keyword to image header to keep track of modified timestamp. This is set to `None` if not modified yet. (L871)~~
* Fixed bug in `advertise_image()`. (L879)
* Auto-close local plugins when channel is deleted.
* Added check to prevent deleting a channel when there is no channel left.
* PEP8 stuff, some doc fixes.

Changes to `Contents.py`:

* Added new MODIFIED column to display modified timestamp, if any.
* Added `image_modified_cb()` method to handle the new `image-modified` callback.
* Change `add-image-info` to use `add_callback()` (see comments in 17c6e7d3f).

`plugin_Contents.cfg` -- Added the new MODIFIED column in the settings.