### PR TITLE
Fixed gtkw.SpinBox.get_value return type

### DIFF
--- a/ginga/gtkw/Widgets.py
+++ b/ginga/gtkw/Widgets.py
@@ -415,13 +415,15 @@ class SpinBox(WidgetBase):
         self.widget.sconnect('value-changed', self._cb_redirect)
 
         self.enable_callback('value-changed')
+        
+        self.dtype = dtype
 
     def _cb_redirect(self, w):
         val = w.get_value()
         self.make_callback('value-changed', val)
 
     def get_value(self):
-        return self.widget.get_value()
+        return self.dtype(self.widget.get_value())
 
     def set_value(self, val):
         self.widget.set_value(val)


### PR DESCRIPTION
Although it takes a dtype keyword parameter, the `gtk` `SpinBox` widget always returns `float` types. I added a `dtype` attribute to `SpinBox`, and a cast in `SpinBox.get_value` such that it will always return a value of the type that was specified at the object's creation. This makes the class more intuitive to use, and makes its behaviour more similar to `qtw.SpinBox`.