### PR TITLE
Get rid of PyFITS deprecation warning

### DIFF
--- a/ginga/util/io_fits.py
+++ b/ginga/util/io_fits.py
@@ -211,7 +211,7 @@ class PyFitsFileHandler(BaseFitsFileHandler):
 
         for kwd in header.keys():
             card = header.get_card(kwd)
-            hdu.header.update(card.key, card.value, comment=card.comment)
+            hdu.header[card.key] = (card.value, card.comment)
 
         fits_f.append(hdu)
         return fits_f


### PR DESCRIPTION
Get rid of PyFITS deprecation warning when Ginga saves a FITS file. You can reproduce it by using "Save" in the `Cuts` plugin.