### PR TITLE
Replace xrange() with range()

### DIFF
--- a/ginga/LayerImage.py
+++ b/ginga/LayerImage.py
@@ -156,7 +156,7 @@ class LayerImage(object):
     # def rgb_compose(self):
     #     slices = []
     #     start_time = time.time()
-    #     for i in xrange(len(self._layer)):
+    #     for i in range(len(self._layer)):
     #         layer = self.get_layer(i)
     #         data = self.alpha_multiply(layer.alpha, layer.image.get_data())
     #         slices.append(data)

--- a/ginga/cvw/CvHelp.py
+++ b/ginga/cvw/CvHelp.py
@@ -159,7 +159,7 @@ class CvContext(object):
 
 ## def bezier_curve_range(steps, points):
 ##     """Range of points in a curve bezier"""
-##     for i in xrange(steps):
+##     for i in range(steps):
 ##         t = i / float(steps - 1)
 ##         yield bezier(t, points)
 

--- a/ginga/misc/plugins/LineProfile.py
+++ b/ginga/misc/plugins/LineProfile.py
@@ -160,7 +160,7 @@ class LineProfile(GingaPlugin.LocalPlugin):
         if image is not None:
             # Add Checkbox widgets
             # `image.naxispath` returns only mdim axes
-            for i in xrange(1, len(image.naxispath)+3):
+            for i in range(1, len(image.naxispath)+3):
                 chkbox = Widgets.CheckBox('NAXIS%d' % i)
                 self.hbox_axes.add_widget(chkbox)
 
@@ -261,7 +261,7 @@ Use MultiDim to change step values of axes.""")
             slice_obj[1] = self.mark_data_y[mk]
 
         # For axis > 3
-        for i in xrange(2, naxes):
+        for i in range(2, naxes):
             slice_obj[i] = self.image.revnaxis[i-2] + 1
 
         # Slice selected axis

--- a/ginga/misc/plugins/MultiDim.py
+++ b/ginga/misc/plugins/MultiDim.py
@@ -637,7 +637,7 @@ class MultiDim(GingaPlugin.LocalPlugin):
 
         W, H = image.get_data_size()
         with self.video_writer(VideoSink((H, W), target_file)) as video:
-            for i in xrange(start, end):
+            for i in range(start, end):
                 video.write(np.flipud(data_rescaled[i]))
 
         self.fv.showStatus("Successfully saved movie")


### PR DESCRIPTION
There is no `xrange` anymore in Python 3, and the ranges are small enough
to just keep them as `range` in Python 2 as well. This closes #343.