### PR TITLE
Increase play timer internal to avoid viewer crashing

### DIFF
--- a/ginga/misc/plugins/MultiDim.py
+++ b/ginga/misc/plugins/MultiDim.py
@@ -52,7 +52,7 @@ class MultiDim(GingaPlugin.LocalPlugin):
         self.play_axis = 2
         self.play_idx = 1
         self.play_max = 1
-        self.play_int_sec = 0.1
+        self.play_int_sec = 1
         self.play_min_sec = 0.1
         self.timer = fv.get_timer()
         self.timer.set_callback('expired', self.play_next)


### PR DESCRIPTION
Increase play timer internal to avoid viewer crashing. Fixes #406. At least on my machine, it works when I increase the interval. With the old value, I could reproduce the crashing.