### PR TITLE
Fixes for Ginga banner and version info display

### DIFF
--- a/ginga/Control.py
+++ b/ginga/Control.py
@@ -45,6 +45,9 @@ from ginga.misc import Bunch, Datasrc, Callback, Timer, Task, Future
 from ginga.util import catalog, iohelper
 from ginga.canvas.CanvasObject import drawCatalog
 
+# Version
+from ginga import __version__
+
 #pluginconfpfx = 'plugins'
 pluginconfpfx = None
 
@@ -1116,7 +1119,12 @@ class GingaControl(Callback.Callbacks):
         viewer.cut_levels(0, 255)
 
         #self.nongui_do(self.load_file, bannerFile, chname=chname)
-        self.load_file(bannerFile, chname=chname, wait=False)
+        image = self.load_file(bannerFile, chname=chname, wait=False)
+
+        # Insert Ginga version info
+        header = image.get_header()
+        header['VERSION'] = __version__
+
         if raiseTab:
             self.change_channel(chname)
             viewer.zoom_fit()

--- a/ginga/main.py
+++ b/ginga/main.py
@@ -477,7 +477,7 @@ class ReferenceViewer(object):
             settings.save()
 
         if (not options.nosplash) and (len(args) == 0) and showBanner:
-            ginga.banner()
+            ginga.banner(raiseTab=True)
 
         # Assume remaining arguments are fits files and load them.
         for imgfile in args:


### PR DESCRIPTION
* Fix banner not showing when `showBanner=True` in `general.cfg` (#229).
* Insert Ginga version info in banner header (#241).