### PR TITLE
Turn grc (now ggrc) and fits2pdf scripts into entry points

### DIFF
--- a/ginga/examples/gtk/fits2pdf.py
+++ b/ginga/examples/gtk/fits2pdf.py
@@ -1,3 +1,4 @@
+#! /usr/bin/env python
 #
 # fits2pdf.py -- Image a FITS file as a PDF.
 #
@@ -21,11 +22,11 @@ from optparse import OptionParser
 
 import cairo
 
-from ..cairow.ImageViewCairo import ImageViewCairo
-from ..AstroImage import AstroImage
+from ginga.cairow.ImageViewCairo import ImageViewCairo
+from ginga.AstroImage import AstroImage
 
 try:
-    from ..version import version
+    from ginga.version import version
 except ImportError:
     version = 'unknown'
 
@@ -77,7 +78,7 @@ def convert(filepath, outfilepath):
         out_f.close()
 
 
-def _main():
+if __name__ == "__main__":
     """Run from command line."""
     usage = "usage: %prog input output"
     optprs = OptionParser(usage=usage, version=version)

--- a/ginga/misc/grc.py
+++ b/ginga/misc/grc.py
@@ -1,54 +1,59 @@
-#! /usr/bin/env python
 #
-# grc -- Ginga Remote Control example client
+# grc.py -- Ginga Remote Control example client
 #
 # This is open-source software licensed under a BSD license.
 # Please see the file LICENSE.txt for details.
 #
+"""See the plugin RC.py for details of the server side.
+
+In Ginga, start the RC plugin to enable Ginga remote control
+(``Plugins->Start RC``).
+
+Show example usage (plugin must be started)::
+
+    $ ggrc help
+
 """
- See the plugin RC.py for details of the server side.
+from __future__ import absolute_import, print_function
 
- In Ginga, start the RC plugin to enable Ginga remote control
-  (Plugins->Start RC).
-
- Show example usage (plugin must be started):
- $ grc help
-
-
-"""
-from __future__ import print_function
 import sys
 from optparse import OptionParser
 
-from ginga.util import grc
+from ..util import grc as _grc
+
+try:
+    from ..version import version
+except ImportError:
+    version = 'unknown'
 
 
 def main(options, args):
 
     # Get proxy to server
-    ginga = grc.RemoteClient(options.host, options.port)
+    ginga = _grc.RemoteClient(options.host, options.port)
 
     if len(args) == 0:
         method_name = 'help'
         args, kwdargs = [], {}
     else:
         method_name = args[0]
-        args, kwdargs = grc.prep_args(args[1:])
+        args, kwdargs = _grc.prep_args(args[1:])
         #print (("args=", args, "kwdargs=", kwdargs))
 
     # invoke method on rest of parameters
     method = ginga.lookup_attr(method_name)
     res = method(*args, **kwdargs)
-    if res not in (grc.undefined, None):
+    if res not in (_grc.undefined, None):
         print(res)
 
 
-if __name__ == "__main__":
-
+def _main():
+    """Run from command line."""
     usage = "usage: %prog [options] cmd [arg] ..."
-    optprs = OptionParser(usage=usage, version=('%%prog'))
+    optprs = OptionParser(usage=usage, version=version)
 
-    optprs.add_option("--debug", dest="debug", default=False, action="store_true",
+    optprs.add_option("--debug", dest="debug", default=False,
+                      action="store_true",
                       help="Enter the pdb debugger on main()")
     optprs.add_option("--host", dest="host", metavar="HOST",
                       default="localhost", help="Connect to server at HOST")

--- a/ginga/util/fits2pdf.py
+++ b/ginga/util/fits2pdf.py
@@ -1,4 +1,3 @@
-#! /usr/bin/env python
 #
 # fits2pdf.py -- Image a FITS file as a PDF.
 #
@@ -9,22 +8,35 @@
 # Please see the file LICENSE.txt for details.
 #
 """
-   $ ./fits2pdf.py <fitsfile> <output.pdf>
+To run this script::
+
+    $ ./fits2pdf.py <fitsfile> <output.pdf>
+
 """
-import sys, os
+from __future__ import absolute_import, division, print_function
+
 import logging
+import sys
+from optparse import OptionParser
 
-from ginga.cairow.ImageViewCairo import ImageViewCairo
 import cairo
-from ginga import AstroImage
 
+from ..cairow.ImageViewCairo import ImageViewCairo
+from ..AstroImage import AstroImage
 
-STD_FORMAT = '%(asctime)s | %(levelname)1.1s | %(filename)s:%(lineno)d (%(funcName)s) | %(message)s'
+try:
+    from ..version import version
+except ImportError:
+    version = 'unknown'
 
-point_in = 1/72.0
+STD_FORMAT = ('%(asctime)s | %(levelname)1.1s | '
+              '%(filename)s:%(lineno)d (%(funcName)s) | %(message)s')
+point_in = 1 / 72.0
 point_cm = 0.0352777778
 
-def main(options, args):
+
+def convert(filepath, outfilepath):
+    """Convert FITS image to PDF."""
 
     logger = logging.getLogger("example1")
     logger.setLevel(logging.INFO)
@@ -37,8 +49,7 @@ def main(options, args):
     fi.configure(500, 1000)
 
     # Load fits file
-    filepath = args[0]
-    image = AstroImage.AstroImage(logger=logger)
+    image = AstroImage(logger=logger)
     image.load_file(filepath)
 
     # Make any adjustments to the image that we want
@@ -51,8 +62,7 @@ def main(options, args):
     ht_pts = 11.0 / point_in
     wd_pts = 8.5 / point_in
     off_x, off_y = 0, 0
-    
-    outfilepath = args[1]
+
     out_f = open(outfilepath, 'w')
     surface = cairo.PDFSurface(out_f, wd_pts, ht_pts)
     # set pixels per inch
@@ -66,8 +76,13 @@ def main(options, args):
     finally:
         out_f.close()
 
-    
-if __name__ == '__main__':
-    main(None, sys.argv[1:])
-    
+
+def _main():
+    """Run from command line."""
+    usage = "usage: %prog input output"
+    optprs = OptionParser(usage=usage, version=version)
+    (options, args) = optprs.parse_args(sys.argv[1:])
+
+    convert(args)
+
 # END

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,4 +46,3 @@ test_suite = ginga.tests.ginga_test_suite
 [entry_points]
 ginga = ginga.main:_main
 ggrc = ginga.misc.grc:_main
-fits2pdf = ginga.util.fits2pdf:_main

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,3 +45,5 @@ test_suite = ginga.tests.ginga_test_suite
 
 [entry_points]
 ginga = ginga.main:_main
+ggrc = ginga.misc.grc:_main
+fits2pdf = ginga.util.fits2pdf:_main


### PR DESCRIPTION
Fixes #303. Also see #200.

For `grc`:

* Moved it to `misc` sub-package as `grc.py`.
* Renamed executable to `ggrc`, which is now an entry point.
* PEP8 fixes.

For `fits2pdf.py` (UPDATED):

* Moved it to `examples/gtk` sub-directory.
* Added a proper option parser.
* PEP8 fixes.

@ejeschke , please give this a spin and merge if satisfactory. c/c @olebole .

Examples (UPDATED):

```
$ which ggrc
~/anaconda/bin/ggrc

$ ggrc --help
Usage: ggrc [options] cmd [arg] ...

Options:
  --version    show program's version number and exit
  -h, --help   show this help message and exit
  --debug      Enter the pdb debugger on main()
  --host=HOST  Connect to server at HOST
  --port=PORT  Connect to server at PORT
  --profile    Run the profiler on main()

$ ggrc --version
2.5.20160603104100
```