### PR TITLE
Unpin qt=4 in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ env:
         # *** TODO: We should test the various GUI toolkits that ginga supports
         # on travis-ci ... probably one build for Python 2 / 3 and each toolkit
         # https://ginga.readthedocs.io/en/latest/install.html#dependences
-        - CONDA_DEPENDENCIES='pyqt qt=4'
+        - CONDA_DEPENDENCIES='pyqt'
         # Conda channels now need to be explicitly listed, ci-helpers won't
         # add astropy and astropy-ci-extras by default.
         - CONDA_CHANNELS='astropy-ci-extras astropy'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,17 +18,15 @@ environment:
 
   matrix:
 
-      # We test Python 2.6 and 3.4 because 2.6 is most likely to have issues in
-      # Python 2 (if 2.6 passes, 2.7 virtually always passes) and Python 3.4 is
-      # the latest Python 3 release.
+      # We test Python 2.7 and 3.5 here.
 
-      - PYTHON_VERSION: "2.6"
-        ASTROPY_VERSION: "1.0"
-        NUMPY_VERSION: "1.9.1"
+      - PYTHON_VERSION: "2.7"
+        ASTROPY_VERSION: "1.2"
+        NUMPY_VERSION: "1.11"
 
-      - PYTHON_VERSION: "3.4"
-        ASTROPY_VERSION: "1.0"
-        NUMPY_VERSION: "1.9.1"
+      - PYTHON_VERSION: "3.5"
+        ASTROPY_VERSION: "1.2"
+        NUMPY_VERSION: "1.11"
 
 platform:
     -x64


### PR DESCRIPTION
Unpin `qt=4` in Travis CI. Also update version numbers in Appveyor CI (not used).

This is an attempt to fix Travis CI failures regarding to `sip` version.