### PR TITLE
Allowed errors to print out from callbacks without loggers

### DIFF
--- a/ginga/gw/Desktop.py
+++ b/ginga/gw/Desktop.py
@@ -19,6 +19,7 @@ class Desktop(Callback.Callbacks):
         super(Desktop, self).__init__()
 
         self.app = app
+        self.logger = app.logger
         # for tabs
         self.tab = Bunch.caselessDict()
         self.tabcount = 0

--- a/ginga/misc/Callback.py
+++ b/ginga/misc/Callback.py
@@ -113,6 +113,10 @@ class Callbacks(object):
                     self.logger.error("Error making callback '%s': %s" % (
                         name, str(e)))
                     self.logger.error("Traceback:\n%s" % (tb_str))
+                else:
+                    print("Error making callback '%s': %s" % (
+                        name, str(e)))
+                    print("Traceback:\n%s" % (tb_str))
 
         return result
 


### PR DESCRIPTION
Previously, when an error was thrown by a callback from an object without a `logger` attribute, the error remained silent. I set it to print errors to stderr when there is no available `Logger`, instead. That way, errors thrown from callbacks to objects without a `logger`, like `Button`, don't get suppressed.
In doing this, I discovered an error in gw/Desktop.py, where `Desktop` tries to log debug messages, but does not have a `logger`. I fixed that by assigning it a `logger` in its `__init__`.