### PR TITLE
Fix Header not updating on modified callback

### DIFF
--- a/ginga/misc/plugins/Header.py
+++ b/ginga/misc/plugins/Header.py
@@ -142,6 +142,8 @@ class Header(GingaPlugin.GlobalPlugin):
             self.add_channel(self.fv, channel)
 
     def redo(self, channel, image):
+        """This is called when buffer is modified."""
+        self._image = None  # Skip cache checking in set_header()
         chname = channel.name
         info = self.channel[chname]
 


### PR DESCRIPTION
Fix `Header` global plugin not updating properly on `'modified'` callback. I encountered this when I modify only the header of the image but not the data. I did something like this:

```python
hdr = image.get_header()
hdr[kwd] = val
image.make_callback('modified')
```

I noticed that the listing in `Header` did not update to reflect the new values until I click the sort checkbox.