### PR TITLE
Fixed changing highlight error on Contents

### DIFF
--- a/ginga/Control.py
+++ b/ginga/Control.py
@@ -759,7 +759,7 @@ class GingaControl(Callback.Callbacks):
         channel = self.get_channelInfo(chname)
         info = channel.get_image_info(image.get('name'))
 
-        self.make_async_gui_callback('add-image', chname, image, info)
+        self.make_gui_callback('add-image', chname, image, info)
 
     def bulk_add_image(self, imname, image, chname):
         channel = self.get_channel_on_demand(chname)


### PR DESCRIPTION
Fixed "changing highlight" error on `Contents` when loading multiple images and simultaneously also auto-loading another extension from those images, as reported in #260.

Thanks, @ejeschke ; Your suggestion works!