### PR TITLE
Fix RTD erroring on numpydoc

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -26,11 +26,12 @@ import sys, os
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.autodoc',
-              'numpydoc',
+              'sphinx.ext.napoleon',
               'sphinx.ext.autosummary',
               'sphinx.ext.intersphinx']
 
-numpydoc_show_class_members = False
+# Still need this?
+#numpydoc_show_class_members = False
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
Replaced `numpydoc` with Sphinx's `napoleon` extension, as suggested by @cdeil . Hopefully this would fix the RTD error reported by @ejeschke in #219.