### PR TITLE
File menu (Qt) enhancement and FBrowser fix

### DIFF
--- a/ginga/misc/plugins/FBrowser.py
+++ b/ginga/misc/plugins/FBrowser.py
@@ -149,6 +149,9 @@ class FBrowser(GingaPlugin.LocalPlugin):
             self.browse_cb(self.entry)
             return
 
+        # Exclude directories
+        paths = [path for path in paths if os.path.isfile(path)]
+
         # Load files
         self.fv.gui_do(self.fitsimage.make_callback, 'drag-drop', paths)
 

--- a/ginga/qtw/QtHelp.py
+++ b/ginga/qtw/QtHelp.py
@@ -204,6 +204,11 @@ class FileSelection(object):
         filenames = QtGui.QFileDialog.getOpenFileNames(
             self.parent, title, initialdir, filename)
 
+        # Special handling for PyQt5, see
+        # https://www.reddit.com/r/learnpython/comments/2xhagb/pyqt5_trouble_with_openinggetting_the_name_of_the/
+        if ginga.toolkit.get_toolkit() == 'qt5':
+            filenames = filenames[0]
+
         for filename in filenames:
 
             # Special handling for wildcard or extension.


### PR DESCRIPTION
Implement multi-selection and wildcard/extension support for File menu in Qt (see #227). The Qt File menu had limited wildcard/ext support from #204 but it was lost in recent changes; I added that back in this PR. The menu should also be pretty flexible now, which allows user to do `shift+click`, `ctrl+click`, or enter things like `*.fits[2]` in the selection box. I am not aware of anything else that uses `FileSelection` class other than the file menu, but please let me know if this unintentionally breaks something else. As usual, I skipped the GTK portion; someone else can implement it if there is interest.

Also fixed error that occurs in `FBrowser` when directory and files are all selected at the same time (during multi-selection).

I toyed with the idea to also support comma-separated text entries (e.g., `image1.fits,image2.fits`) but I abandoned it because it gets confusing really fast unless you explicitly enter the full path every time (otherwise, Ginga automatically assumes some internal base directory that might not be the currently displayed directory). At this point, it is easier to just do `ctrl+click` or open them separately.