### PR TITLE
Enable auto insert of cfg into docstring

### DIFF
--- a/doc/manual/plugins_global/changehistory.rst
+++ b/doc/manual/plugins_global/changehistory.rst
@@ -12,3 +12,5 @@ This global plugin is used to log any changes to data buffer. For example,
 a change log would appear here if a new image is added to a mosaic via the
 Mosaic plugin. Like :ref:`sec-plugins-contents`, the log is sorted by channel,
 and then by image name.
+
+.. automodule:: ginga.misc.plugins.ChangeHistory

--- a/ginga/misc/plugins/ChangeHistory.py
+++ b/ginga/misc/plugins/ChangeHistory.py
@@ -256,3 +256,10 @@ class ChangeHistory(GingaPlugin.GlobalPlugin):
 
     def __str__(self):
         return 'changehistory'
+
+
+# Replace module docstring with config doc for auto insert by Sphinx.
+# In the future, if we need the real docstring, we can append instead of
+# overwrite.
+from ginga.util.toolbox import generate_cfg_example
+__doc__ = generate_cfg_example('plugin_ChangeHistory', package='ginga')

--- a/ginga/util/toolbox.py
+++ b/ginga/util/toolbox.py
@@ -4,6 +4,18 @@
 # This is open-source software licensed under a BSD license.
 # Please see the file LICENSE.txt for details.
 #
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+# STDLIB
+import io
+import os
+import warnings
+
+# THIRD-PARTY
+from astropy.utils.data import get_pkg_data_contents
+from astropy.utils.exceptions import AstropyUserWarning
+
 
 class ModeIndicator(object):
     """
@@ -90,5 +102,60 @@ class ModeIndicator(object):
         bm = view.get_bindmap()
         mode, modetype = bm.current_mode()
         self.mode_change_cb(bm, mode, modetype)
+
+
+def generate_cfg_example(config_name, **kwargs):
+    """Generate config file documentation for a given config name.
+
+    If found, it will be a Python code block of the contents.
+    If not found, it will have a generic message that the config
+    is not available.
+
+    Parameters
+    ----------
+    config_name : str
+        Config name that is attached to the configuration file.
+        This is the same as input for ``prefs.createCategory()``.
+        For example, ``'general'``, ``'channel_Image'``, or
+        ``'plugin_Zoom'``.
+
+    kwargs : dict
+        Optional keywords for :func:`~astropy.utils.data.get_pkg_data_contents`.
+
+    Returns
+    -------
+    docstr : str
+        Docstring to be inserted into documentation.
+
+    """
+    cfgpath = 'examples/configs'  # Where it is in pkg data
+    cfgname = config_name + '.cfg'
+
+    try:
+        cfgdata = get_pkg_data_contents(
+            os.path.join(cfgpath, cfgname), **kwargs)
+    except Exception as e:
+        warnings.warn(str(e), AstropyUserWarning)
+        return ''
+
+    userpath = '~/.ginga'  # Where user should save it
+    userfile = os.path.join(userpath, cfgname)
+
+    docstring = io.StringIO()
+    docstring.write("""It is customizable using ``{0}``:
+
+.. code-block:: Python
+
+""".format(userfile))
+
+    for line in cfgdata.split('\n'):
+        line = line.strip()
+
+        if len(line) == 0:
+            docstring.write('\n')  # Prevent trailing spaces
+        else:
+            docstring.write('  {0}\n'.format(line))
+
+    return docstring.getvalue()
 
 #END

--- a/ginga/util/toolbox.py
+++ b/ginga/util/toolbox.py
@@ -138,15 +138,16 @@ def generate_cfg_example(config_name, **kwargs):
         warnings.warn(str(e), AstropyUserWarning)
         return ''
 
-    userpath = '~/.ginga'  # Where user should save it
-    userfile = os.path.join(userpath, cfgname)
+    homepath = '~'  # Symbol for HOME for doc only, not actual code
+    userfile = os.path.join(homepath, '.ginga', cfgname)
 
     docstring = io.StringIO()
-    docstring.write("""It is customizable using ``{0}``:
+    docstring.write("""It is customizable using ``{0}``, where ``{1}``
+is your HOME directory:
 
 .. code-block:: Python
 
-""".format(userfile))
+""".format(userfile, homepath))
 
     for line in cfgdata.split('\n'):
         line = line.strip()


### PR DESCRIPTION
As discussed during sprint session. This automatically inserts config file contents from examples into plugins doc.