### PR TITLE
Fix import error in RTD build

### DIFF
--- a/doc/rtd-pip-requirements
+++ b/doc/rtd-pip-requirements
@@ -1,0 +1,5 @@
+numpy
+matplotlib
+Cython
+astropy-helpers
+astropy


### PR DESCRIPTION
This is a follow-up of #305. I forgot the quirks of building on RTD. I already made sure this works on my own [RTD branch](http://gingabranchlim.readthedocs.org/en/fix-rtd-import/manual/plugins_global/changehistory.html).

Note: @ejeschke , you have to ensure you have the following settings:

![screenshot](https://cloud.githubusercontent.com/assets/2090236/14327654/44358396-fc01-11e5-97f4-071a9dc9e853.png)
...
![screenshot-1](https://cloud.githubusercontent.com/assets/2090236/14327559/db64a1b2-fc00-11e5-8dae-62b4ee9c7bf8.png)