### PR TITLE
Always require at least one active channel

### DIFF
--- a/ginga/gw/GingaGw.py
+++ b/ginga/gw/GingaGw.py
@@ -732,6 +732,10 @@ class GingaView(GwMain.GwMain, Widgets.Application):
         w.delete()
         if rsp == 0:
             return
+        if len(self.channelNames) <= 1:
+            self.logger.error('Delete channel failed. Need at least one '
+                              'active channel.')
+            return
         self.delete_channel(chname)
         return True
 


### PR DESCRIPTION
Always require at least one active channel. I think this makes sense, but I am open to alternatives.

When only one channel is present, Ginga will refuse to delete it and emits the following log entry:
```python
<timestamp> | E | GingaGw.py:735 (delete_channel_cb) | Delete channel failed. Need at least one active channel.
```

This was brought up in #91, where I reported that there is no safe-guard on the "Delete Channel" functionality.