### PR TITLE
ModuleManager cannot reload properly in Python 3

### DIFF
--- a/ginga/misc/ModuleManager.py
+++ b/ginga/misc/ModuleManager.py
@@ -1,3 +1,4 @@
+"""Dynamically manage module imports."""
 #
 # ModuleManager.py -- Simple class to dynamically manage module imports.
 #
@@ -7,7 +8,15 @@
 # This is open-source software licensed under a BSD license.
 # Please see the file LICENSE.txt for details.
 #
+from __future__ import absolute_import
+
+from ..util.six.moves import reload_module
+
+__all__ = ['ModuleManager']
+
+
 def my_import(name):
+    """Return imported module for the given name."""
     mod = __import__(name)
     components = name.split('.')
     for comp in components[1:]:
@@ -16,20 +25,24 @@ def my_import(name):
 
 
 class ModuleManagerError(Exception):
+    """Exception related to module manager."""
     pass
 
+
 class ModuleManager(object):
+    """Simple class to dynamically manage module imports."""
 
     def __init__(self, logger):
         self.logger = logger
-        
+
         self.module = {}
 
     def loadModule(self, moduleName, pfx=None):
+        """Load module from the given name."""
         try:
             if moduleName in self.module:
                 self.logger.info("Reloading module '%s'..." % moduleName)
-                module = reload(self.module[moduleName])
+                module = reload_module(self.module[moduleName])
 
             else:
                 if pfx:
@@ -39,7 +52,7 @@ class ModuleManager(object):
 
                 self.logger.info("Loading module '%s'..." % moduleName)
                 module = my_import(name)
-                
+
             self.module[moduleName] = module
 
         except Exception as e:
@@ -48,8 +61,7 @@ class ModuleManager(object):
             raise ModuleManagerError(e)
 
     def getModule(self, moduleName):
+        """Return loaded module from the given name."""
         return self.module[moduleName]
 
-    
-            
 #END


### PR DESCRIPTION
Currently, I see the following error with the dev version in Python 3:

```
2016-06-27 11:56:32,685 | E | ModuleManager.py:47 (loadModule) | Failed to load module 'FBrowser': name 'reload' is not defined
2016-06-27 11:56:32,685 | E | Control.py:384 (add_local_plugin) | Unable to load local plugin 'FBrowser': name 'reload' is not defined
```

This PR fixes the above in `ModuleManager.py`. I also added docstrings and addressed minor PEP8 issues.