### PR TITLE
Doc links follow-up

### DIFF
--- a/doc/FAQ.rst
+++ b/doc/FAQ.rst
@@ -1,3 +1,5 @@
+.. _ginga-faq:
+
 +++++++++++++
 The Ginga FAQ
 +++++++++++++
@@ -57,7 +59,7 @@ Yes.  There is more information in Section :ref:`sec-bindings`.
 
 Where can I find a quick reference of the bindings?
 ---------------------------------------------------
-`Look here <https://ginga.readthedocs.io/en/latest/quickref.html>`_.
+See Section :ref:`ginga-quick-reference`.
 
 -------------
 Miscellaneous

--- a/ginga/doc/help.html
+++ b/ginga/doc/help.html
@@ -16,11 +16,11 @@
 
 <ul>
   <li> <a href="index.html">Local documentation</a> (if installed) </li>
-  <li> <a href="https://readthedocs.org/docs/ginga/en/latest/index.html">Web
+  <li> <a href="http://ginga.readthedocs.io/en/latest/">Web
   documentation</a> (latest version) </li>
 </ul>
 
-Web documentation at: https://readthedocs.org/docs/ginga/en/latest/
+Web documentation at: http://ginga.readthedocs.io/en/latest/
 
 </body>
 </html>

--- a/ginga/examples/ipython-notebook/ginga_ipython_demo.ipynb
+++ b/ginga/examples/ipython-notebook/ginga_ipython_demo.ipynb
@@ -53,7 +53,7 @@
     "\n",
     "# Get ginga from github (https://github.com/ejeschke/ginga) or\n",
     "#   pypi (https://pypi.python.org/pypi/ginga)\n",
-    "# Ginga documentation at: http://ginga.readthedocs.org/en/latest/"
+    "# Ginga documentation at: http://ginga.readthedocs.io/en/latest/"
    ]
   },
   {
@@ -141,7 +141,7 @@
     "\n",
     "You can open as many of these viewers as you want--just keep a handle to it and use a different name for each unique one.\n",
     "\n",
-    "Keyboard/mouse bindings in the viewer window: http://ginga.readthedocs.org/en/latest/quickref.html\n",
+    "Keyboard/mouse bindings in the viewer window: http://ginga.readthedocs.io/en/latest/quickref.html\n",
     "\n",
     "You will want to check the box that says \"I'm using a trackpad\" if you are--it makes zooming much smoother"
    ]
@@ -1097,7 +1097,7 @@
     "- for drawing, you will need either PIL/pillow, OpenCv or the [`aggdraw` module](https://github.com/ejeschke/aggdraw) module (python 2 only).  PIL is included in anaconda, so is usually all you need.\n",
     "- optional, but highly recommended: `webbrowser`, OpenCv\n",
     "\n",
-    "Latest Ginga documentation, including detailed installation instructions, can be found [here](http://ginga.readthedocs.org/en/latest/)."
+    "Latest Ginga documentation, including detailed installation instructions, can be found [here](http://ginga.readthedocs.io/en/latest/)."
    ]
   },
   {

--- a/ginga/util/wcsmod.py
+++ b/ginga/util/wcsmod.py
@@ -411,7 +411,7 @@ class AstropyWCS2(BaseWCS):
         We include this here to make this compatible with the other WCSs.  But
         "coordsys" is a bad name in astropy coordinates, and using the name
         `coordframe` internally makes it clearer what's going on (see
-        http://astropy.readthedocs.io/en/latest/coordinates/definitions.html)
+        :ref:`Astropy Coordinates Definitions <astropy:astropy-coordinates-definitions>`).
         """
         return self.coordframe
 


### PR DESCRIPTION
This is a follow-up of 33c15be . Fixes #332.

* Replaced direct URL with `intersphinx` magic, where possible.
* Replaced remaining `readthedocs.org` with `readthedocs.io`.

p.s. I'd prefer to merge this *after* #313, as it is easier to resolve conflicts here than over there.