### PR TITLE
Disable 2to3 in setup.py

### DIFF
--- a/ginga/misc/Task.py
+++ b/ginga/misc/Task.py
@@ -16,12 +16,8 @@ if six.PY2:
     import thread
     import Queue
 else:
-    import _thread
-    import queue
-
-    # NOTE: For whatever reason "import ... as ..." did not work on Travis CI.
-    thread = _thread
-    Queue = queue
+    import _thread as thread
+    import queue as Queue
 
     # NOTE: See http://bugs.python.org/issue7946
     # we cannot effectively use threading for loading files/network/etc.

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,7 @@ setup(name=PACKAGENAME,
       long_description=LONG_DESCRIPTION,
       cmdclass=cmdclassd,
       zip_safe=False,
-      use_2to3=True,
+      use_2to3=False,
       entry_points=entry_points,
       **package_info
 )


### PR DESCRIPTION
Set `use_2to3=False` in `setup.py`, as discussed in #338.

Thanks for investigating, @wtgee! Sorry for this oversight, @ejeschke !