### PR TITLE
Qt TreeView to be sorted by leaf index

### DIFF
--- a/ginga/qtw/Widgets.py
+++ b/ginga/qtw/Widgets.py
@@ -567,9 +567,7 @@ class TreeView(WidgetBase):
         treeview = self.widget
         treeview.setColumnCount(len(columns))
         treeview.setSortingEnabled(self.sortable)
-        if self.sortable:
-            # Sort increasing by default
-            treeview.sortByColumn(1, QtCore.Qt.AscendingOrder)
+
         # speeds things up a bit
         treeview.setUniformRowHeights(True)
 
@@ -583,6 +581,10 @@ class TreeView(WidgetBase):
 
         self.datakeys = datakeys
         self.leaf_idx = datakeys.index(self.leaf_key)
+
+        if self.sortable:
+            # Sort increasing by default
+            treeview.sortByColumn(self.leaf_idx, QtCore.Qt.AscendingOrder)
 
         treeview.setHeaderLabels(headers)
 


### PR DESCRIPTION
Qt `TreeView` should be sorted by the given leaf index, not "Column 1".