### PR TITLE
Make QLabel (Qt) text selectable

### DIFF
--- a/ginga/qtw/Widgets.py
+++ b/ginga/qtw/Widgets.py
@@ -253,6 +253,9 @@ class Label(WidgetBase):
 
             lbl.customContextMenuRequested.connect(on_context_menu)
 
+        # Enable highlighting for copying
+        lbl.setTextInteractionFlags(QtCore.Qt.TextSelectableByMouse)
+
         self.enable_callback('activated')
 
     def _cb_redirect(self, event):


### PR DESCRIPTION
Make `QLabel` (Qt) text selectable. This is nice to have if user wants to copy the value from Ginga display. 