### PR TITLE
Catch and report error to logger in AstropyWCS.pixtocoords

### DIFF
--- a/ginga/util/wcsmod.py
+++ b/ginga/util/wcsmod.py
@@ -576,12 +576,17 @@ class AstropyWCS2(BaseWCS):
             return coord
 
         toclass = astropy.coordinates.frame_transform_graph.lookup_name(system)
+        if toclass is None:
+            raise WCSError(
+                "No such coordinate system available: '{0}'".format(system))
 
         transform = self.coordframe.is_transformable_to(toclass)
         if transform and transform != 'same':
             coord = coord.transform_to(toclass)
         else:
-            self.logger.error("Frame {} is not Transformable to {}, falling back to {}".format(self.coordframe.name, toclass.name, self.coordframe.name))
+            self.logger.error("Frame {} is not Transformable to {}, "
+                              "falling back to {}".format(
+                    self.coordframe.name, toclass.name, self.coordframe.name))
 #            self.prefs.set("wcs_coords", self.coordframe.name)
 
         return coord
@@ -760,9 +765,16 @@ class AstropyWCS(BaseWCS):
             coord = coord.transform_to(toclass)
 
         else:
-            frameClass = coordinates.frame_transform_graph.lookup_name(self.coordsys)
+            frameClass = coordinates.frame_transform_graph.lookup_name(
+                self.coordsys)
+            if frameClass is None:
+                raise WCSError("No such coordinate system available: '%s'" % (
+                    self.coordsys))
             coord = frameClass(ra_deg * units.degree, dec_deg * units.degree)
             toClass = coordinates.frame_transform_graph.lookup_name(system)
+            if toClass is None:
+                raise WCSError("No such coordinate system available: '%s'" % (
+                    system))
             # Skip in input and output is the same (no realize_frame
             # call in astropy)
             if toClass != frameClass:


### PR DESCRIPTION
Catch and report less confusing error to logger in `pixtocoords()` methods, as discussed in #250. The log will look like this:

```python
2015-12-10 15:36:55,274 | W | AstroImage.py:702 (info_xy) | Bad coordinate conversion: No such coordinate system available: 'helioprojective'
2015-12-10 15:36:55,278 | E | AstroImage.py:709 (info_xy) | Traceback:
  File ".../ginga/AstroImage.py", line 669, in info_xy
    args, system=system, coords='data')
  File ".../ginga/util/wcsmod.py", line 629, in pixtosystem
    c = self.pixtocoords(idxs, system=system, coords=coords)
  File ".../ginga/util/wcsmod.py", line 606, in pixtocoords
    raise WCSError(errmsg)
```

Is this worth merging, @ejeschke ?