### PR TITLE
Add Canvas to RC

### DIFF
--- a/doc/manual/plugins_global/rc.rst
+++ b/doc/manual/plugins_global/rc.rst
@@ -174,7 +174,7 @@ of points defined by two Numpy arrays:
 
     x = np.arange(100)
     y = np.sqrt(x)
-    points = zip(x.tolist(), y.tolist())
+    points = list(zip(x.tolist(), y.tolist()))
     canvas.add('path', points, color='red')
 
 This will draw a red line on the image.

--- a/doc/manual/plugins_global/rc.rst
+++ b/doc/manual/plugins_global/rc.rst
@@ -110,3 +110,72 @@ usually interpreted as a program option.  In order to pass a signed
 integer you may need to do something like::
 
     $ grc -- channel FOO zoom -7
+
+
+Interfacing from within Python
+==============================
+
+It is also possible to control Ginga in RC mode
+from within Python.   The following describes
+some of the functionality.
+
+Connecting
+----------
+
+One first launches Ginga and starts the RC plugin.
+This can be done from the command line::
+
+    ginga --modules=RC
+
+From within Python, connect with a RemoteClient object as
+follows::
+
+    from ginga.util import grc
+    host='localhost'
+    port=9000
+    viewer = grc.RemoteClient(host, port)
+
+This viewer object is now linked to the Ginga using RC.
+
+Load an Image
+-------------
+
+One can load an image from memory in a channel of
+one's choosing.  First connect to a Channel::
+
+    ch = viewer.channel('Image')
+
+Then load a numpy image (i.e. any 2D ndarray)::
+
+    img = np.ones((100,100))
+    ch.load_np('any_str_here', img, 'fits', {})
+
+The image will display in Ginga and can be manipulated
+as usual.
+
+Overlay a Canvas Object
+-----------------------
+
+It is possible to add objects to the Canvas in a given
+Channel.  First connect::
+
+    canvas = viewer.canvas('Image')
+
+This connects to the Channel named "Image".  One can
+clear the objects drawn in the Canvas::
+
+    canvas.clear()
+
+Or add any basic Canvas object.  The key issue to keep in
+mind is that the objects input must pass through the XMLRC
+protocol.  This means simple data types:  float, int, lists, str.
+No arrays.  Here is an example to plot a line through a series
+of points defined by two Numpy arrays:
+
+    x = np.arange(100)
+    y = np.sqrt(x)
+    points = zip(x.tolist(), y.tolist())
+    canvas.add('path', points, color='red')
+
+This will draw a red line on the image.
+

--- a/ginga/rv/plugins/RC.py
+++ b/ginga/rv/plugins/RC.py
@@ -357,12 +357,4 @@ class GingaWrapper(object):
         elif command == 'clear':
             canvas.delete_objects()
 
-    #def add_canvas_obj(self, chname, typename, *args, **kwargs):
-    #    chinfo = self.fv.get_channel(chname)
-    #    canvas = chinfo.viewer.get_canvas()
-    #    klass = canvas.get_draw_class(typename)
-    #    obj = klass(*args, **kwargs)
-    #    return self.fv.gui_call(canvas.add, obj)
-
-
 #END

--- a/ginga/rv/plugins/RC.py
+++ b/ginga/rv/plugins/RC.py
@@ -346,5 +346,23 @@ class GingaWrapper(object):
         _method = getattr(self.fv, method_name)
         return self.fv.gui_call(_method, *args, **kwdargs)
 
+    def canvas(self, chname, command, *args, **kwargs):
+        chinfo = self.fv.get_channel(chname)
+        canvas = chinfo.viewer.get_canvas()
+        if command == 'add':
+            klass = canvas.get_draw_class(args[0])
+            newargs = args[1:]
+            obj = klass(*newargs, **kwargs)
+            return self.fv.gui_call(canvas.add, obj)
+        elif command == 'clear':
+            canvas.delete_objects()
+
+    #def add_canvas_obj(self, chname, typename, *args, **kwargs):
+    #    chinfo = self.fv.get_channel(chname)
+    #    canvas = chinfo.viewer.get_canvas()
+    #    klass = canvas.get_draw_class(typename)
+    #    obj = klass(*args, **kwargs)
+    #    return self.fv.gui_call(canvas.add, obj)
+
 
 #END

--- a/ginga/rv/plugins/RC.py
+++ b/ginga/rv/plugins/RC.py
@@ -354,7 +354,18 @@ class GingaWrapper(object):
             newargs = args[1:]
             obj = klass(*newargs, **kwargs)
             return self.fv.gui_call(canvas.add, obj)
-        elif command == 'clear':
-            canvas.delete_objects()
+        elif command == 'clear':  # Clear only drawn objects, not the image
+            nobj = len(canvas.objects)
+            if nobj == 0:
+                return
+            elif nobj == 1:  # Assume it is the image, don't remove
+                return
+            else:
+                canvas.objects = canvas.objects[0:1]
+        elif command == 'nobj':
+            return len(canvas.objects)
+        else:
+            print("Canvas RC command not recognized")
+            return
 
 #END

--- a/ginga/util/grc.py
+++ b/ginga/util/grc.py
@@ -35,6 +35,22 @@ class _ginga_proxy(object):
             return self._fn(name, *args, **kwdargs)
         return _call
 
+class _canvas_proxy(object):
+    """ Links to the canvas method in ginga.rv.plugins.RC.GingaWrapper
+    User has to be savvy on the objects that can be passed through
+    the XMLRPC service (e.g. lists, not arrays)
+    """
+
+    def __init__(self, client, chname):
+        self._client = client
+        self._chname = chname
+        self._fn = client.lookup_attr('canvas')
+
+    def __getattr__(self, command):
+        def _call(*args, **kwdargs):
+            return self._fn(self._chname, command, *args, **kwdargs)
+        return _call
+
 class _channel_proxy(object):
 
     def __init__(self, client, chname):
@@ -162,6 +178,9 @@ class RemoteClient(object):
 
     def channel(self, chname):
         return _channel_proxy(self, chname)
+
+    def canvas(self, chname):
+        return _canvas_proxy(self, chname)
 
     def lookup_attr(self, method_name):
         def call(*args, **kwdargs):


### PR DESCRIPTION
Provides access to the Canvas of a given Channel within the RC plugin.
Includes a new canvas proxy within ginga.util.grc

Also added docs.  

Can add a Test if given guidance.  
I have confirmed it performs as intended in my own applications.