### PR TITLE
Some modifications to the ginga/colors.py file and added tests for the same

### DIFF
--- a/ginga/colors.py
+++ b/ginga/colors.py
@@ -764,9 +764,22 @@ def lookup_color(name, format='tuple'):
     else:
         raise ValueError("format needs to be 'tuple' or 'hash'")
 
+def _validate_color_tuple(tup):
+    if not(isinstance(tup, tuple) or isinstance(tup, list)) :
+        raise TypeError("the color element must be a tuple or list")    
+
+    if len(tup) != 3:
+        raise ValueError("length of color tuple must be 3 specifying RBG values")
+
+    for rbg_value in tup:
+        if rbg_value < 0.0 or rbg_value > 1.0:
+            raise ValueError("RBG value can only be a number between 0 and 1")
+
 def add_color(name, tup):
+    _validate_color_tuple(tup)
+
     global color_dict
-    color_dict[name] = tup
+    color_dict[name] = tuple(tup)
     recalc_color_list()
 
 def remove_color(name):

--- a/ginga/colors.py
+++ b/ginga/colors.py
@@ -789,7 +789,10 @@ def add_color(name, tup):
 
 def remove_color(name):
     global color_dict
-    del color_dict[name]
+    try:
+        del color_dict[name]
+    except KeyError:
+        raise KeyError("%s color does not exist in color_dict"%(name))
     recalc_color_list()
 
 def get_colors():

--- a/ginga/colors.py
+++ b/ginga/colors.py
@@ -802,6 +802,9 @@ def scan_rgbtxt(filepath):
     with open(filepath, 'r') as in_f:
         buf = in_f.read()
 
+    return scan_rgbtxt_buf(buf)
+
+def scan_rgbtxt_buf(buf):
     res = {}
 
     for line in buf.split('\n'):

--- a/ginga/colors.py
+++ b/ginga/colors.py
@@ -755,7 +755,12 @@ def recalc_color_list():
     color_list.sort()
 
 def lookup_color(name, format='tuple'):
-    color = color_dict[name]
+    color = None
+    try:
+        color = color_dict[name]
+    except KeyError:
+        raise KeyError("%s color does not exist in color_dict"%(name))
+
     if format == 'tuple':
         return color
     elif format == 'hash':

--- a/ginga/tests/test_colors.py
+++ b/ginga/tests/test_colors.py
@@ -7,7 +7,8 @@ import unittest
 import logging
 import numpy as np
 
-from ginga.colors import *
+import ginga.colors
+
 
 class TestError(Exception):
     pass
@@ -16,42 +17,160 @@ class TestError(Exception):
 class TestColors(unittest.TestCase):
 	def setUp(self):
 		self.logger = logging.getLogger("TestColors")
-		self.initial_color_list_length = len(color_list)
+		self.color_list_length = len(ginga.colors.color_dict)
+
+	# Tests for the lookup_color() funtion
 
 	def test_lookup_color_white_tuple(self):
 		expected = (1.0, 1.0, 1.0)
-		actual = lookup_color("white", "tuple")
-
+		actual = ginga.colors.lookup_color("white", "tuple")
 		assert np.allclose(expected, actual)
-
 
 	def test_lookup_color_black_tuple(self):
 		expected = (0.0, 0.0, 0.0)
-		actual = lookup_color("black", "tuple")
-
+		actual = ginga.colors.lookup_color("black", "tuple")
 		assert np.allclose(expected, actual)
 
 	def test_lookup_color_white_hash(self):
 		expected = "#ffffff"
-		actual = lookup_color("white", "hash")
-
+		actual = ginga.colors.lookup_color("white", "hash")
 		assert expected == actual
-
 
 	def test_lookup_color_black_black(self):
 		expected = "#000000"
-		actual = lookup_color("black", "hash")
-
+		actual = ginga.colors.lookup_color("black", "hash")
 		assert expected == actual
 
 	def test_lookup_color_yellow_tuple(self):
 		expected = (1.0, 1.0, 0.0)
-		actual = lookup_color("yellow")
-
+		actual = ginga.colors.lookup_color("yellow")
 		assert np.allclose(expected, actual)
 
-	def test_lookup_color_raise_exception(self):
-		self.assertRaises(ValueError, lookup_color, "white", "unknown_format")
+	def test_lookup_color_unknown(self):
+		self.assertRaises(KeyError, ginga.colors.lookup_color, "unknown_color")
+
+	def test_lookup_color_raise_exception_unknown_key(self):
+		self.assertRaises(KeyError, ginga.colors.lookup_color, "unknown_key")
+
+	def test_lookup_color_raise_exception_unknown_format(self):
+		self.assertRaises(ValueError, ginga.colors.lookup_color, "white", "unknown_format")
+
+
+	# Tests for the get_colors() function
+	def test_get_colors_len(self):
+		expected = self.color_list_length
+		actual = len(ginga.colors.get_colors())
+		assert expected == actual
+
+	def test_add_and_get_colors_len(self):
+		ginga.colors.add_color("test_color_white", (0.0, 0.0, 0.0))
+
+		expected = self.color_list_length + 1
+		actual = len(ginga.colors.get_colors())
+		assert expected == actual
+
+		ginga.colors.remove_color("test_color_white")
+
+
+
+	# Tests for the add_color() and remove_color() function
+
+	def test_add_and_remove_color_len(self):
+		ginga.colors.add_color("test_color_white", (0.0, 0.0, 0.0))
+
+		expected = self.color_list_length + 1
+		actual = len(ginga.colors.color_dict)
+		assert expected == actual
+
+		expected = len(ginga.colors.color_dict)
+		actual = len(ginga.colors.color_list)
+		assert expected == actual
+
+		ginga.colors.remove_color("test_color_white")
+
+		expected = self.color_list_length
+		actual = len(ginga.colors.color_dict)
+		assert expected == actual
+
+		expected = len(ginga.colors.color_dict)
+		actual = len(ginga.colors.color_list)
+		assert expected == actual
+
+
+	def test_add_and_remove_color_rbg(self):
+		ginga.colors.add_color("test_color_white", (0.0, 0.0, 0.0))
+
+		expected = (0.0, 0.0, 0.0)
+		actual = ginga.colors.lookup_color("test_color_white")
+		assert np.allclose(expected, actual)
+
+		ginga.colors.remove_color("test_color_white")
+		self.assertRaises(KeyError, ginga.colors.remove_color, "test_color_white")
+
+
+	def test_add_color_wrong_rbg_type(self):
+		self.assertRaises(TypeError, ginga.colors.add_color, "white", "string_wrong_format")
+
+	def test_add_color_wrong_rbg_values(self):
+		self.assertRaises(ValueError, ginga.colors.add_color, "test_color", (-1.0, 0.0, 0.0))
+
+	def test_add_color_wrong_tuple_length(self):
+		self.assertRaises(ValueError, ginga.colors.add_color, "test_color", (0.0, 0.0))
+
+	def test_remove_color_unknown(self):
+		self.assertRaises(KeyError, ginga.colors.remove_color, "unknown_color")
+
+
+	# Tests for recalc_color_list() function
+
+	def test_recalc_color_list(self):
+		ginga.colors.color_dict["test_color_white"] = (0.0, 0.0, 0.0)
+
+		expected = len(ginga.colors.color_dict) - 1 
+		actual = len(ginga.colors.color_list)
+		assert expected == actual
+
+		ginga.colors.recalc_color_list()
+
+		expected = len(ginga.colors.color_dict)
+		actual = len(ginga.colors.color_list)
+		assert expected == actual
+
+		del ginga.colors.color_dict["test_color_white"]
+
+		expected = len(ginga.colors.color_dict) + 1
+		actual = len(ginga.colors.color_list)
+		assert expected == actual
+
+		ginga.colors.recalc_color_list()
+
+		expected = len(ginga.colors.color_dict)
+		actual = len(ginga.colors.color_list)
+		assert expected == actual
+
+	# Tests for scan_rgbtxt_buf() function
+	
+	def test_scan_rgbtxt_buf(self):
+		test_rgb_lines = '''
+			255 255 255		white
+			0   0   0		black
+			255   0   0		red
+			0 255	  0		green
+			0   0 255		blue
+		'''
+
+		result = ginga.colors.scan_rgbtxt_buf(test_rgb_lines)
+
+		assert isinstance(result, dict)
+
+		expected = 5
+		actual = len(result)
+		assert expected == actual
+
+		expected = (1.0, 1.0, 1.0)
+		actual = result["white"]
+		assert np.allclose(expected, actual)
+
 
 	def tearDown(self):
 		pass

--- a/ginga/tests/test_colors.py
+++ b/ginga/tests/test_colors.py
@@ -1,0 +1,27 @@
+#
+# Unit Tests for the colors.py functions
+#
+# Rajul Srivastava  (rajul09@gmail.com)
+#
+import unittest
+import logging
+import numpy as np
+
+from ginga.colors import *
+
+class TestError(Exception):
+    pass
+
+
+class TestColors(unittest.TestCase):
+	def setUp(self):
+		self.logger = logging.getLogger("TestColors")
+		self.initial_color_list_length = len(color_list)
+
+	def tearDown(self):
+		pass
+
+if __name__ == '__main__':
+    unittest.main()
+
+#END

--- a/ginga/tests/test_colors.py
+++ b/ginga/tests/test_colors.py
@@ -18,6 +18,41 @@ class TestColors(unittest.TestCase):
 		self.logger = logging.getLogger("TestColors")
 		self.initial_color_list_length = len(color_list)
 
+	def test_lookup_color_white_tuple(self):
+		expected = (1.0, 1.0, 1.0)
+		actual = lookup_color("white", "tuple")
+
+		assert np.allclose(expected, actual)
+
+
+	def test_lookup_color_black_tuple(self):
+		expected = (0.0, 0.0, 0.0)
+		actual = lookup_color("black", "tuple")
+
+		assert np.allclose(expected, actual)
+
+	def test_lookup_color_white_hash(self):
+		expected = "#ffffff"
+		actual = lookup_color("white", "hash")
+
+		assert expected == actual
+
+
+	def test_lookup_color_black_black(self):
+		expected = "#000000"
+		actual = lookup_color("black", "hash")
+
+		assert expected == actual
+
+	def test_lookup_color_yellow_tuple(self):
+		expected = (1.0, 1.0, 0.0)
+		actual = lookup_color("yellow")
+
+		assert np.allclose(expected, actual)
+
+	def test_lookup_color_raise_exception(self):
+		self.assertRaises(ValueError, lookup_color, "white", "unknown_format")
+
 	def tearDown(self):
 		pass
 


### PR DESCRIPTION
Made a few changes to the functions of the *ginga/colors.py* file
* lookup_color(): Added a meaningful error message if queried with a non-existent color name
* add_color(): Added a _validate_color_tuple() to validate the passed the color before adding it to color_dict
* remove_color():  Added a meaningful error message if a non-existent color name is tried to remove
* scan_rgbtxt(): Refactored this function into two; added a scan_rgbtxt_buf() which takes a string/buffer argument and parses it to read RGB values

**Tests**: Added tests for the old and the new functionalities of the file
