### PR TITLE
Typo fix and adding optional keyword

### DIFF
--- a/ginga/misc/plugins/SaveImage.py
+++ b/ginga/misc/plugins/SaveImage.py
@@ -1,4 +1,4 @@
-"""Save output images local plugin for Ginga."""
+"""Save output images global plugin for Ginga."""
 from __future__ import absolute_import, division, print_function
 from ginga.util.six import itervalues
 from ginga.util.six.moves import map

--- a/ginga/util/toolbox.py
+++ b/ginga/util/toolbox.py
@@ -107,7 +107,7 @@ class ModeIndicator(object):
         self.mode_change_cb(bm, mode, modetype)
 
 
-def generate_cfg_example(config_name, **kwargs):
+def generate_cfg_example(config_name, cfgpath='examples/configs', **kwargs):
     """Generate config file documentation for a given config name.
 
     If found, it will be a Python code block of the contents.
@@ -122,6 +122,9 @@ def generate_cfg_example(config_name, **kwargs):
         For example, ``'general'``, ``'channel_Image'``, or
         ``'plugin_Zoom'``.
 
+    cfgpath : str
+        Where it is within package data.
+
     kwargs : dict
         Optional keywords for :func:`~astropy.utils.data.get_pkg_data_contents`.
 
@@ -131,7 +134,6 @@ def generate_cfg_example(config_name, **kwargs):
         Docstring to be inserted into documentation.
 
     """
-    cfgpath = 'examples/configs'  # Where it is in pkg data
     cfgname = config_name + '.cfg'
 
     try:


### PR DESCRIPTION
Fixed typo in `SaveImage` doc. Make `cfgpath` optional for `generate_cfg_example()`.

@ejeschke , nothing controversial here. I need `cfgpath` to be optional for one of my projects using that function.