### PR TITLE
Resized screenshots and corrected typos in doc

### DIFF
--- a/doc/manual/developers.rst
+++ b/doc/manual/developers.rst
@@ -836,9 +836,9 @@ you create new channels, delete channels or load images into channels.
 Writing Separately Installable Plugins
 --------------------------------------
 If you want to distribute your plugin(s) as a separately installable
-package and have Ginga discover them when it starts up, you can use
-the .. _Ginga Plugin Template: https://github.com/ejeschke/ginga-plugin-template to
-write your own package that installs plugins.
+package and have Ginga discover them when it starts up, you can use the
+`Ginga Plugin Template <https://github.com/ejeschke/ginga-plugin-template>`_
+to write your own package that installs plugins.
 
 You can include as many plugins in your package as you want.
 You write your plugins in exactly the same way as described above, and

--- a/doc/manual/plugins_local/blink.rst
+++ b/doc/manual/plugins_local/blink.rst
@@ -4,6 +4,7 @@ Blink
 =====
 
 .. image:: figures/blink-plugin.png
+   :width: 400px
    :align: center
 
 Blink switches through the images shown in a channel at a rate chosen by
@@ -18,7 +19,7 @@ within a short timescale--like blinking your eyes.
 
 .. note:: Local plugins are started from the "Operations" button, while
           global plugins are started from the "Plugins" menu.
-   
+
 
 Usage
 -----

--- a/doc/manual/plugins_local/crosshair.rst
+++ b/doc/manual/plugins_local/crosshair.rst
@@ -4,6 +4,7 @@ Crosshair
 =========
 
 .. image:: figures/crosshair-plugin.png
+   :width: 400px
    :align: center
 
 
@@ -19,6 +20,6 @@ Usage
 -----
 Select the appropriate type of output in the "Format" drop-down
 box in the UI: "xy" for pixel coordinates, "coords" for the WCS
-coordinates and "value" for the value at the crosshair position.
+coordinates, and "value" for the value at the crosshair position.
 
 Then click and drag to position the crosshair.

--- a/doc/manual/plugins_local/histogram.rst
+++ b/doc/manual/plugins_local/histogram.rst
@@ -4,6 +4,7 @@ Histogram
 =========
 
 .. image:: figures/histogram-plugin.png
+   :width: 400px
    :align: center
 
 
@@ -14,7 +15,7 @@ entire image.
           separately for each channel in which you want to use it.  If a
           new image is selected for the channel the histogram plot will
           be recalculated based on the current parameters with the new
-          data. 
+          data.
 
 Usage
 -----
@@ -26,14 +27,15 @@ of the image calculating the full histogram can take time).
 UI Controls
 -----------
 Three radio buttons at the bottom of the UI are used to control the
-effects of the click/drag action::
+effects of the click/drag action:
+
 * select "Move" to drag the region to a different location
 * select "Draw" to draw a new region
 * select "Edit" to edit the region
 
 To make a log plot of the histogram, check the "Log Histogram" checkbox.
 To plot by the full range of values in the image instead of by the range
-within the cut values, uncheck the "Plot By Cuts" checkbox. 
+within the cut values, uncheck the "Plot By Cuts" checkbox.
 
 The "NumBins" parameter determines how many bins are used in calculating
 the histogram.  Type a number in the box and press Enter to change the

--- a/doc/manual/plugins_local/overlays.rst
+++ b/doc/manual/plugins_local/overlays.rst
@@ -4,16 +4,17 @@ Overlays
 ========
 
 .. image:: figures/overlays-plugin.png
+   :width: 400px
    :align: center
 
 A plugin for generating color overlays representing under- and
-overexposure in the loaded image.
+over-exposure in the loaded image.
 
 .. note:: Overlays is a local plugin, and thus must be invoked
           separately for each channel in which you want to use it.  If a
           new image is selected for the channel the overlays will
           be recalculated based on the current parameters with the new
-          data. 
+          data.
 
 
 Usage


### PR DESCRIPTION
Resized screenshots and corrected typos in newly added doc.

Out of scope of this PR, but I think the screenshots should also include the image display area. For instance, it is more useful to see what the crosshair looks like in addition to the plugin UI. If you decide to do that, remember to increase the `:width:` value in the Sphinx image directive (800px should be sufficient).

p.s. Setting the width ensures that the screenshot does not appear too large. However, taking a smaller screenshot can also decrease the overall repo size.