### PR TITLE
Update Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 
 python:
     - 2.7
-    - 3.4
     - 3.5
 
 # Setting sudo to false opts in to Travis-CI container-based builds.
@@ -26,15 +25,17 @@ env:
         # overidden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
         - NUMPY_VERSION=stable
+        - ASTROPY_VERSION=stable
         - SETUP_CMD='test'
         - PIP_DEPENDENCIES=''
+        - MAIN_CMD='python setup.py'
         # *** TODO: We should test the various GUI toolkits that ginga supports
         # on travis-ci ... probably one build for Python 2 / 3 and each toolkit
         # https://ginga.readthedocs.io/en/latest/install.html#dependences
-        - CONDA_DEPENDENCIES='pyqt'
-        # Use dev version until astropy/astropy#4748 is in stable version (1.2)
-        #- ASTROPY_VERSION=stable
-        - ASTROPY_VERSION=development
+        - CONDA_DEPENDENCIES='pyqt qt=4'
+        # Conda channels now need to be explicitly listed, ci-helpers won't
+        # add astropy and astropy-ci-extras by default.
+        - CONDA_CHANNELS='astropy-ci-extras astropy'
 
     matrix:
         # Make sure that egg_info works without dependencies
@@ -43,6 +44,10 @@ env:
         - SETUP_CMD='test'
 
 matrix:
+
+    # Don't wait for allowed failures
+    fast_finish: true
+
     include:
 
         # Do a coverage test in Python 2.
@@ -59,10 +64,12 @@ matrix:
 
         # Try Astropy development version
         # NOTE: Uncomment this if global version is stable, not dev
-        #- python: 2.7
-        #  env: ASTROPY_VERSION=development
-        #- python: 3.5
-        #  env: ASTROPY_VERSION=development
+        - python: 2.7
+          env: ASTROPY_VERSION=development
+        - python: 3.5
+          env: ASTROPY_VERSION=development
+
+        # Try Astropy LTS version (disabled for now)
         #- python: 2.7
         #  env: ASTROPY_VERSION=lts
         #- python: 3.5
@@ -73,14 +80,22 @@ matrix:
           env: NUMPY_VERSION=1.10
         - python: 2.7
           env: NUMPY_VERSION=1.9
-        - python: 2.7
-          env: NUMPY_VERSION=1.8
-        - python: 2.7
-          env: NUMPY_VERSION=1.7
+        - python: 3.5
+          env: NUMPY_VERSION=1.10
+        - python: 3.5
+          env: NUMPY_VERSION=1.9
 
         # Try numpy pre-release
         - python: 3.5
           env: NUMPY_VERSION=prerelease
+
+        # Do a PEP8 test with pycodestyle
+        - python: 3.5
+          env: MAIN_CMD='pycodestyle ginga --count' SETUP_CMD=''
+
+    allow_failures:
+        - python: 3.5
+          env: MAIN_CMD='pycodestyle ginga --count' SETUP_CMD=''
 
 before_install:
 
@@ -115,7 +130,7 @@ install:
     # other dependencies.
 
 script:
-   - python setup.py $SETUP_CMD
+   - $MAIN_CMD $SETUP_CMD
 
 after_success:
     # If coveralls.io is set up for this package, uncomment the line


### PR DESCRIPTION
Update Travis CI:

* Pin Qt4 to fix Sphinx build failure.
* Remove Python 3.4 from test (2.7 and 3.5 alone should be sufficient).
* Remove Numpy 1.7 and 1.8 tests, and replaced them with Numpy 1.9 and 1.10 tests with Python 3.
* Now that Astropy 1.2 is released, added stable Astropy back to tests.
* Added conda channels to accommodate for an upcoming `ci-helpers` change.
* Added PEP8 test and allow it to fail. This is useful if you want to clean up the code in the future.
