### PR TITLE
Replaced obsolete setItemSelected

### DIFF
--- a/ginga/qtw/Widgets.py
+++ b/ginga/qtw/Widgets.py
@@ -787,7 +787,7 @@ class TreeView(WidgetBase):
 
     def select_path(self, path):
         item = self._path_to_item(path)
-        self.widget.setItemSelected(item, True)
+        item.setSelected(True)
 
     def highlight_path(self, path, onoff, font_color='green'):
         item = self._path_to_item(path)


### PR DESCRIPTION
Replaced `setItemSelected(item,True)` with `item.setSelected(True)` in Qt widget. The former was deprecated in Qt4 and removed in Qt5. Fixes #412 