### PR TITLE
Ginga Startup

### DIFF
--- a/ginga/gw/GwMain.py
+++ b/ginga/gw/GwMain.py
@@ -14,8 +14,8 @@ import threading
 import logging
 import ginga.util.six as six
 if six.PY2:
-    import thread
-    import Queue
+    import thread as thread
+    import Queue as Queue
 else:
     import _thread as thread
     import queue as Queue


### PR DESCRIPTION
* Couldn't get `ginga` to start without following modifications.  
  * Ubuntu 16.04
  * Python 3.5.1 :: Anaconda 4.0.0 (64-bit)