### PR TITLE
Fix error when channel tries to reload image that fell out of cache

### DIFF
--- a/ginga/Control.py
+++ b/ginga/Control.py
@@ -1503,7 +1503,7 @@ class Channel(Callback.Callbacks):
                 # perpetuate the image_future
                 image.set(image_future=image_future, name=imname,
                           path=path)
-                self.fv.gui_do(self.switch, image)
+                self.fv.gui_do(self.switch_image, image)
 
             self.fv.nongui_do(_load_n_switch, imname, info.path,
                               info.image_future)


### PR DESCRIPTION
Fix error when channel tries to reload image that fell out of cache. Traceback:
```python
2015-12-02 11:14:40,474 | E | Task.py:387 (execute) | Task '<ginga.main.Ginga object at 0x7f18bb7230d0>.task0' terminated with exception: 'Channel' object has no attribute 'switch'
2015-12-02 11:14:40,476 | E | Task.py:391 (execute) | Traceback:
  File ".../ginga-2.5.20151124191302-py2.7.egg/ginga/misc/Task.py", line 377, in execute
    res = self.func(*self.args, **self.kwdargs)
  File ".../ginga-2.5.20151124191302-py2.7.egg/ginga/Control.py", line 1507, in _load_n_switch
    self.fv.gui_do(self.switch, image)
```