### PR TITLE
Tight layout for plots

### DIFF
--- a/ginga/misc/plugins/Cuts.py
+++ b/ginga/misc/plugins/Cuts.py
@@ -122,7 +122,6 @@ class Cuts(GingaPlugin.LocalPlugin):
                                   show_cuts_legend=False, enable_slit=False)
         self.settings.load(onError='silent')
         self.colors = self.settings.get('colors', cut_colors)
-        self.show_legend = self.settings.get('show_cuts_legend', False)
 
         self.dc = fv.getDrawClasses()
         canvas = self.dc.DrawingCanvas()
@@ -172,12 +171,6 @@ class Cuts(GingaPlugin.LocalPlugin):
         self.plot.resize(400, 300)
         ax = self.cuts_plot.add_axis()
         ax.grid(True)
-
-        # Shrink plot width by 20%
-        if self.show_legend:
-            cbox = self.cuts_plot.ax.get_position()
-            self.cuts_plot.ax.set_position(
-                [cbox.x0, cbox.y0, cbox.width * 0.8, cbox.height])
 
         self.slit_plot = plots.Plot(logger=self.logger,
                                     width=400, height=300)
@@ -576,14 +569,13 @@ Keyboard shortcuts: press 'h' for a full horizontal cut and 'j' for a full verti
         self.cuts_plot.cuts(points, xtitle="Line Index", ytitle="Pixel Value",
                             color=rgb)
 
-        if self.show_legend:
+        if self.settings.get('show_cuts_legend', False):
             self.add_legend()
 
     def add_legend(self):
         """Add or update Cuts plot legend."""
         cuts = [tag for tag in self.tags if tag is not self._new_cut]
-        self.cuts_plot.ax.legend(cuts, loc='center left',
-                                 bbox_to_anchor=(1, 0.5),
+        self.cuts_plot.ax.legend(cuts, loc='best',
                                  shadow=True, fancybox=True,
                                  prop={'size': 8}, labelspacing=0.2)
 
@@ -706,6 +698,7 @@ Keyboard shortcuts: press 'h' for a full horizontal cut and 'j' for a full verti
                     self.save_slit.set_enabled(True)
 
         # force mpl redraw
+        self.cuts_plot.fig.tight_layout(pad=0.3)
         self.cuts_plot.draw()
 
         self.canvas.redraw(whence=3)

--- a/ginga/misc/plugins/Histogram.py
+++ b/ginga/misc/plugins/Histogram.py
@@ -322,6 +322,7 @@ class Histogram(GingaPlugin.LocalPlugin):
 
         self.w.cut_low.set_text(str(loval))
         self.w.cut_high.set_text(str(hival))
+        self.plot.fig.tight_layout(pad=0.3)
         self.plot.fig.canvas.draw()
 
         self.fv.showStatus("Click or drag left mouse button to move region")

--- a/ginga/misc/plugins/LineProfile.py
+++ b/ginga/misc/plugins/LineProfile.py
@@ -241,6 +241,7 @@ Use MultiDim to change step values of axes.""")
 
             self.clear_plot()
             self.plot.plot(axis_data, mddata[slice_obj])
+            self.plot.fig.tight_layout(pad=0.3)
 
     def _slice(self, naxes, mk):
         # Build N-dim slice


### PR DESCRIPTION
I have identified 4 plugins below with labels cut off, as mentioned in #246. 

- [x] `Cuts` - Adding tight layout requires the legend to be within the plot itself, not outside. Still have to scroll horizontally sometimes to see the rest of the plot, but at least everything is showing now.
- [x] `Histogram` - Adding tight layout works nicely.
- [x] `LineProfile` - Seems to work but I only have 1 data cube file to test with.
- [ ] `Pick` - Has no effect, not sure why.