### PR TITLE
Updates to put license back in root of repository

### DIFF
--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2016, Eric R. Jeschke
+Copyright (c) 2011-2017, Eric R. Jeschke
 
 All rights reserved.
 
@@ -14,7 +14,7 @@ met:
   documentation and/or other materials provided with the
   distribution. 
 
-* Neither the name of Eric R. Jeschke nor the names of any
+* Neither the name of the Eric R. Jeschke nor the names of its
   contributors may be used to endorse or promote products derived from
   this software without specific prior written permission. 
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,31 @@
+Copyright (c) 2011-2017, Eric R. Jeschke
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met: 
+
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer. 
+
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the
+  distribution. 
+
+* Neither the name of the Eric R. Jeschke nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 

--- a/doc/LICENSE.rst
+++ b/doc/LICENSE.rst
@@ -1,33 +1,4 @@
-:orphan:
+Ginga is licensed under a 3-clause BSD style license:
 
-Copyright (c) 2011-2017, Eric R. Jeschke
+.. include:: ../LICENSE.rst
 
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met: 
-
-* Redistributions of source code must retain the above copyright
-  notice, this list of conditions and the following disclaimer. 
-
-* Redistributions in binary form must reproduce the above copyright
-  notice, this list of conditions and the following disclaimer in the
-  documentation and/or other materials provided with the
-  distribution. 
-
-* Neither the name of the Eric R. Jeschke nor the names of its
-  contributors may be used to endorse or promote products derived from
-  this software without specific prior written permission. 
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
-IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
-TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
-TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 

--- a/ginga/__init__.py
+++ b/ginga/__init__.py
@@ -7,8 +7,6 @@ automatic cut levels algorithms and canvases for plotting scalable
 geometric forms.  In addition to this widget, a general purpose
 'reference' FITS viewer is provided, based on a plugin framework.
 
-Copyright (c) 2011-2017 Eric R. Jeschke. All rights reserved.
-
 Ginga is distributed under an open-source BSD licence. Please see the
 file LICENSE.txt in the top-level directory for details.
 """

--- a/licenses/README.rst
+++ b/licenses/README.rst
@@ -1,0 +1,7 @@
+Licenses
+========
+This directory holds license and credit information for works the Ginga
+package is derived from or distributes, and/or datasets.
+
+The license file for the Ginga package itself is located in the root of
+this repository.


### PR DESCRIPTION
Seems good practice to keep the license at the root of the repository.  This PR moves it back where it was originally.  Following cues from [this discussion](https://github.com/astropy/astropy/issues/5914).

This also updates a date to 2017.

We might want eventually to remove the duplicate `LICENSE.txt` file, but that name is referenced in many, many files.  For now I think it is ok to maintain two side-by-side files.