### PR TITLE
Added mask creation functionality in Drawing

### DIFF
--- a/ginga/misc/plugins/Drawing.py
+++ b/ginga/misc/plugins/Drawing.py
@@ -4,11 +4,6 @@
 # This is open-source software licensed under a BSD license.
 # Please see the file LICENSE.txt for details.
 #
-
-# THIRD-PARTY
-import numpy as np
-
-# LOCSL
 from ginga import GingaPlugin
 from ginga import colors
 from ginga.gw import Widgets
@@ -373,7 +368,7 @@ For polygons/paths press 'v' to create a vertex, 'z' to remove last vertex.""")
         if old_image is None:
             return
 
-        mask = np.zeros(old_image.shape).astype(np.bool)
+        mask = None
         obj_kinds = set()
 
         # Create mask
@@ -386,13 +381,17 @@ For polygons/paths press 'v' to create a vertex, 'z' to remove last vertex.""")
                 self.logger.error('Cannot create mask: {0}'.format(str(e)))
                 continue
 
-            mask |= cur_mask
+            if mask is not None:
+                mask |= cur_mask
+            else:
+                mask = cur_mask
+
             obj_kinds.add(obj.kind)
 
         # Might be useful to inherit header from displayed image (e.g., WCS)
         # but the displayed image should not be modified.
         # Bool needs to be converted to int so FITS writer would not crash.
-        image = dp.make_image(mask.astype(np.int16), old_image, {},
+        image = dp.make_image(mask.astype('int16'), old_image, {},
                               pfx=self._mask_prefix)
         imname = image.get('name')
 


### PR DESCRIPTION
In the `Drawing` local plugin, I added a "Create Mask" button to create boolean mask from drawn objects. The resultant mask has 1's where the drawn object contains the pixels, and 0's otherwise. Mask shape is taken from the displayed image when the button was pressed.

Not all drawn objects create mask that makes sense. For example, text or crosshair. But for the shapes that matter (e.g., circle, box, closed polygon, and the like), this should work properly.

The resultant mask will be inserted into Ginga as a new image, not unlike what happens when you use the `Mosaic` plugin.