### PR TITLE
Small typo fix in example file

### DIFF
--- a/ginga/examples/gtk/example1_gtk.py
+++ b/ginga/examples/gtk/example1_gtk.py
@@ -31,7 +31,7 @@ class FitsViewer(object):
         root.connect("delete_event", lambda w, e: self.quit(w))
         self.root = root
 
-        self.select = GtkHelp.FileSelection(rootr)
+        self.select = GtkHelp.FileSelection(root)
         vbox = gtk.VBox(spacing=2)
 
         fi = ImageViewCanvas(logger)


### PR DESCRIPTION
Removed an extra character in example1_gtk.py, file runs without error now. 