### PR TITLE
Make matplotlib optional and handle v2 deprecation

### DIFF
--- a/ginga/rv/plugins/Cuts.py
+++ b/ginga/rv/plugins/Cuts.py
@@ -6,11 +6,17 @@
 #
 import numpy
 
-from ginga.gw import Widgets, Plot
+from ginga.gw import Widgets
 from ginga import GingaPlugin, colors
 from ginga.util.six.moves import map, zip
 from ginga.canvas.coordmap import OffsetMapper
-from ginga.util import plots
+
+try:
+    from ginga.gw import Plot
+    from ginga.util import plots
+    have_mpl = True
+except ImportError:
+    have_mpl = False
 
 # default cut colors
 cut_colors = ['magenta', 'skyblue2', 'chartreuse2', 'cyan', 'pink',
@@ -152,6 +158,9 @@ class Cuts(GingaPlugin.LocalPlugin):
         self.gui_up = False
 
     def build_gui(self, container):
+        if not have_mpl:
+            raise ImportError('Install matplotlib to use this plugin')
+
         top = Widgets.VBox()
         top.set_border_width(4)
 

--- a/ginga/rv/plugins/Cuts.py
+++ b/ginga/rv/plugins/Cuts.py
@@ -182,7 +182,11 @@ class Cuts(GingaPlugin.LocalPlugin):
 
         self.slit_plot = plots.Plot(logger=self.logger,
                                     width=400, height=400)
-        self.slit_plot.add_axis(axisbg='black')
+        if plots.MPL_GE_2_0:
+            kwargs = {'facecolor': 'black'}
+        else:
+            kwargs = {'axisbg': 'black'}
+        self.slit_plot.add_axis(**kwargs)
         self.plot2 = Plot.PlotWidget(self.slit_plot)
         self.plot2.resize(400, 400)
 

--- a/ginga/rv/plugins/Histogram.py
+++ b/ginga/rv/plugins/Histogram.py
@@ -6,10 +6,16 @@
 #
 import numpy
 
-from ginga.gw import Widgets, Plot
+from ginga.gw import Widgets
 from ginga import GingaPlugin
 from ginga import AutoCuts
-from ginga.util import plots
+
+try:
+    from ginga.gw import Plot
+    from ginga.util import plots
+    have_mpl = True
+except ImportError:
+    have_mpl = False
 
 
 class Histogram(GingaPlugin.LocalPlugin):
@@ -102,6 +108,9 @@ class Histogram(GingaPlugin.LocalPlugin):
         self.gui_up = False
 
     def build_gui(self, container):
+        if not have_mpl:
+            raise ImportError('Install matplotlib to use this plugin')
+
         top = Widgets.VBox()
         top.set_border_width(4)
 

--- a/ginga/rv/plugins/LineProfile.py
+++ b/ginga/rv/plugins/LineProfile.py
@@ -4,11 +4,17 @@
 # This is open-source software licensed under a BSD license.
 # Please see the file LICENSE.txt for details.
 #
-from ginga import GingaPlugin
-from ginga.gw import Widgets, Plot
-from ginga.util import plots
-
 import numpy as np
+
+from ginga import GingaPlugin
+from ginga.gw import Widgets
+
+try:
+    from ginga.gw import Plot
+    from ginga.util import plots
+    have_mpl = True
+except ImportError:
+    have_mpl = False
 
 
 class LineProfile(GingaPlugin.LocalPlugin):
@@ -74,6 +80,9 @@ class LineProfile(GingaPlugin.LocalPlugin):
         self.gui_up = False
 
     def build_gui(self, container):
+        if not have_mpl:
+            raise ImportError('Install matplotlib to use this plugin')
+
         top = Widgets.VBox()
         top.set_border_width(4)
 

--- a/ginga/rv/plugins/MultiDim.py
+++ b/ginga/rv/plugins/MultiDim.py
@@ -18,7 +18,6 @@ from ginga.util.videosink import VideoSink
 from ginga.table.AstroTable import AstroTable
 
 import numpy as np
-import matplotlib.pyplot as plt
 
 have_mencoder = False
 if spawn.find_executable("mencoder"):
@@ -615,6 +614,8 @@ class MultiDim(GingaPlugin.LocalPlugin):
         self.w.hdu.set_enabled(len(self.file_obj) > 0)
 
     def save_slice_cb(self):
+        import matplotlib.pyplot as plt
+
         target = Widgets.SaveDialog(title='Save slice',
                                     selectedfilter='*.png').get_path()
         with open(target, 'w') as target_file:

--- a/ginga/rv/plugins/Pick.py
+++ b/ginga/rv/plugins/Pick.py
@@ -382,7 +382,11 @@ class Pick(GingaPlugin.LocalPlugin):
             hbox = Widgets.HBox()
             self.contour_plot = plots.ContourPlot(logger=self.logger,
                                                   width=400, height=300)
-            self.contour_plot.add_axis(axisbg='black')
+            if plots.MPL_GE_2_0:
+                kwargs = {'facecolor': 'black'}
+            else:
+                kwargs = {'axisbg': 'black'}
+            self.contour_plot.add_axis(**kwargs)
             pw = Plot.PlotWidget(self.contour_plot)
             pw.resize(400, 300)
             hbox.add_widget(pw, stretch=1)
@@ -407,7 +411,11 @@ class Pick(GingaPlugin.LocalPlugin):
             # FWHM gaussians plot
             self.fwhm_plot = plots.FWHMPlot(logger=self.logger,
                                             width=400, height=300)
-            self.fwhm_plot.add_axis(axisbg='white')
+            if plots.MPL_GE_2_0:
+                kwargs = {'facecolor': 'white'}
+            else:
+                kwargs = {'axisbg': 'white'}
+            self.fwhm_plot.add_axis(**kwargs)
             pw = Plot.PlotWidget(self.fwhm_plot)
             pw.resize(400, 300)
             nb.add_widget(pw, title="FWHM")
@@ -415,7 +423,7 @@ class Pick(GingaPlugin.LocalPlugin):
             # Radial profile plot
             self.radial_plot = plots.RadialPlot(logger=self.logger,
                                                 width=400, height=300)
-            self.radial_plot.add_axis(axisbg='white')
+            self.radial_plot.add_axis(**kwargs)
             pw = Plot.PlotWidget(self.radial_plot)
             pw.resize(400, 300)
             nb.add_widget(pw, title="Radial")

--- a/ginga/rv/plugins/Pick.py
+++ b/ginga/rv/plugins/Pick.py
@@ -12,12 +12,13 @@ import os.path
 
 from ginga.gw import Widgets, Viewers
 from ginga.misc import Bunch
-from ginga.util import iqcalc, plots, wcs
+from ginga.util import iqcalc, wcs
 from ginga import GingaPlugin
 from ginga.util.six.moves import map, zip, filter
 
 try:
     from ginga.gw import Plot
+    from ginga.util import plots
     have_mpl = True
 except ImportError:
     have_mpl = False

--- a/ginga/rv/plugins/PlotTable.py
+++ b/ginga/rv/plugins/PlotTable.py
@@ -7,9 +7,15 @@
 import numpy as np
 
 from ginga.GingaPlugin import LocalPlugin
-from ginga.gw import Widgets, Plot
+from ginga.gw import Widgets
 from ginga.table.AstroTable import AstroTable
-from ginga.util import plots
+
+try:
+    from ginga.gw import Plot
+    from ginga.util import plots
+    have_mpl = True
+except ImportError:
+    have_mpl = False
 
 
 class PlotTable(LocalPlugin):
@@ -50,6 +56,9 @@ class PlotTable(LocalPlugin):
         self.gui_up = False
 
     def build_gui(self, container):
+        if not have_mpl:
+            raise ImportError('Install matplotlib to use this plugin')
+
         top = Widgets.VBox()
         top.set_border_width(4)
 

--- a/ginga/util/plots.py
+++ b/ginga/util/plots.py
@@ -5,6 +5,8 @@
 # Please see the file LICENSE.txt for details.
 #
 import numpy
+from astropy.utils.introspection import minversion
+
 import matplotlib as mpl
 from matplotlib.figure import Figure
 # fix issue of negative numbers rendering incorrectly with default font
@@ -12,6 +14,9 @@ mpl.rcParams['axes.unicode_minus'] = False
 
 from ginga.util import iqcalc
 from ginga.misc import Callback
+
+MPL_GE_2_0 = minversion(mpl, '2.0')
+
 
 class Plot(Callback.Callbacks):
 
@@ -208,7 +213,10 @@ class ContourPlot(Plot):
         ##     self.cbar.remove()
 
         self.ax.cla()
-        self.ax.set_axis_bgcolor('#303030')
+        if MPL_GE_2_0:
+            self.ax.set_facecolor('#303030')
+        else:
+            self.ax.set_axis_bgcolor('#303030')
 
         try:
             im = self.ax.imshow(data, interpolation=self.interpolation,
@@ -500,7 +508,12 @@ class SurfacePlot(Plot):
             from mpl_toolkits.mplot3d import Axes3D
             from matplotlib.ticker import LinearLocator, FormatStrFormatter
 
-            self.ax = self.fig.gca(projection='3d', axisbg='#808080')
+            if MPL_GE_2_0:
+                kwargs = {'facecolor': '#808080'}
+            else:
+                kwargs = {'axisbg': '#808080'}
+
+            self.ax = self.fig.gca(projection='3d', **kwargs)
             self.ax.set_aspect('equal', adjustable='box')
             #self.ax.cla()
 


### PR DESCRIPTION
Fix #486 -- Make `matplotlib` optional and make its import error more obvious. Tested this with and without `matplotlib`.

Fix #477 -- Handle `matplotlib` v2 deprecation warnings. Tested this with `matplotlib` 1.5.1 and 2.x.