### PR TITLE
Fix for swapped NAXIS3 and NAXIS4 in MultiDim [#202]

### DIFF
--- a/ginga/misc/plugins/MultiDim.py
+++ b/ginga/misc/plugins/MultiDim.py
@@ -292,6 +292,8 @@ class MultiDim(GingaPlugin.LocalPlugin):
             for n in range(2, len(dims)):
                 key = 'axis%d' % (n + 1)
                 self.w[key].add_callback('activated', play_axis_change_func_creator(n))
+                if n == 2:
+                    self.w[key].set_state(True)
 
             
         self.play_axis = 2


### PR DESCRIPTION
This patch is a fix for the swap of NAXIS3 and NAXIS4 in the MultiLib window, as noted in #202. The code was inverting the indices, when no inversion was necessary. 

As noted in #202, the control buttons don't work with NAXIS4. Also the NAXIS4 GUI axis skips by two when dragging the pointer across the scale. These problems still persist; the only issue fixed is the axis swap. 