### PR TITLE
Fixing configparser in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,13 @@ from astropy_helpers.git_helpers import get_git_devstr
 from astropy_helpers.version_helpers import generate_version_py
 
 # Get some values from the setup.cfg
-from distutils import config
-conf = config.ConfigParser()
+try:
+    from ConfigParser import ConfigParser
+except ImportError:
+    from configparser import ConfigParser
+
+conf = ConfigParser()
+
 conf.read(['setup.cfg'])
 metadata = dict(conf.items('metadata'))
 


### PR DESCRIPTION
Causing error with py 3.5.2, e.g https://travis-ci.org/astropy/conda-channel-astropy/jobs/141395583#L2108