### PR TITLE
Fix for PIL and Tk backend

### DIFF
--- a/ginga/pilw/ImageViewPil.py
+++ b/ginga/pilw/ImageViewPil.py
@@ -52,6 +52,15 @@ class ImageViewPil(ImageView.ImageViewBase):
         # get window contents as a buffer and paste it into the PIL surface
         rgb_arr = self.getwin_array(order=self._rgb_order)
         p_image = Image.fromarray(rgb_arr)
+
+        if p_image.size != canvas.size:
+            # window size must have changed out from underneath us!
+            width, height = self.get_window_size()
+            canvas = Image.new("RGB", (width, height), color=0)
+            assert p_image.size == canvas.size, \
+                   ImageViewPilError("Rendered image does not match window size")
+            self.surface = canvas
+
         canvas.paste(p_image)
 
         cr = PilHelp.PilContext(canvas)
@@ -77,7 +86,7 @@ class ImageViewPil(ImageView.ImageViewBase):
         # create PIL surface the size of the window
         # NOTE: pillow needs an RGB image in order to draw with alpha
         # blending, not RGBA
-        #self.surface = Image.new("RGBA", (width, height), color=0)
+        #self.surface = Image.new(self._rgb_order, (width, height), color=0)
         self.surface = Image.new("RGB", (width, height), color=0)
 
         # inform the base class about the actual window size
@@ -114,7 +123,7 @@ class ImageViewPil(ImageView.ImageViewBase):
         # Get PIL surface
         p_image = self.get_surface()
         arr8 = numpy.array(p_image, dtype=numpy.uint8)
-        #arr8 = arr8.reshape((ht, wd, 4))
+        arr8 = arr8.reshape((ht, wd, 3))
         return arr8
 
     def get_image_as_buffer(self, output=None):

--- a/ginga/tkw/ImageViewTk.py
+++ b/ginga/tkw/ImageViewTk.py
@@ -57,6 +57,7 @@ class ImageViewTk(ImageView):
         # see reschedule_redraw() method
         self._defer_task = None
 
+
     def set_widget(self, canvas):
         """Call this method with the Tkinter canvas that will be used
         for the display.
@@ -86,12 +87,7 @@ class ImageViewTk(ImageView):
         wd, ht = self.get_window_size()
 
         # Get surface as a numpy array
-        surface = self.get_surface()
-        if isinstance(surface, numpy.ndarray):
-            arr8 = surface
-        else:
-            arr8 = numpy.fromstring(surface.tostring(), dtype=numpy.uint8)
-            arr8 = arr8.reshape((ht, wd, 4))
+        arr8 = self.get_image_as_array()
 
         # make a Tk photo image and stick it to the canvas
         image = PILimage.fromarray(arr8)


### PR DESCRIPTION
This fixes an issue where the PIL backend doesn't have the correct
surface size configured for the window and a render happens, causing
error messages for the first redraw.  Since the Tk backend frequently
relies on PIL to do the rendering, this fixes the Tk backend in those
cases.

-