### PR TITLE
Added thread up status to fix blocking in terminal

### DIFF
--- a/ginga/misc/Task.py
+++ b/ginga/misc/Task.py
@@ -1106,6 +1106,7 @@ class ThreadPool(object):
                                       self.runningcount)
                     self.regcond.wait()
 
+            self.status = 'up'
             self.logger.debug("startall done")
 
 


### PR DESCRIPTION
@ejeschke This is a really small fix, I think it's in the correct place. The problem I was having was with blocking in the python terminal. I'm able to start up the HTML viewer and interact with no problems from a termina;, but when it comes time to exit python, the kernel was hanging and I had to kill it to get out. 

When I did some investigating the server thread was never being updated from 'start' to 'up', so when it came time to run stopall() it was just hanging.

I tested this with the notebook and a few consoles. See if this is the correct fix and works on your end? 