### PR TITLE
Fix/improve Ginga doc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,6 +104,8 @@ install:
     # currently 2.7, so that's fine
     - if [[ $SETUP_CMD == build_sphinx* ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION Sphinx matplotlib; fi
     - if [[ $SETUP_CMD == build_sphinx* ]]; then $PIP_INSTALL linkchecker; fi
+    # This is needed for API autodoc
+    - if [[ $SETUP_CMD == build_sphinx* ]]; then $PIP_INSTALL numpydoc; fi
 
     # COVERAGE DEPENDENCIES
     - if [[ $SETUP_CMD == 'test --coverage' ]]; then $PIP_INSTALL coverage coveralls; fi

--- a/doc/WhatsNew.rst
+++ b/doc/WhatsNew.rst
@@ -6,15 +6,17 @@ Ver 2.2.20150203025858
 ======================
 Ginga drawing canvas objects now can specify points and radii in world
 coordinates degrees and sexigesimal notation.
+
 - default is still data coordinates
 - can play with this from Drawing plugin in reference viewer
 
 Ver 2.1.20141203011503
 ======================
 Major updates to the drawing features of ginga:
+
 - new canvas types including ellipses, boxes, triangles, paths, images
-- objects are editable: press 'b' to go into edit mode to select and 
-  manipulate objects graphically (NOTE: 'b' binding is considered 
+- objects are editable: press 'b' to go into edit mode to select and
+  manipulate objects graphically (NOTE: 'b' binding is considered
   experimental for now--editing interface is still evolving)
 - editing: scale, rotate, move; change: fill, alpha transparency, etc.
 - editing features available in all versions of the widget
@@ -23,6 +25,7 @@ Major updates to the drawing features of ginga:
 Ver 2.0.20140905210415
 ======================
 Updates to the core display and bindings classes:
+
 - improvements to interactive rotation command--now resume rotation from
   current value and direction is relative to horizontal motion of mouse
 - most keyboard modes are now locking and not oneshot (press to turn on,
@@ -65,24 +68,24 @@ New interactive command to orient the image by WCS to North=Up.  The
 default binding to 'o' creates left-handed orientation ('O' for
 right-handed).  Added a command to rotate the image in 90 deg
 increments.  Default binding to 'e' rotates by 90 deg ('E' for -90
-deg). 
+deg).
 
 
 Ver 2.0.20140412025038
 ======================
 Major update for scale (mapping) algorithms
-    
-The scale mapping algorithms (for mapping data values during rendering) 
+
+The scale mapping algorithms (for mapping data values during rendering)
 havebeen completely refactored.  They are now separated from the RGBMap
 class and are pluggable.  Furthermore I have redone them modeled after
 the ds9 algorithms.
-    
+
 There are now eight algorithms available: linear, log, power, sqrt, squared,
 asinh, sinh, histeq.  You can choose the mapping from the Preferences plugin
 or cycle through them using the binding to the 's' key (Use 'S' to reset to
 linear).  There is also a mouse wheel mapping than can be assigned to
 this function if you customize your bindings.  It is not enabled by default.
-    
+
 The Preferences plugin has been updated to make the function a little
 clearer, since there was some confusion also with the intensity map feature
 that is also part of the final color mapping process.
@@ -121,7 +124,7 @@ pinch and pan gestures:
 Also in this release there has been a lot of updates to the
 documentation.  The developer and internals sections in particular have
 a lot of new material.
- 
+
 
 Ver 2.0.20131030190529
 ======================
@@ -158,11 +161,11 @@ cause for you.  Fire up your editor of choice and do a query/replace of
 Ver 1.5-20131022230350
 ======================
 Ginga gets a Matplotlib backend!
-    
+
 Ginga can now render to any Matplotlib FigureCanvas.  The performance using
 this backend is not as fast as the others, but it is acceptable and opens
 up huge opportunities for overplotting.
-    
+
 See scripts/example{1,2,3,4,5}_mpl.py
 
 Also merges in bug fixes for recent changes to astropy, and support for
@@ -175,13 +178,13 @@ Ver 1.5-20130923184124
 Efficiency improvements
 -----------------------
 Efforts to improve speed of entire rendering pipeline and widget
-specific redrawing 
+specific redrawing
 
 * Decent improvements, Ginga can now render HD video (no sound) at 30
   FPS on older hardware (see scripts/example1_video.py).  This
   translates to a slightly speedier feel overall for many operations
   viewing regular scientific files.
-* Fixed a bug that gave an error message of 
+* Fixed a bug that gave an error message of
   Callback.py:83 (make_callback) | Error making callback 'field-info':
   'Readout' object has no attribute 'fitsimage'
 
@@ -196,7 +199,7 @@ New Agg backend
 There is now an Agg rendering version of the ImageView object.
 
 * uses the python "aggdraw" module for drawing; get it here  -->
-  https://github.com/ejeschke/aggdraw 
+  https://github.com/ejeschke/aggdraw
 * this will make it easy to support all kinds of surfaces because the
   graphics drawing code does not have to be replicated for each
   toolkit
@@ -214,13 +217,15 @@ There is now a Tk rendering version of the ImageView object.
 
 AutoCuts
 --------
+
 * the ginga.AutoCuts module has been refactored into individual classes
-  for each algorithm 
+  for each algorithm
 * The Preferences plugin for ginga now exposes all of the parameters
     used for each cut levels algorithm and will save them
 
 Etc
 ---
+
 * additions to the manual (still incomplete, but coming along)
 * lots of docstrings for methods added (sphinx API doc coming)
 * many colors added to the color drawing example programs

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -1,0 +1,13 @@
+.. _api:
+
+###
+API
+###
+
+*UNDER CONSTRUCTION*
+
+.. toctree::
+   :maxdepth: 3
+
+   main
+   wcsutil

--- a/doc/api/main.rst
+++ b/doc/api/main.rst
@@ -1,0 +1,9 @@
+.. _api_rv:
+
+################
+Reference Viewer
+################
+
+.. currentmodule:: ginga.main
+
+.. autoclass:: ReferenceViewer

--- a/doc/api/wcsutil.rst
+++ b/doc/api/wcsutil.rst
@@ -1,0 +1,22 @@
+.. _api_wcsutil:
+
+#####################
+WCS Utility Functions
+#####################
+
+``util.wcsmod``
+===============
+
+.. currentmodule:: ginga.util.wcsmod
+
+.. automodule:: ginga.util.wcsmod
+  :members:
+
+
+``util.wcs``
+============
+
+.. currentmodule:: ginga.util.wcs
+
+.. automodule:: ginga.util.wcs
+  :members:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -25,7 +25,12 @@ import sys, os
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc']
+extensions = ['sphinx.ext.autodoc',
+              'numpydoc',
+              'sphinx.ext.autosummary',
+              'sphinx.ext.intersphinx']
+
+numpydoc_show_class_members = False
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -88,14 +93,14 @@ exclude_patterns = ['_build']
 pygments_style = 'sphinx'
 
 # A list of ignored prefixes for module index sorting.
-#modindex_common_prefix = []
+modindex_common_prefix = ['ginga.']
 
 
 # -- Options for HTML output ---------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -287,3 +292,12 @@ epub_copyright = u'2013-2015, Eric Jeschke'
 
 # Allow duplicate toc entries.
 #epub_tocdup = True
+
+# Configuration for intersphinx
+intersphinx_mapping = {
+    'python': ('http://docs.python.org/', None),
+    'numpy': ('http://docs.scipy.org/doc/numpy/', None),
+    'scipy': ('http://docs.scipy.org/doc/scipy/reference/', None),
+    'matplotlib': ('http://matplotlib.org/', None),
+    'astropy': ('http://docs.astropy.org/en/stable/', None)
+    }

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -15,20 +15,20 @@ About Ginga
 ===========
 
 Ginga is a toolkit designed for building viewers for scientific image
-data in Python, visualizing 2D pixel data in numpy arrays.  
+data in Python, visualizing 2D pixel data in numpy arrays.
 It can view astronomical data such as contained in files based on the
 FITS (Flexible Image Transport System) file format.  It is written and
 is maintained by software engineers at the Subaru Telescope, National
 Astronomical Observatory of Japan.
 
-The Ginga toolkit centers around an image display class which supports 
+The Ginga toolkit centers around an image display class which supports
 zooming and panning, color and intensity mapping, a choice of several
 automatic cut levels algorithms and canvases for plotting scalable
 geometric forms.  In addition to this widget, a general purpose
 "reference" FITS viewer is provided, based on a plugin framework.
 A fairly complete set of "standard" plugins are provided for features
 that we expect from a modern FITS viewer: panning and zooming windows,
-star catalog access, cuts, star pick/fwhm, thumbnails, etc. 
+star catalog access, cuts, star pick/fwhm, thumbnails, etc.
 
 =====================
 Copyright and License
@@ -37,7 +37,7 @@ Copyright and License
 Copyright (c) 2011-2015 Eric R. Jeschke. All rights reserved.
 
 Ginga is distributed under an open-source BSD licence. Please see the
-file LICENSE.txt in the top-level directory for details. 
+file LICENSE.txt in the top-level directory for details.
 
 ====================================
 Requirements and Supported Platforms
@@ -67,7 +67,7 @@ Building and Installation
 Download and install from `pip`::
     $ pip install ginga
 
-Or, if you have downloaded the source, go into the top level directory and:: 
+Or, if you have downloaded the source, go into the top level directory and::
 
     $ python setup.py install
 
@@ -89,11 +89,12 @@ Documentation
    quickref
    FAQ
    manual/index
+   api/index
 
-Some training videos are available in the 
+Some training videos are available in the
 `downloads <https://github.com/ejeschke/ginga/downloads>`_ section at
 github.
-Be sure to also check out the 
+Be sure to also check out the
 `wiki <https://github.com/ejeschke/ginga/wiki>`_.
 
 ===========
@@ -111,7 +112,7 @@ invoke Ginga with the logging options to capture any logged errors::
 
 If the difficulty is with non-display or non-working WCS for a
 particular image file please be ready to supply the file for our aid in
-debugging. 
+debugging.
 
 ==============
 Developer Info
@@ -120,7 +121,7 @@ Developer Info
 In the source code `examples/*` directories, see example{1,2}_gtk.py (Gtk),
 example{1,2}_qt.py (Qt), example{1,2}_tk.py (Tk) or
 example{1,2,3,4,5}_mpl.py (matplotlib).
-There is more information for developers in the :ref:`manual`.  
+There is more information for developers in the :ref:`manual`.
 
 See also the Module Index at the bottom of this document.
 
@@ -130,9 +131,9 @@ Etymology
 
 "Ginga" is the romanized spelling of the Japanese word "銀河" (hiragana:
 ぎんが), meaning "galaxy" (in general) and, more familiarly, the Milky
-Way. This viewer was written by software engineers at 
+Way. This viewer was written by software engineers at
 `Subaru Telescope <http://subarutelescope.org/>`_,
-National Astronomical Observatory of Japan--thus the connection. 
+National Astronomical Observatory of Japan--thus the connection.
 
 =============
 Pronunciation
@@ -150,5 +151,3 @@ Indices and tables
 
 * :ref:`genindex`
 * :ref:`modindex`
-* :ref:`search`
-

--- a/doc/manual/canvas.rst
+++ b/doc/manual/canvas.rst
@@ -14,7 +14,7 @@ Canvases and Canvas Objects
 Ginga's canvas is based on the ``DrawingCanvas`` class.
 On the canvas can be placed a number of different kinds of
 *canvas objects*, including many geometric shapes.  The set of canvas
-objects includes: 
+objects includes:
 
 * ``Text``:  a piece of text having a single point coordinate.
 * ``Polygon``:  a closed polygon defined by N points.
@@ -43,7 +43,7 @@ objects includes:
   canvas objects.
 * ``Canvas``:  a transparent subcanvas on which items can be placed.
 * ``DrawingCanvas``:  Like a ``Canvas``, but also can support manual
-  drawing operations initiated in a viewer to create shapes on itself. 
+  drawing operations initiated in a viewer to create shapes on itself.
 * ``ColorBar``: a bar with a color range and ticks and value markers to
   help indicate the mapping of color to the value range of the data.
 * ``ModeIndicator``: a small rectangular overlay with text indicating
@@ -71,9 +71,9 @@ canvas defined by:
 
 * dimensions of their viewport (typically tied to the height and
   width of the native widget's window into which the viewer is rendering),
-* scale in X and Y dimensions, 
+* scale in X and Y dimensions,
 * a *pan position* linking the center of the viewport to a canvas
- coordinate,
+  coordinate,
 * a transform consisting of possible flips in X, Y axes and/or swapping
   of X/Y axes, and
 * a rotation.
@@ -90,4 +90,3 @@ overlaid graphics.
 The various subclasses of ``ImageView`` are designed to render into a
 different widget set or "native" canvas using a ``CanvasRenderer``
 customized for that target.
-

--- a/doc/manual/developers.rst
+++ b/doc/manual/developers.rst
@@ -7,7 +7,7 @@ Developing with Ginga
 * :ref:`modindex`
 
 Developers interested in using Ginga in their project will probably
-follow one of two logical development paths: 
+follow one of two logical development paths:
 
 - using Ginga toolkit classes in a program of their own design, or
 - starting with the full-featured reference viewer that comes with Ginga
@@ -48,12 +48,12 @@ A channel has a name and maintains its own history of images that have
 cycled through it.  The user can create new channels as needed.  For
 example, they might use different channels for different kinds of
 images: camera vs. spectrograph, or channels organized by CCD, or by
-target, or raw data vs. quick look, etc.  In the default layout, shown
-in :ref:`fig2` the channel tabs are in the large middle pane, while the
+target, or raw data vs. quick look, etc.  In the default layout,
+the channel tabs are in the large middle pane, while the
 plugins occupy the left and right panes.  Other layouts are possible, by
 simply changing a table used in the startup script.
 
-Ginga distinguishes between two types of plugin: *global* and *local*.  
+Ginga distinguishes between two types of plugin: *global* and *local*.
 Global plugins are used where the functionality is generally enabled
 during the entire session with the viewer and where the plugin is active
 no matter which channel is currenly under interaction with the user.
@@ -80,9 +80,9 @@ open, and does not capture the mouse actions unless the channel it is
 operating on is selected.  Thus one can have two different Pick
 operations going on concurrently on two different channels, for example,
 or a Pick operation in a camera channel, and a Cuts (line cuts)
-operation on a spectrograph channel. 
+operation on a spectrograph channel.
 Figure :ref:`fig5` shows an example of the Pick local plugin occupying a
-notebook tab. 
+notebook tab.
 
 .. _fig5:
 .. figure:: figures/local_plugin1.png
@@ -98,7 +98,7 @@ Anatomy of a Local Ginga Plugin
 
 Let's take a look at a local plugin to understand the API for
 interfacing to the Ginga shell.  In Listing 2, we show a stub for a
-local plugin.  
+local plugin.
 
 .. code-block:: python
 
@@ -267,18 +267,18 @@ Manager bar.
 
         def resume(self):
             """
-            This method is called when the plugin gets focus. 
+            This method is called when the plugin gets focus.
             It should take any actions necessary to start handling user
             interaction events for the operations that it does.
             This method may be called many times as the plugin is focused or
             defocused.  The method may be omitted if there is no user event
-            handling to enable. 
+            handling to enable.
             """
             pass
 
         def stop(self):
             """
-            This method is called when the plugin is stopped. 
+            This method is called when the plugin is stopped.
             It should perform any special clean up necessary to terminate
             the operation.  The GUI will be destroyed by the plugin manager
             so there is no need for the stop method to do that.
@@ -309,7 +309,7 @@ The instance variables "fv" and "fitsimage" will be assigned by the
 superclass initializer to self.fv and self.fitsimage--these are the
 reference viewer "shell" and the ginga display object respectively.
 To interact with the viewer you will be calling methods on one or both
-of these objects. 
+of these objects.
 
 The best way to get a feel for these APIs is to look at the source of
 one of the many plugins distributed with Ginga.  Most of them are not
@@ -324,7 +324,7 @@ ginga configuration area.  In a terminal:
 
     $ mkdir $HOME/.ginga/plugins
 
-Put your plugin in there (a good one to start with is to modify the 
+Put your plugin in there (a good one to start with is to modify the
 MyLocalPlugin example that comes with Ginga):
 
     $ cp MyPlugin.py $HOME/.ginga/plugins/.
@@ -341,7 +341,7 @@ menu to select your plugin and it should be launched in the right panel.
 If you don't see the name of your plugin in the Operation menu, then
 there was probably an error trying to load it.  Examine the log and
 search for the name of your plugin--you should find some error message
-associated with it. 
+associated with it.
 
 If you select your plugin from the menu, but it doesn't launch a GUI,
 there may be a problem or error in the plugin file.  Again, examine the
@@ -366,7 +366,7 @@ the GUI or possibly under the Errors tab.
           plugin into the "Local plugin" box in "Debug" and press
           "Reload"--this will reload the python module representing your
           plugin and you should be able to immediately restart it using
-          the Plugin Manager bar as described above. 
+          the Plugin Manager bar as described above.
 
           If you have edited third party modules that are included in
           the plugin, this will not be enough to pick up those changes.
@@ -377,8 +377,7 @@ A more complex example: The ``Ruler`` Plugin
 Finally, in Listing 3 we show a completed plugin for ``Ruler``.  The
 purpose of this plugin to draw triangulation (distance measurement)
 rulers on the image.  For reference, you may want to refer to the ruler
-shown on the canvas in Figure :ref:`fig2` and the plugin GUI shown in
-Figure :ref:`fig6`.   
+shown in :ref:`fig6`.
 
 .. _fig6:
 .. figure:: figures/ruler_plugin.png
@@ -394,17 +393,17 @@ Figure :ref:`fig6`.
     #
     from ginga import GingaPlugin
     from ginga.gw import Widgets
-    
+
     class Ruler(GingaPlugin.LocalPlugin):
-    
+
         def __init__(self, fv, fitsimage):
             # superclass defines some variables for us, like logger
             super(Ruler, self).__init__(fv, fitsimage)
-    
+
             self.rulecolor = 'green'
             self.layertag = 'ruler-canvas'
             self.ruletag = None
-    
+
             self.dc = fv.getDrawClasses()
             canvas = self.dc.DrawingCanvas()
             canvas.enable_draw(True)
@@ -418,45 +417,45 @@ Figure :ref:`fig6`.
             canvas.register_for_cursor_drawing(self.fitsimage)
             canvas.name = 'Ruler-canvas'
             self.canvas = canvas
-    
+
             self.w = None
             self.unittypes = ('arcmin', 'degrees', 'pixels')
             self.units = 'arcmin'
-    
+
         def build_gui(self, container):
             top = Widgets.VBox()
             top.set_border_width(4)
-    
+
             vbox, sw, orientation = Widgets.get_oriented_box(container)
             vbox.set_border_width(4)
             vbox.set_spacing(2)
-    
+
             self.msgFont = self.fv.getFont("sansFont", 12)
             tw = Widgets.TextArea(wrap=True, editable=False)
             tw.set_font(self.msgFont)
             self.tw = tw
-    
+
             fr = Widgets.Expander("Instructions")
             fr.set_widget(tw)
             vbox.add_widget(fr, stretch=0)
-    
+
             fr = Widgets.Frame("Ruler")
-    
+
             captions = (('Units:', 'label', 'Units', 'combobox'),
                         )
             w, b = Widgets.build_info(captions, orientation=orientation)
             self.w = b
-    
+
             combobox = b.units
             for name in self.unittypes:
                 combobox.append_text(name)
             index = self.unittypes.index(self.units)
             combobox.set_index(index)
             combobox.add_callback('activated', lambda w, idx: self.set_units())
-    
+
             fr.set_widget(w)
             vbox.add_widget(fr, stretch=0)
-    
+
             mode = self.canvas.get_draw_mode()
             hbox = Widgets.HBox()
             btn1 = Widgets.RadioButton("Draw")
@@ -465,53 +464,53 @@ Figure :ref:`fig6`.
             btn1.set_tooltip("Choose this to draw a ruler")
             self.w.btn_draw = btn1
             hbox.add_widget(btn1)
-    
+
             btn2 = Widgets.RadioButton("Edit", group=btn1)
             btn2.set_state(mode == 'edit')
             btn2.add_callback('activated', lambda w, val: self.set_mode_cb('edit', val))
             btn2.set_tooltip("Choose this to edit a ruler")
             self.w.btn_edit = btn2
             hbox.add_widget(btn2)
-    
+
             hbox.add_widget(Widgets.Label(''), stretch=1)
             vbox.add_widget(hbox, stretch=0)
-    
+
             spacer = Widgets.Label('')
             vbox.add_widget(spacer, stretch=1)
-    
+
             top.add_widget(sw, stretch=1)
-    
+
             btns = Widgets.HBox()
             btns.set_spacing(3)
-    
+
             btn = Widgets.Button("Close")
             btn.add_callback('activated', lambda w: self.close())
             btns.add_widget(btn, stretch=0)
             btns.add_widget(Widgets.Label(''), stretch=1)
             top.add_widget(btns, stretch=0)
-    
+
             container.add_widget(top, stretch=1)
-    
+
         def set_units(self):
             index = self.w.units.get_index()
             units = self.unittypes[index]
             self.canvas.set_drawtype('ruler', color='cyan', units=units)
-    
+
             if self.ruletag is not None:
                 obj = self.canvas.getObjectByTag(self.ruletag)
                 if obj.kind == 'ruler':
                     obj.units = units
                     self.canvas.redraw(whence=3)
             return True
-    
+
         def close(self):
             chname = self.fv.get_channelName(self.fitsimage)
             self.fv.stop_local_plugin(chname, str(self))
             return True
-    
+
         def instructions(self):
             self.tw.set_text("""Draw (or redraw) a line with the cursor.
-    
+
     Display the Zoom tab at the same time to precisely see detail while drawing.""")
 
         def start(self):
@@ -520,17 +519,17 @@ Figure :ref:`fig6`.
             p_canvas = self.fitsimage.get_canvas()
             if not p_canvas.has_object(self.canvas):
                 p_canvas.add(self.canvas, tag=self.layertag)
-    
+
             self.canvas.delete_all_objects()
             self.resume()
-    
+
         def pause(self):
             self.canvas.ui_setActive(False)
-    
+
         def resume(self):
             self.canvas.ui_setActive(True)
             self.fv.showStatus("Draw a ruler with the right mouse button")
-    
+
         def stop(self):
             # remove the canvas from the image
             p_canvas = self.fitsimage.get_canvas()
@@ -540,19 +539,19 @@ Figure :ref:`fig6`.
                 pass
             self.canvas.ui_setActive(False)
             self.fv.showStatus("")
-    
+
         def redo(self):
             obj = self.canvas.get_object_by_tag(self.ruletag)
             if obj.kind != 'ruler':
                 return True
             # redraw updates ruler measurements
             self.canvas.redraw(whence=3)
-    
+
         def clear(self, canvas, button, data_x, data_y):
             self.canvas.delete_all_objects()
             self.ruletag = None
             return False
-    
+
         def wcsruler(self, surface, tag):
             obj = self.canvas.get_object_by_tag(tag)
             if obj.kind != 'ruler':
@@ -562,18 +561,18 @@ Figure :ref:`fig6`.
                 self.canvas.delete_object_by_tag(self.ruletag)
             except:
                 pass
-    
+
             # change some characteristics of the drawn image and
             # save as the new ruler
             self.ruletag = tag
             obj.color = self.rulecolor
             obj.cap = 'ball'
             self.canvas.redraw(whence=3)
-    
+
         def edit_cb(self, canvas, obj):
             self.redo()
             return True
-    
+
         def edit_select_ruler(self):
             if self.ruletag is not None:
                 obj = self.canvas.get_object_by_tag(self.ruletag)
@@ -581,23 +580,23 @@ Figure :ref:`fig6`.
             else:
                 self.canvas.clear_selected()
             self.canvas.update_canvas()
-    
+
         def set_mode_cb(self, mode, tf):
             if tf:
                 self.canvas.set_draw_mode(mode)
                 if mode == 'edit':
                     self.edit_select_ruler()
             return True
-    
+
         def __str__(self):
             return 'ruler'
-    
+
     #END
-    
+
 This plugin shows a standard design pattern typical to local plugins.
 Often one is wanting to draw or plot something on top of the image
 below.  The ``ImageViewCanvas`` widget used by Ginga allows this to be
-done very cleanly and conveniently by adding a ``DrawingCanvas`` 
+done very cleanly and conveniently by adding a ``DrawingCanvas``
 object to the image and drawing on that.  Canvases can be layered on top
 of each other in a manner analogous to "layers" in an image editing
 program.  Since each local plugin maintains it's own canvas, it is very
@@ -615,16 +614,16 @@ notice a ``setSurface()`` call that associates this canvas with a
 ``ImageView``-based widget--this is the key for the canvas to utilize WCS
 information for correct plotting.
 All the other methods shown are support methods for doing the ruler
-drawing operation and interacting with the plugin GUI. 
+drawing operation and interacting with the plugin GUI.
 
 .. _sec-writing-global-plugins:
 
 Writing a Global Plugin
 -----------------------
-The last example was focused on writing a local plugin.  Global plugins 
+The last example was focused on writing a local plugin.  Global plugins
 employ a nearly identical API to that shown in Listing 2, except that
 the constructor does not take a ``fitsimage`` parameter.
-``pause()`` and ``resume()`` can safely be omitted.  Like local plugins, 
+``pause()`` and ``resume()`` can safely be omitted.  Like local plugins,
 ``build_gui()`` can be omitted if there is no GUI associated with the plugin.
 
 A template: MyGlobalPlugin
@@ -637,7 +636,7 @@ invoked from a terminal:
 
     $ ginga --modules=MyGlobalPlugin --loglevel=20 --log=/tmp/ginga.log
 
-The plugin will be started at program startup and can be seen in the 
+The plugin will be started at program startup and can be seen in the
 "MyGlobalPlugin" tab in the right panel.  Watch the status message as
 you create new channels, delete channels or load images into channels.
 
@@ -810,7 +809,7 @@ you create new channels, delete channels or load images into channels.
 
         def stop(self):
             """
-            This method is called when the plugin is stopped. 
+            This method is called when the plugin is stopped.
             It should perform any special clean up necessary to terminate
             the operation.  This method could be called more than once if
             the plugin is opened and closed, and may be omitted if there is no

--- a/doc/manual/index.rst
+++ b/doc/manual/index.rst
@@ -9,7 +9,7 @@ The Ginga Viewer and Toolkit Manual
 Ginga is a toolkit for building viewers for scientific data in Python,
 particularly astronomical data.  It also includes a reference viewer for
 viewing FITS (Flexible Image Transport System) files.
-The Ginga viewer is based on an image display object which supports 
+The Ginga viewer is based on an image display object which supports
 zooming and panning, color and intensity mapping, a choice of several
 automatic cut levels algorithms and canvases for plotting scalable
 geometric forms.  In addition to this widget, the reference viewer
@@ -24,9 +24,8 @@ windows, star catalog access, cuts, star pick/fwhm, thumbnails, etc.
    introduction
    concepts
    operation
+   canvas
    plugins
    customizing
    developers
    internals
-
-

--- a/doc/manual/operation.rst
+++ b/doc/manual/operation.rst
@@ -7,7 +7,7 @@ the most part these apply both to Ginga ImageView classes that can be
 embedded in a python application as well as to the reference viewer
 distributed with Ginga.  In cases where we are referring to something
 that is only available in the reference viewer these will be prefixed by
-the notation "[RV]". 
+the notation "[RV]".
 
 ===========
 Terminology
@@ -23,9 +23,9 @@ with the mouse:
 * *Scroll* means to scroll with the middle mouse wheel;
 * *Scroll-click* means to click with the middle mouse wheel/button;
 * *Scroll-drag* means to click, hold and drag with the middle
-  mouse wheel/button; 
+  mouse wheel/button;
 * *Right-click* means to click on an item with the right mouse
-  button; 
+  button;
 * *Right-drag* means to click, hold and drag with the right
   mouse button.
 
@@ -64,7 +64,7 @@ There are several ways to load a file into Ginga:
 
 * [RV] Use the "Load Image" entry from the `File` menu on the main menu
   bar at the top of the window.  This opens a standard file dialog popup
-  window where you can navigate to the file you wish to load. 
+  window where you can navigate to the file you wish to load.
 
 .. _zooming-and-panning:
 
@@ -74,7 +74,7 @@ Zooming and panning
 
 The display object used throughout most of the Ginga panels has built-in
 support for zooming and panning.  The :ref:`ginga-quick-reference` has the
-complete listing of default keyboard and mouse bindings.  
+complete listing of default keyboard and mouse bindings.
 Briefly, the scroll wheel of the mouse can be used to zoom in and out,
 along with the "+" and "-" keys.  The backquote key will fit the
 image to the window.  Digit keys (1, 2, etc) will zoom in to the
@@ -91,18 +91,18 @@ and dragging) or press and release "q" and then Left-drag.
 *Proportional panning* or "drag panning" pans the image in direct
 proportion to the distance the mouse is moved; a common idiom is
 dragging the image canvas in the direction you want to move it under the
-window.  To utilize a proportional pan, Ctrl-drag the canvas.  
+window.  To utilize a proportional pan, Ctrl-drag the canvas.
 
 [RV] The Pan plugin (usually embedded under the Info tab) shows the
 outline of the current pan position as a rectangle on a small version of
 the whole image.  Dragging this outline will also pan the image in the main
 window.  You can also click anywhere in the Pan window to set the pan
 position, or right drag an outline to roughly specify the region to zoom
-and pan to together. 
+and pan to together.
 
-Panning in Ginga is based on an (X, Y) coordinate known as the 
-*pan position*.  The pan position determines what Ginga will 
-try to keep in the middle of the window as the image is zoomed.  
+Panning in Ginga is based on an (X, Y) coordinate known as the
+*pan position*.  The pan position determines what Ginga will
+try to keep in the middle of the window as the image is zoomed.
 When zoomed out, one can Shift-click on a particular point in the image
 (or press the "p" key while hovering over a spot),
 setting the pan position.  Zooming afterward will keep the pan
@@ -111,7 +111,7 @@ center of the image, press 'c'.
 
 Ginga has an auto zoom feature to automatically fit newly loaded images
 to the window, similar to what happens when the backquote key is
-pressed.  See section :ref:`preferences-zoom` for details.
+pressed.  See section :ref:`preferences_zoom` for details.
 
 ================================
 How Ginga maps an image to color
@@ -123,9 +123,9 @@ steps:
 1) setting the *cut levels*, which scales all values in the image to a
    specified range,
 2) a *color distribution algorithm*, which distributes values within
-   that range to indexes into a color map table, and 
+   that range to indexes into a color map table, and
 3) an *intensity map* and *color map*, which are applied to these
-   indexes to map the final values to RGB pixels. 
+   indexes to map the final values to RGB pixels.
 
 .. _setting_cut_levels:
 
@@ -170,9 +170,9 @@ Ginga can algorithmically estimate and set the cut levels--a so called
 
 [RV] The auto cut levels feature is controlled by several factors in the
 preferences, including the choice of algorithm and some parameters to
-the algorithm.  See section :ref:`preferences-autocuts` for details.
+the algorithm.  See section :ref:`preferences_autocuts` for details.
 Ginga can also automatically set the cut levels for new images displayed
-in the view.  See section :ref:`preferences-newimages` for details.
+in the view.  See section :ref:`preferences_newimages` for details.
 
 Setting the color scale algorithm
 =================================
@@ -189,7 +189,7 @@ Preferences plugin, under the heading "Color Distribution".
 Changing the color and intensity maps
 =====================================
 
-The color and intensity maps 
+The color and intensity maps
 
 ===========================
 Transforming the image view
@@ -204,7 +204,7 @@ thereof.  These operations can be done by keyboard shortcuts:
 * Press "]" to flip in Y, "}" to restore.
 * Press "\" to swap X and Y axes, "|" to restore.
 
-The image can also be rotated in arbitrary amounts.  
+The image can also be rotated in arbitrary amounts.
 
 An interactive rotate operation can be initiated by pressing "r" in the
 image and then dragging the mouse horizontally left or right to set the
@@ -214,7 +214,7 @@ angle.  Press "R" (Shift+R) to restore the angle to 0 (unrotated).
 	  the simple transforms (flip, swap) than by the rotation
 	  feature.  Rotation may slow down some viewing operations.
 
-[RV] The image can also be transformed in the channel Preferences (see 
-:ref:`preferences-transform`) which has checkboxes for flip X, flip Y,
+[RV] The image can also be transformed in the channel Preferences (see
+:ref:`preferences_transform`) which has checkboxes for flip X, flip Y,
 swap XY and a box for rotation by degrees.
 

--- a/ginga/util/wcsmod.py
+++ b/ginga/util/wcsmod.py
@@ -18,6 +18,8 @@ object from a FITS header.
 
 To force the use of one, do:
 
+.. code-block:: python
+
     from ginga.util import wcsmod
     wcsmod.use('kapteyn')
 
@@ -41,12 +43,17 @@ have_astlib = False
 have_pywcs = False
 have_astropy = False
 have_starlink = False
+
 WCS = None
+"""Alias to the chosen WCS system."""
+
 
 class WCSError(Exception):
     pass
 
+
 def use(wcspkg, raise_err=True):
+    """Choose WCS package."""
     global coord_types, wcs_configured, WCS, \
            have_kapteyn, kapwcs, \
            have_astlib, astWCS, astCoords, \
@@ -138,7 +145,6 @@ def use(wcspkg, raise_err=True):
 
         return True
 
-
     elif wcspkg == 'astropy':
         try:
             import astropy.wcs as pywcs
@@ -185,7 +191,7 @@ def use(wcspkg, raise_err=True):
 
 
 class BaseWCS(object):
-
+    """Base class for WCS."""
     def get_keyword(self, key):
         return self.header[key]
 
@@ -252,23 +258,19 @@ class AstropyWCS2(BaseWCS):
         Wrap frame.realize_frame, modify self.coordframe to reflect the
         new coords.
 
+        .. note::
+            This is really an ugly hack, which should be in BaseFrame.
+            What it is doing is only changing the internal representation of
+            the data in a Frame.
+
+            This means that a new frame is not initialized, which is a
+            substantial speed improvement.
+
         Parameters
         ----------
+        data : tuple of Quantity
+            The coordinate data (assumed unit spherical).
 
-        data : tuple of `astropy.units.Quantity`
-            The coordinate data (assumed unit spherical)
-
-        Returns
-        -------
-        None
-
-        Notes
-        -----
-
-        This is really an ugly hack, which should be in BaseFrame. What it is
-        doing is only changing the internal representation of the data in a Frame.
-        This means that a new frame is not initilized, which is a substantial
-        speed improvement.
         """
         # If the representation is a subclass of Spherical we need to check for
         # the new _unitrep attr to give the corresponding unit spherical subclass.
@@ -419,12 +421,10 @@ class AstropyWCS2(BaseWCS):
 class AstropyWCS(BaseWCS):
     """A WCS interface for astropy.wcs
     You need to install python module 'astropy'
-
-        http://pypi.python.org/pypi/astropy
-
+    (http://pypi.python.org/pypi/astropy)
     if you want to use this version.
-    """
 
+    """
     def __init__(self, logger):
         super(AstropyWCS, self).__init__()
 
@@ -613,12 +613,10 @@ class AstropyWCS(BaseWCS):
 class AstLibWCS(BaseWCS):
     """A WCS interface for astLib.astWCS.WCS
     You need to install python module 'astLib'
-
-        http://sourceforge.net/projects/astlib
-
+    (http://sourceforge.net/projects/astlib)
     if you want to use this version.
-    """
 
+    """
     def __init__(self, logger):
         super(AstLibWCS, self).__init__()
 
@@ -733,12 +731,10 @@ class AstLibWCS(BaseWCS):
 class KapteynWCS(BaseWCS):
     """A WCS interface for kapteyn.wcs.Projection
     You need to install python module 'kapteyn'
-
-        http://www.astro.rug.nl/software/kapteyn/
-
+    (http://www.astro.rug.nl/software/kapteyn/)
     if you want to use this version.
-    """
 
+    """
     def __init__(self, logger):
         super(KapteynWCS, self).__init__()
 
@@ -857,12 +853,10 @@ class KapteynWCS(BaseWCS):
 class StarlinkWCS(BaseWCS):
     """A WCS interface for Starlink
     You need to install python module 'starlink-pyast'
-
-        http://www.astro.rug.nl/software/kapteyn/
-
+    (http://www.astro.rug.nl/software/kapteyn/)
     if you want to use this version.
-    """
 
+    """
     def __init__(self, logger):
         super(StarlinkWCS, self).__init__()
 
@@ -1012,13 +1006,12 @@ class StarlinkWCS(BaseWCS):
 class BareBonesWCS(BaseWCS):
     """A very basic WCS.  Assumes J2000, units in degrees, projection TAN.
 
-    ***** NOTE *****:
-    We strongly recommend that you install one of the 3rd party python
-    WCS modules referred to at the top of this module, all of which are
-    much more capable than BareBonesWCS.
-    ****************
-    """
+    .. note::
+        We strongly recommend that you install one of the 3rd party python
+        WCS modules referred to at the top of this module, all of which are
+        much more capable than BareBonesWCS.
 
+    """
     def __init__(self, logger):
         super(BareBonesWCS, self).__init__()
         self.logger = logger
@@ -1258,6 +1251,5 @@ if not wcs_configured:
 
         except Exception as e:
             continue
-
 
 #END


### PR DESCRIPTION
Fix warnings reported in #219 and more.

* Fixed doc warnings.
* Spiced up Sphinx `conf.py` a little.
* Added prototype of API doc (just to get `modindex` to work). *A lot* of work is needed to get all the API documented, but this shows the potential.
* Removed empty Search page (there is already a search box on top left menu).
* Cleaned up WCS in-code doc for API doc (no change to actual functionality).
* Added canvas doc that was previously (accidentally?) excluded in developer doc.
* My Emacs automatically removing trailing whitespace.

p.s: Also see #182 