### PR TITLE
Fixed a bug in canvas.types.astro.Compass.draw

### DIFF
--- a/ginga/canvas/types/astro.py
+++ b/ginga/canvas/types/astro.py
@@ -308,9 +308,14 @@ class Compass(OnePointOneRadiusMixin, CanvasObjectBase):
                                   self.cap_radius)
 
     def draw(self, viewer):
-        (cx1, cy1), (cx2, cy2), (cx3, cy3) = self.get_cpoints(viewer)
         cr = viewer.renderer.setup_cr(self)
         cr.set_font_from_shape(self)
+        
+        try:
+            (cx1, cy1), (cx2, cy2), (cx3, cy3) = self.get_cpoints(viewer)
+        except ValueError:
+            cr.draw_text(self.x, self.y, 'BAD WCS')
+            return
 
         # draw North line and arrowhead
         cr.draw_line(cx1, cy1, cx2, cy2)

--- a/ginga/qtw/Widgets.py
+++ b/ginga/qtw/Widgets.py
@@ -250,7 +250,7 @@ class Label(WidgetBase):
             lbl.setAlignment(QtCore.Qt.AlignLeft)
         elif halign == 'center':
             lbl.setAlignment(QtCore.Qt.AlignHCenter)
-        elif halign == 'center':
+        elif halign == 'right':
             lbl.setAlignment(QtCore.Qt.AlignRight)
 
         self.widget = lbl


### PR DESCRIPTION
When `util.wcsmod.AstropyWCS.radectopix` returns `nan` (caused by some kind of faulty FITS file), `Compass.draw` throws an error that causes the viewer at the top of the Info tab to stop working properly. I'm not sure what caused the error in `radectopix`, but the FITS files I'm using have some bizarre transformations on them from IRAF, so I guess the coordinates are all messed up. I set it to print `"BAD WCS"` like `Ruler` does when it can't resolve coordinates.