### PR TITLE
Fix ImportError in Python 3.5.2

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -42,8 +42,11 @@ except ImportError:
 from astropy_helpers.sphinx.conf import *
 
 # Get configuration information from setup.cfg
-from distutils import config
-conf = config.ConfigParser()
+try:
+    from ConfigParser import ConfigParser
+except ImportError:
+    from configparser import ConfigParser
+conf = ConfigParser()
 conf.read([os.path.join(os.path.dirname(__file__), '..', 'setup.cfg')])
 setup_cfg = dict(conf.items('metadata'))
 


### PR DESCRIPTION
Fix `ImportError` in Python 3.5.2, as per astropy/package-template#180.