### PR TITLE
Suppress traceback from Cursor when only table is displayed

### DIFF
--- a/ginga/misc/plugins/Cursor.py
+++ b/ginga/misc/plugins/Cursor.py
@@ -10,6 +10,7 @@ import numpy
 from ginga import GingaPlugin, toolkit
 from ginga.misc import Bunch
 from ginga.gw import Widgets, Readout
+from ginga.ImageView import ImageViewNoDataError
 
 
 class Cursor(GingaPlugin.GlobalPlugin):
@@ -96,7 +97,12 @@ class Cursor(GingaPlugin.GlobalPlugin):
         if image is None:
             return True
 
-        width, height = fitsimage.get_data_size()
+        try:
+            width, height = fitsimage.get_data_size()
+        except ImageViewNoDataError as exc:  # table
+            self.logger.debug(str(exc))
+            return
+
         # Set size of coordinate areas (4 is "." + precision 3)
         readout.maxx = len(str(width)) + 4
         readout.maxy = len(str(height)) + 4


### PR DESCRIPTION
Suppress the following traceback from `Cursor` when only table is displayed:

```
2016-11-22 13:33:14,929 | E | GwMain.py:86 (update_pending) | gui error: No data found
2016-11-22 13:33:15,030 | E | GwMain.py:90 (update_pending) | Traceback:
  File ".../ginga-2.6.1.dev1266-py3.5.egg/ginga/gw/GwMain.py", line 81, in update_pending
    res = future.thaw(suppress_exception=False)
  File ".../ginga-2.6.1.dev1266-py3.5.egg/ginga/misc/Future.py", line 40, in thaw
    res = self.method(*self.args, **self.kwdargs)
  File ".../ginga-2.6.1.dev1266-py3.5.egg/ginga/misc/plugins/Cursor.py", line 109, in redo
    self.readout_config(channel.fitsimage, image, readout)
  File ".../ginga-2.6.1.dev1266-py3.5.egg/ginga/misc/plugins/Cursor.py", line 99, in readout_config
    width, height = fitsimage.get_data_size()
  File ".../ginga-2.6.1.dev1266-py3.5.egg/ginga/ImageView.py", line 416, in get_data_size
    raise ImageViewNoDataError("No data found")
```