### PR TITLE
Fix ref tag syntax in PlotTable page

### DIFF
--- a/doc/manual/plugins_local/plottable.rst
+++ b/doc/manual/plugins_local/plottable.rst
@@ -1,4 +1,4 @@
-. _sec-plugins-plottable:
+.. _sec-plugins-plottable:
 
 PlotTable
 =========


### PR DESCRIPTION
Fixed `ref` tag syntax in `PlotTable` page. Ops, not sure how I missed that. I didn't notice it when I generated the page locally (but that was before #383).