### PR TITLE
Enhancement to Contents plugin to manage images in channels

### DIFF
--- a/ginga/GingaPlugin.py
+++ b/ginga/GingaPlugin.py
@@ -71,6 +71,10 @@ class GlobalPlugin(BasePlugin):
         """This method is called when an image is set in a channel."""
         pass
 
+    def blank(self, channel):
+        """This method is called when a channel is no longer displaying any object."""
+        pass
+
 
 class LocalPlugin(BasePlugin):
     """Class to handle a local plugin."""
@@ -84,6 +88,8 @@ class LocalPlugin(BasePlugin):
             self.channel = self.fv.get_channel(self.chname)
             # TO BE DEPRECATED
             self.chinfo = self.channel
+
+            self.fv.add_callback('delete-channel', self._delete_channel_cb)
 
     def modes_off(self):
         """Turn off any mode user may be in."""
@@ -120,5 +126,18 @@ class LocalPlugin(BasePlugin):
         it is doing.
         """
         pass
+
+    def blank(self):
+        """
+        This method is called when no object is displayed in the channel
+        associated with the plugin.  It can optionally clear whatever operation
+        it is doing.
+        """
+        pass
+
+    def _delete_channel_cb(self, fv, channel):
+        # stop ourself if our channel is deleted
+        if channel is self.channel:
+            self.stop()
 
 # END

--- a/ginga/canvas/types/astro.py
+++ b/ginga/canvas/types/astro.py
@@ -161,6 +161,10 @@ class Ruler(TwoPointMixin, CanvasObjectBase):
         return (text_x, text_y, text_h)
 
     def draw(self, viewer):
+        image = viewer.get_image()
+        if image is None:
+            return
+
         points = self.get_points()
         x1, y1 = points[0]
         x2, y2 = points[1]
@@ -329,6 +333,10 @@ class Compass(OnePointOneRadiusMixin, CanvasObjectBase):
         return self.within_radius(viewer, pt, p0, self.cap_radius)
 
     def draw(self, viewer):
+        image = viewer.get_image()
+        if image is None:
+            return
+
         cr = viewer.renderer.setup_cr(self)
         cr.set_font_from_shape(self)
 
@@ -475,6 +483,8 @@ class Crosshair(OnePointMixin, CanvasObjectBase):
 
             else:
                 image = viewer.get_image()
+                if image is None:
+                    return
                 # NOTE: x, y are assumed to be in data coordinates
                 info = image.info_xy(self.x, self.y, viewer.get_settings())
                 if self.format == 'coords':

--- a/ginga/examples/configs/plugin_Thumbs.cfg
+++ b/ginga/examples/configs/plugin_Thumbs.cfg
@@ -28,6 +28,9 @@ rebuild_wait = 4.0
 # Max length of thumb on the long side
 thumb_length = 150
 
+# Separation between thumbs in pixels
+thumb_sep = 15
+
 # Sort the thumbs alphabetically
 #sort_order = 'alpha'
 sort_order = None
@@ -35,7 +38,7 @@ sort_order = None
 # Thumbnail label length in num of characters (None = no limit)
 label_length = 25
 
-# Cut off long label ('left' or 'right')
+# Cut off long label ('left', 'right' or None)
 label_cutoff = 'right'
 
 # Option to highlight images that are displayed in channels.

--- a/ginga/rv/Channel.py
+++ b/ginga/rv/Channel.py
@@ -82,25 +82,28 @@ class Channel(Callback.Callbacks):
         if self == channel:
             return
 
+        # transfer image info
+        info = self.image_index[imname]
+        channel._add_info(info)
+
         try:
             # copy image to other channel's datasrc if still
             # in memory
             image = self.datasrc[imname]
 
         except KeyError:
-            # transfer image info
-            info = self.image_index[imname]
-            channel._add_info(info)
             return
 
-        #channel.datasrc[imname] = image
         channel.add_image(image, silent=silent)
 
     def remove_image(self, imname):
+        info = self.remove_history(imname)
+
         if imname in self.datasrc:
             self.datasrc.remove(imname)
+            self.fv.make_async_gui_callback('remove-image', self.name,
+                                            info.name, info.path)
 
-        info = self.remove_history(imname)
         return info
 
     def get_image_names(self):

--- a/ginga/rv/Channel.py
+++ b/ginga/rv/Channel.py
@@ -97,7 +97,7 @@ class Channel(Callback.Callbacks):
         channel.add_image(image, silent=silent)
 
     def remove_image(self, imname):
-        if self.datasrc.has_key(imname):
+        if imname in self.datasrc:
             self.datasrc.remove(imname)
 
         info = self.remove_history(imname)
@@ -176,7 +176,6 @@ class Channel(Callback.Callbacks):
         info = self.add_history(info.name, info.path,
                                 image_loader=image_loader,
                                 image_future=image_future)
-        self.fv.make_async_gui_callback('add-image-info', self, info)
 
     def get_image_info(self, imname):
         return self.image_index[imname]
@@ -258,6 +257,8 @@ class Channel(Callback.Callbacks):
             if self.hist_sort is not None:
                 self.history.sort(key=self.hist_sort)
 
+            self.fv.make_async_gui_callback('add-image-info', self, info)
+
     def add_history(self, imname, path, idx=None,
                     image_loader=None, image_future=None):
 
@@ -287,6 +288,8 @@ class Channel(Callback.Callbacks):
             info = self.image_index[imname]
             del self.image_index[imname]
             self.history.remove(info)
+
+            self.fv.make_async_gui_callback('remove-image-info', self, info)
             return info
         return None
 

--- a/ginga/rv/Channel.py
+++ b/ginga/rv/Channel.py
@@ -107,9 +107,9 @@ class Channel(Callback.Callbacks):
             self.datasrc.remove(imname)
 
             # clear viewer if we are removing the currently displayed image
-            cur_image = self.fitsimage.get_image()
+            cur_image = self.viewer.get_image()
             if cur_image == image:
-                self.fitsimage.clear()
+                self.viewer.clear()
 
         self.fv.make_async_gui_callback('remove-image', self.name,
                                         info.name, info.path)

--- a/ginga/rv/Channel.py
+++ b/ginga/rv/Channel.py
@@ -222,7 +222,8 @@ class Channel(Callback.Callbacks):
 
     def _image_modified_cb(self, image):
         imname = image.get('name', None)
-        if (imname is None) or (not imname in self.image_index):
+        if (imname is None) or (imname not in self.image_index):
+            # not one of ours apparently (maybe used to be, but got removed)
             return
 
         info = self.image_index[imname]

--- a/ginga/rv/Control.py
+++ b/ginga/rv/Control.py
@@ -892,6 +892,13 @@ class GingaShell(GwMain.GwMain, Widgets.Application):
                 str(imname), str(e)))
 
     def redo_plugins(self, image, channel):
+        if image is not None:
+            imname = image.get('name', None)
+            if (imname is not None) and (imname not in channel):
+                # image may have been removed--
+                # skip updates to this channel's plugins
+                return
+
         # New data in channel
         # update active global plugins
         opmon = self.gpmon

--- a/ginga/rv/Control.py
+++ b/ginga/rv/Control.py
@@ -1233,8 +1233,6 @@ class GingaShell(GwMain.GwMain, Widgets.Application):
                 viewer.clear()
 
         channel.remove_image(imname)
-        self.make_async_gui_callback('remove-image',
-                                     channel.name, imname, impath)
 
     def move_image_by_name(self, from_chname, imname, to_chname, impath=None):
 

--- a/ginga/rv/Control.py
+++ b/ginga/rv/Control.py
@@ -898,7 +898,10 @@ class GingaShell(GwMain.GwMain, Widgets.Application):
         for key in opmon.get_active():
             obj = opmon.get_plugin(key)
             try:
-                self.gui_do(obj.redo, channel, image)
+                if image is None:
+                    self.gui_do(obj.blank, channel)
+                else:
+                    self.gui_do(obj.redo, channel, image)
 
             except Exception as e:
                 self.logger.error(
@@ -910,7 +913,10 @@ class GingaShell(GwMain.GwMain, Widgets.Application):
         for key in opmon.get_active():
             obj = opmon.get_plugin(key)
             try:
-                self.gui_do(obj.redo)
+                if image is None:
+                    self.gui_do(obj.blank)
+                else:
+                    self.gui_do(obj.redo)
 
             except Exception as e:
                 self.logger.error(
@@ -938,7 +944,8 @@ class GingaShell(GwMain.GwMain, Widgets.Application):
 
             # add cb so that if image is modified internally
             #  our plugins get updated
-            image.add_callback('modified', self.redo_plugins, channel)
+            if image is not None:
+                image.add_callback('modified', self.redo_plugins, channel)
 
             self.logger.debug("executing redo() in plugins...")
             self.redo_plugins(image, channel)

--- a/ginga/rv/Control.py
+++ b/ginga/rv/Control.py
@@ -944,7 +944,7 @@ class GingaShell(GwMain.GwMain, Widgets.Application):
             self.redo_plugins(image, channel)
 
             split_time1 = time.time()
-            self.logger.info("Large image update: %.4f sec" % (
+            self.logger.info("Channel image update: %.4f sec" % (
                 split_time1 - start_time))
 
     def change_channel(self, chname, image=None, raisew=True):

--- a/ginga/rv/Control.py
+++ b/ginga/rv/Control.py
@@ -111,7 +111,7 @@ class GingaShell(GwMain.GwMain, Widgets.Application):
         # For callbacks
         for name in ('add-image', 'channel-change', 'remove-image',
                      'add-channel', 'delete-channel', 'field-info',
-                     'add-image-info', 'add-operation'):
+                     'add-image-info', 'remove-image-info', 'add-operation'):
             self.enable_callback(name)
 
         # Initialize the timer factory

--- a/ginga/rv/plugins/Catalogs.py
+++ b/ginga/rv/plugins/Catalogs.py
@@ -317,7 +317,10 @@ class Catalogs(GingaPlugin.LocalPlugin):
 
     def stop(self):
         # stop catalog operation
-        self.clear_all()
+        try:
+            self.clear_all()
+        except:
+            pass
         # remove the canvas from the image
         self.canvas.ui_set_active(False)
         p_canvas = self.fitsimage.get_canvas()

--- a/ginga/rv/plugins/Contents.py
+++ b/ginga/rv/plugins/Contents.py
@@ -472,7 +472,7 @@ class Contents(GingaPlugin.GlobalPlugin):
         dialog = Widgets.Dialog(title="%s Images" % (verb),
                                 flags=0,
                                 buttons=[['Cancel', 0], ['Ok', 1]],
-                                parent=self.fv.w.root)
+                                parent=self.treeview)
         box = dialog.get_content_area()
         box.set_border_width(6)
         if len(l_img) < 12:

--- a/ginga/rv/plugins/Contents.py
+++ b/ginga/rv/plugins/Contents.py
@@ -5,7 +5,7 @@
 # Please see the file LICENSE.txt for details.
 #
 from ginga.util.six import itervalues
-from ginga.util.six.moves import map
+from ginga.util.six.moves import map, filter
 
 from ginga import GingaPlugin
 from ginga.misc import Bunch
@@ -62,10 +62,12 @@ class Contents(GingaPlugin.GlobalPlugin):
         self.highlight_tracks_keyboard_focus = self.settings.get(
             'highlight_tracks_keyboard_focus', True)
         self._hl_path = set([])
+        self.chnames = []
 
         fv.add_callback('add-image', self.add_image_cb)
-        fv.add_callback('add-image-info', self.add_image_info_cb)
         fv.add_callback('remove-image', self.remove_image_cb)
+        fv.add_callback('add-image-info', self.add_image_info_cb)
+        fv.add_callback('remove-image-info', self.remove_image_info_cb)
         fv.add_callback('add-channel', self.add_channel_cb)
         fv.add_callback('delete-channel', self.delete_channel_cb)
         fv.add_callback('channel-change', self.focus_cb)
@@ -73,37 +75,76 @@ class Contents(GingaPlugin.GlobalPlugin):
         self.gui_up = False
 
     def build_gui(self, container):
+        vbox = Widgets.VBox()
+        vbox.set_border_width(2)
+        vbox.set_spacing(4)
+
         # create the Treeview
         always_expand = self.settings.get('always_expand', False)
         color_alternate = self.settings.get('color_alternate_rows', True)
         treeview = Widgets.TreeView(auto_expand=always_expand,
                                     sortable=True,
+                                    selection='multiple',
                                     use_alt_row_color=color_alternate)
         self.treeview = treeview
         treeview.setup_table(self.columns, 2, 'NAME')
 
-        treeview.add_callback('selected', self.switch_image)
-        container.add_widget(treeview, stretch=1)
+        #treeview.add_callback('selected', self.switch_image)
+        vbox.add_widget(treeview, stretch=1)
 
+        btns = Widgets.HBox()
+        btns.set_spacing(4)
+        b1 = Widgets.Button('Display')
+        b1.add_callback('activated', self.switch_image_cb)
+        btns.add_widget(b1)
+        b2 = Widgets.Button('Move')
+        b2.add_callback('activated', lambda w: self.ask_action_images('move'))
+        btns.add_widget(b2)
+        b3 = Widgets.Button('Copy')
+        b3.add_callback('activated', lambda w: self.ask_action_images('copy'))
+        btns.add_widget(b3)
+        b4 = Widgets.Button('Delete')
+        b4.add_callback('activated', lambda w: self.ask_action_images('remove'))
+        btns.add_widget(b4)
+        btns.add_widget(Widgets.Label(''), stretch=1)
+
+        self._rebuild_channels()
+
+        vbox.add_widget(btns, stretch=0)
+
+        container.add_widget(vbox, stretch=1)
         self.gui_up = True
 
     def stop(self):
         self.gui_up = False
 
-    def switch_image(self, widget, res_dict):
+    def get_selected(self):
+        res = []
+        res_dict = self.treeview.get_selected()
         if len(res_dict) == 0:
+            return res
+        for chname in res_dict.keys():
+            img_dict = res_dict[chname]
+            if len(img_dict) == 0:
+                continue
+            for imname in img_dict.keys():
+                bnch = img_dict[imname]
+                res.append((chname, bnch))
+        return res
+
+    def switch_image_cb(self, widget):
+        res = self.get_selected()
+        if len(res) != 1:
+            self.fv.show_error("select just one file to load!")
             return
-        chname = list(res_dict.keys())[0]
-        img_dict = res_dict[chname]
-        if len(img_dict) == 0:
-            return
-        imname = list(img_dict.keys())[0]
-        bnch = img_dict[imname]
+
+        chname, bnch = res[0]
+
         if not 'path' in bnch:
             # may be a top-level channel node, e.g. in gtk
             return
-
         path = bnch.path
+        imname = bnch.imname
         self.logger.debug("chname=%s name=%s path=%s" % (
             chname, imname, path))
 
@@ -208,7 +249,7 @@ class Contents(GingaPlugin.GlobalPlugin):
         self.logger.debug("%s added to Contents" % (name))
 
     def add_image_info_cb(self, viewer, channel, image_info):
-        """Almost the same as add_image_info(), except that the image
+        """Almost the same as add_image_cb(), except that the image
         may not be loaded in memory.
         """
         chname = channel.name
@@ -247,6 +288,12 @@ class Contents(GingaPlugin.GlobalPlugin):
         self.recreate_toc()
         self.logger.debug("%s removed from Contents" % (name))
 
+    def remove_image_info_cb(self, viewer, channel, image_info):
+        """Almost the same as remove_image_cb().
+        """
+        return self.remove_image_cb(viewer, channel.name,
+                                    image_info.name, image_info.path)
+
     def clear(self):
         self.name_dict = Bunch.caselessDict()
         self._hl_path = set([])
@@ -270,6 +317,8 @@ class Contents(GingaPlugin.GlobalPlugin):
         tree_dict = { chname: { } }
         self.treeview.add_tree(tree_dict)
 
+        self._rebuild_channels()
+
     def delete_channel_cb(self, viewer, channel):
         """Called when a channel is deleted from the main interface.
         Parameter is a channel (a Channel object)."""
@@ -286,6 +335,11 @@ class Contents(GingaPlugin.GlobalPlugin):
         if not self.gui_up:
             return False
         self.recreate_toc()
+
+        self._rebuild_channels()
+
+    def _rebuild_channels(self):
+        self.chnames = self.fv.get_channel_names()
 
     def _get_hl_key(self, chname, image):
         return (chname, image.get('name', 'none'))
@@ -373,6 +427,71 @@ class Contents(GingaPlugin.GlobalPlugin):
         if self.highlight_tracks_keyboard_focus:
             self.update_highlights(self._hl_path, new_highlight)
             self._hl_path = new_highlight
+
+    def ask_action_images(self, action):
+
+        images = self.get_selected()
+
+        l_img = list(map(lambda tup: "%s/%s" % (tup[0], tup[1].imname),
+                         images))
+
+        verb = action.capitalize()
+        l_img.insert(0, "%s images\n" % (verb))
+
+        # build dialog
+        dialog = Widgets.Dialog(title="%s Images" % (verb),
+                                flags=0,
+                                buttons=[['Cancel', 0], ['Ok', 1]],
+                                parent=self.fv.w.root)
+        box = dialog.get_content_area()
+        box.set_border_width(6)
+        if len(l_img) < 12:
+            text = Widgets.Label("\n".join(l_img))
+        else:
+            text = Widgets.TextArea(wrap=None)
+            text.set_text("\n".join(l_img))
+        box.add_widget(text, stretch=1)
+
+        if action != 'remove':
+            hbox = Widgets.HBox()
+            hbox.add_widget(Widgets.Label("To channel: "))
+            chnl = Widgets.ComboBox()
+            for chname in self.chnames:
+                chnl.append_text(chname)
+            hbox.add_widget(chnl)
+            hbox.add_widget(Widgets.Label(''), stretch=1)
+            box.add_widget(hbox)
+        else:
+            chnl = None
+
+        dialog.add_callback('activated',
+                            lambda w, rsp: self.action_images_cb(w, rsp,
+                                                                 chnl,
+                                                                 images,
+                                                                 action))
+
+        self.fv.ds.show_dialog(dialog)
+
+    def action_images_cb(self, w, rsp, chnl_w, images, action):
+        # dst channel
+        if chnl_w is not None:
+            idx = chnl_w.get_index()
+            chname = self.chnames[idx]
+            dst_channel = self.fv.get_channel(chname)
+
+        self.fv.ds.remove_dialog(w)
+        if rsp == 0:
+            # user canceled
+            return
+
+        for chname, info in images:
+            src_channel = self.fv.get_channel(chname)
+            if action == 'copy':
+                src_channel.copy_image_to(info.imname, dst_channel)
+            elif action == 'move':
+                src_channel.move_image_to(info.imname, dst_channel)
+            elif action == 'remove':
+                src_channel.remove_image(info.imname)
 
     def __str__(self):
         return 'contents'

--- a/ginga/rv/plugins/Contents.py
+++ b/ginga/rv/plugins/Contents.py
@@ -90,6 +90,7 @@ class Contents(GingaPlugin.GlobalPlugin):
         treeview.setup_table(self.columns, 2, 'NAME')
 
         treeview.add_callback('activated', self.dblclick_cb)
+        treeview.add_callback('selected', self.select_cb)
         vbox.add_widget(treeview, stretch=1)
 
         btns = Widgets.HBox()
@@ -97,20 +98,25 @@ class Contents(GingaPlugin.GlobalPlugin):
         b1 = Widgets.Button('Display')
         b1.add_callback('activated', self.display_cb)
         b1.set_tooltip("Display the selected object in its channel viewer")
+        b1.set_enabled(False)
         btns.add_widget(b1)
         b2 = Widgets.Button('Move')
         b2.add_callback('activated', lambda w: self.ask_action_images('move'))
         b2.set_tooltip("Move the selected objects to a channel")
+        b2.set_enabled(False)
         btns.add_widget(b2)
         b3 = Widgets.Button('Copy')
         b3.add_callback('activated', lambda w: self.ask_action_images('copy'))
         b3.set_tooltip("Copy the selected objects to a channel")
+        b3.set_enabled(False)
         btns.add_widget(b3)
         b4 = Widgets.Button('Remove')
         b4.add_callback('activated', lambda w: self.ask_action_images('remove'))
         b4.set_tooltip("Remove the selected objects from a channel")
+        b4.set_enabled(False)
         btns.add_widget(b4)
         btns.add_widget(Widgets.Label(''), stretch=1)
+        self.btn_list = [b1, b2, b3, b4]
 
         self._rebuild_channels()
 
@@ -146,6 +152,12 @@ class Contents(GingaPlugin.GlobalPlugin):
 
         self.fv.switch_name(chname, imname, path=path,
                             image_future=bnch.image_future)
+
+    def select_cb(self, widget, d):
+        res = self.get_selected()
+        tf = (len(res) > 0)
+        for btn in self.btn_list:
+            btn.set_enabled(tf)
 
     def display_cb(self, widget):
         res = self.get_selected()

--- a/ginga/rv/plugins/Contents.py
+++ b/ginga/rv/plugins/Contents.py
@@ -96,15 +96,19 @@ class Contents(GingaPlugin.GlobalPlugin):
         btns.set_spacing(4)
         b1 = Widgets.Button('Display')
         b1.add_callback('activated', self.display_cb)
+        b1.set_tooltip("Display the selected object in its channel viewer")
         btns.add_widget(b1)
         b2 = Widgets.Button('Move')
         b2.add_callback('activated', lambda w: self.ask_action_images('move'))
+        b2.set_tooltip("Move the selected objects to a channel")
         btns.add_widget(b2)
         b3 = Widgets.Button('Copy')
         b3.add_callback('activated', lambda w: self.ask_action_images('copy'))
+        b3.set_tooltip("Copy the selected objects to a channel")
         btns.add_widget(b3)
-        b4 = Widgets.Button('Delete')
+        b4 = Widgets.Button('Remove')
         b4.add_callback('activated', lambda w: self.ask_action_images('remove'))
+        b4.set_tooltip("Remove the selected objects from a channel")
         btns.add_widget(b4)
         btns.add_widget(Widgets.Label(''), stretch=1)
 
@@ -146,7 +150,7 @@ class Contents(GingaPlugin.GlobalPlugin):
     def display_cb(self, widget):
         res = self.get_selected()
         if len(res) != 1:
-            self.fv.show_error("select just one file to load!")
+            self.fv.show_error("Please select just one file to display!")
             return
 
         chname, bnch = res[0]
@@ -369,7 +373,7 @@ class Contents(GingaPlugin.GlobalPlugin):
         try:
             self.treeview.highlight_path(hl_path, tf, font_color=fc)
         except Exception as e:
-            self.logger.error('Error changing highlight on treeview path '
+            self.logger.info('Error changing highlight on treeview path '
                               '({0}): {1}'.format(hl_path, str(e)))
 
     def update_highlights(self, old_highlight_set, new_highlight_set):
@@ -442,6 +446,9 @@ class Contents(GingaPlugin.GlobalPlugin):
     def ask_action_images(self, action):
 
         images = self.get_selected()
+        if len(images) == 0:
+            self.fv.show_error("Please select some images first")
+            return
 
         l_img = list(map(lambda tup: "%s/%s" % (tup[0], tup[1].imname),
                          images))

--- a/ginga/rv/plugins/Contents.py
+++ b/ginga/rv/plugins/Contents.py
@@ -89,13 +89,13 @@ class Contents(GingaPlugin.GlobalPlugin):
         self.treeview = treeview
         treeview.setup_table(self.columns, 2, 'NAME')
 
-        #treeview.add_callback('selected', self.switch_image)
+        treeview.add_callback('activated', self.dblclick_cb)
         vbox.add_widget(treeview, stretch=1)
 
         btns = Widgets.HBox()
         btns.set_spacing(4)
         b1 = Widgets.Button('Display')
-        b1.add_callback('activated', self.switch_image_cb)
+        b1.add_callback('activated', self.display_cb)
         btns.add_widget(b1)
         b2 = Widgets.Button('Move')
         b2.add_callback('activated', lambda w: self.ask_action_images('move'))
@@ -132,7 +132,18 @@ class Contents(GingaPlugin.GlobalPlugin):
                 res.append((chname, bnch))
         return res
 
-    def switch_image_cb(self, widget):
+    def dblclick_cb(self, widget, d):
+        chname = list(d.keys())[0]
+        imname = list(d[chname].keys())[0]
+        bnch = d[chname][imname]
+        path = bnch.path
+        self.logger.debug("chname=%s name=%s path=%s" % (
+            chname, imname, path))
+
+        self.fv.switch_name(chname, imname, path=path,
+                            image_future=bnch.image_future)
+
+    def display_cb(self, widget):
         res = self.get_selected()
         if len(res) != 1:
             self.fv.show_error("select just one file to load!")

--- a/ginga/rv/plugins/Header.py
+++ b/ginga/rv/plugins/Header.py
@@ -154,12 +154,17 @@ class Header(GingaPlugin.GlobalPlugin):
             self.add_channel(self.fv, channel)
 
     def redo(self, channel, image):
-        """This is called when buffer is modified."""
+        """This is called when image changes."""
         self._image = None  # Skip cache checking in set_header()
-        chname = channel.name
         info = channel.extdata._header_info
 
         self.set_header(info, image)
+
+    def blank(self, channel):
+        """This is called when image is cleared."""
+        self._image = None
+        info = channel.extdata._header_info
+        info.table.clear()
 
     def set_sortable_cb(self, info):
         self._image = None

--- a/ginga/rv/plugins/Pan.py
+++ b/ginga/rv/plugins/Pan.py
@@ -181,14 +181,17 @@ class Pan(GingaPlugin.GlobalPlugin):
         paninfo = channel.extdata._pan_info
 
         if (image is None) or not isinstance(image, BaseImage):
-            # TODO: clear not yet working
-            #paninfo.panimage.clear()
+            paninfo.panimage.clear()
             return
 
         loval, hival = channel.fitsimage.get_cut_levels()
         paninfo.panimage.cut_levels(loval, hival)
 
         self.set_image(channel, paninfo, image)
+
+    def blank(self, channel):
+        paninfo = channel.extdata._pan_info
+        paninfo.panimage.clear()
 
     def focus_cb(self, viewer, channel):
         chname = channel.name
@@ -237,8 +240,7 @@ class Pan(GingaPlugin.GlobalPlugin):
 
     def set_image(self, channel, paninfo, image):
         if (image is None) or not isinstance(image, BaseImage):
-            # TODO: clear not yet working
-            #paninfo.panimage.clear()
+            paninfo.panimage.clear()
             return
 
         if not self.use_shared_canvas:
@@ -285,8 +287,7 @@ class Pan(GingaPlugin.GlobalPlugin):
     def panset(self, fitsimage, channel, paninfo):
         image = fitsimage.get_image()
         if (image is None) or not isinstance(image, BaseImage):
-            # TODO: clear not yet working
-            #paninfo.panimage.clear()
+            paninfo.panimage.clear()
             return
 
         x, y = fitsimage.get_pan()

--- a/ginga/rv/plugins/Thumbs.py
+++ b/ginga/rv/plugins/Thumbs.py
@@ -89,6 +89,7 @@ class Thumbs(GingaPlugin.GlobalPlugin):
         fv.set_callback('add-image', self.add_image_cb)
         fv.set_callback('add-image-info', self.add_image_info_cb)
         fv.set_callback('remove-image', self.remove_image_cb)
+        fv.set_callback('remove-image-info', self.remove_image_info_cb)
         fv.set_callback('add-channel', self.add_channel_cb)
         fv.set_callback('delete-channel', self.delete_channel_cb)
         fv.add_callback('channel-change', self.focus_cb)
@@ -237,6 +238,12 @@ class Thumbs(GingaPlugin.GlobalPlugin):
         except Exception as e:
             self.logger.error("Error removing thumb for %s: %s" % (
                 name, str(e)))
+
+    def remove_image_info_cb(self, viewer, channel, image_info):
+        """Almost the same as remove_image_cb().
+        """
+        return self.remove_image_cb(viewer, channel.name,
+                                    image_info.name, image_info.path)
 
     def remove_thumb(self, thumbkey):
         with self.thmblock:
@@ -764,7 +771,6 @@ class Thumbs(GingaPlugin.GlobalPlugin):
                        info.path, thumbkey, info.image_future,
                        save_thumb=save_thumb,
                        thumbpath=thumbpath)
-
 
     def __str__(self):
         return 'thumbs'

--- a/ginga/rv/plugins/Thumbs.py
+++ b/ginga/rv/plugins/Thumbs.py
@@ -750,14 +750,14 @@ class Thumbs(GingaPlugin.GlobalPlugin):
         # TODO: should really be text ht
         text_ht = self.thumb_sep
 
-        # calc in canvas coords
+        # calc in window coords
         twd_plus = self.thumb_width + text_ht + self.thumb_sep
         xt = self.thumb_sep + col * twd_plus
         yt = self._cmyoff + (row * twd_plus) + text_ht
 
         # convert to data coords
-        crdmap = self.c_view.get_coordmap('canvas')
-        xt, yt = crdmap.to_data(xt, yt)
+        crdmap = self.c_view.get_coordmap('window')
+        xt, yt = crdmap.to_data((xt, yt))
 
         xi = xt
         yi = yt

--- a/ginga/rv/plugins/Thumbs.py
+++ b/ginga/rv/plugins/Thumbs.py
@@ -13,6 +13,8 @@ from ginga.misc import Bunch
 from ginga.util import iohelper
 from ginga.gw import Widgets, Viewers
 from ginga.util.paths import icondir
+from ginga import cmap, RGBImage
+from ginga.pilw.ImageViewPil import CanvasView
 
 class Thumbs(GingaPlugin.GlobalPlugin):
     """
@@ -51,6 +53,10 @@ class Thumbs(GingaPlugin.GlobalPlugin):
         self.thumb_col_count = 0
         # distance in pixels between thumbs
         self.thumb_sep = 15
+        self._wd = 300
+        self._ht = 400
+        self._cmyoff = 10
+        self._max_y = 0
         tt_keywords = ['OBJECT', 'FRAMEID', 'UT', 'DATE-OBS']
 
         prefs = self.fv.get_preferences()
@@ -63,19 +69,33 @@ class Thumbs(GingaPlugin.GlobalPlugin):
                                    mouseover_name_key='NAME',
                                    thumb_length=192,
                                    sort_order=None,
-                                   label_length=25,
+                                   label_length=14,
                                    label_cutoff='right',
                                    highlight_tracks_keyboard_focus=True,
-                                   label_font_color='black',
+                                   label_font_color='white',
+                                   label_font_size=10,
                                    label_bg_color='lightgreen')
         self.settings.load(onError='silent')
         # max length of thumb on the long side
-        self.thumb_width = self.settings.get('thumb_length', 150)
+        self.thumb_width = self.settings.get('thumb_length', 192)
+
+        tg = CanvasView(logger=self.logger)
+        tg.configure_surface(self.thumb_width, self.thumb_width)
+        tg.enable_autozoom('on')
+        tg.set_autocut_params('zscale')
+        tg.enable_autocuts('override')
+        tg.enable_auto_orient(True)
+        tg.defer_redraw = False
+        tg.set_bg(0.7, 0.7, 0.7)
+        self.thumb_generator = tg
 
         self.thmbtask = fv.get_timer()
         self.thmbtask.set_callback('expired', self.redo_delay_timer)
         self.lagtime = self.settings.get('rebuild_wait', 4.0)
         self.thmblock = threading.RLock()
+
+        # this will hold the thumbnails pane viewer
+        self.c_view = None
 
         # TODO: these maybe should be configurable by channel
         # different instruments have different keywords of interest
@@ -97,34 +117,43 @@ class Thumbs(GingaPlugin.GlobalPlugin):
         self.gui_up = False
 
     def build_gui(self, container):
-        # width, height = 300, 300
-        # cm, im = self.fv.cm, self.fv.im
+        vbox = Widgets.VBox()
+        vbox.set_border_width(4)
+        vbox.set_spacing(2)
 
-        thumb_len = self.settings.get('thumb_length', 192)
+        # construct an interaactive viewer to view and scroll
+        # the RGB image, and to let the user pick the cmap
+        self.c_view = Viewers.CanvasView(logger=self.logger)
+        c_v = self.c_view
+        c_v.set_desired_size(self._wd, self._ht)
+        c_v.enable_autozoom('off')
+        c_v.enable_autocuts('off')
+        c_v.set_pan(0, 0)
+        c_v.zoom_to(1)
+        c_v.transform(False, True, False)
+        c_v.cut_levels(0, 255)
+        c_v.set_bg(0.4, 0.4, 0.4)
+        # for debugging
+        c_v.set_name('cmimage')
+        c_v.add_callback('configure', self.thumbpane_resized_cb)
+        c_v.add_callback('drag-drop', self.drag_drop_cb)
 
-        tg = Viewers.ImageViewCanvas(logger=self.logger)
-        tg.configure_window(thumb_len, thumb_len)
-        tg.enable_autozoom('on')
-        tg.set_autocut_params('zscale')
-        tg.enable_autocuts('override')
-        tg.enable_auto_orient(True)
-        tg.defer_redraw = False
-        tg.set_bg(0.7, 0.7, 0.7)
-        self.thumb_generator = tg
+        canvas = c_v.get_canvas()
+        canvas.register_for_cursor_drawing(c_v)
+        c_v.add_callback('scroll', self.scroll_cb)
+        canvas.set_draw_mode('pick')
+        canvas.ui_set_active(True)
 
-        sw = Widgets.ScrollArea()
-        sw.add_callback('configure', self.thumbpane_resized_cb)
+        bd = c_v.get_bindings()
+        bd.enable_pan(True)
+        # disable zooming so scrolling can be used to pan up/down
+        bd.enable_zoom(False)
+        bd.enable_cmap(False)
 
-        # Create thumbnails pane
-        vbox = Widgets.GridBox()
-        vbox.set_margins(4, 4, 4, 4)
-        vbox.set_column_spacing(14)
-        self.w.thumbs = vbox
+        iw = Viewers.GingaScrolledViewerWidget(c_v)
+        iw.resize(self._wd, self._ht)
 
-        sw.set_widget(vbox)
-        self.w.thumbs_scroll = sw
-
-        container.add_widget(sw, stretch=1)
+        vbox.add_widget(iw, stretch=1)
 
         captions = (('Auto scroll', 'checkbutton', 'Clear', 'button'),)
         w, b = Widgets.build_info(captions)
@@ -136,9 +165,36 @@ class Thumbs(GingaPlugin.GlobalPlugin):
         b.clear.add_callback('activated', lambda w: self.clear())
         auto_scroll = self.settings.get('auto_scroll', True)
         b.auto_scroll.set_state(auto_scroll)
-        container.add_widget(w, stretch=0)
+        vbox.add_widget(w, stretch=0)
+
+        container.add_widget(vbox, stretch=1)
 
         self.gui_up = True
+
+    def scroll_cb(self, viewer, direction, amt, data_x, data_y):
+        """Called when the user scrolls in the thumb pane.
+        Pan up or down to show additional thumbs.
+        """
+        bd = viewer.get_bindings()
+        direction = bd.get_direction(direction)
+        pan_x, pan_y = viewer.get_pan()[:2]
+        qty = self.thumb_sep * amt * self.settings.get('thumb_pan_accel', 1.0)
+        if direction == 'up':
+            pan_y -= qty
+        else:
+            pan_y += qty
+
+        limits = viewer.get_limits(coord='data')
+        pan_y = min(max(pan_y, limits[0][1]), limits[1][1])
+
+        viewer.set_pan(pan_x, pan_y)
+
+    def drag_drop_cb(self, viewer, urls):
+        """Punt drag-drops to the ginga shell.
+        """
+        channel = self.fv.get_current_channel()
+        self.fv.dragdrop(channel.viewer, urls)
+        return True
 
     def _get_thumb_key(self, chname, image):
         path = image.get('path', None)
@@ -200,18 +256,66 @@ class Thumbs(GingaPlugin.GlobalPlugin):
             self.copy_attrs(channel.fitsimage)
             thumb_np = image.get_thumbnail(self.thumb_width)
             self.thumb_generator.set_data(thumb_np)
-            imgwin = self.thumb_generator.get_plain_image_as_widget()
-
-        label_length = self.settings.get('label_length', None)
-        label_cutoff = self.settings.get('label_cutoff', 'right')
-
-        # Shorten thumbnail label, if requested
-        if label_length is not None:
-            thumbname = iohelper.shorten_name(thumbname, label_length,
-                                              side=label_cutoff)
+            rgb_img = self.thumb_generator.get_image_as_array()
+            imgwin = RGBImage.RGBImage(rgb_img)
 
         self.insert_thumbnail(imgwin, thumbkey, thumbname, chname, name, path,
                               thumbpath, metadata, future)
+
+    def add_image_info_cb(self, viewer, channel, info):
+
+        save_thumb = self.settings.get('cache_thumbs', False)
+
+        # Do we already have this thumb loaded?
+        chname = channel.name
+        thumbkey = self.get_thumb_key(chname, info.name, info.path)
+        thumbpath = self.get_thumbpath(info.path)
+
+        with self.thmblock:
+            try:
+                bnch = self.thumb_dict[thumbkey]
+                # if these are not equal then the mtime must have
+                # changed on the file, better reload and regenerate
+                if bnch.thumbpath == thumbpath:
+                    return
+            except KeyError:
+                pass
+
+        # Is there a cached thumbnail image on disk we can use?
+        thmb_image = RGBImage.RGBImage()
+        loaded = False
+        if (thumbpath is not None) and os.path.exists(thumbpath):
+            #save_thumb = False
+            try:
+                # try to load the thumbnail image
+                thmb_image.load_file(thumbpath)
+                # make sure name is consistent
+                thmb_image.set(name=info.name)
+                loaded = True
+
+            except Exception as e:
+                self.logger.warning("Error loading thumbnail: %s" % (str(e)))
+
+        if not loaded:
+            # no luck loading thumbnail, try to load a cached image
+            try:
+                thmb_image = channel.get_loaded_image(info.name)
+
+            except KeyError:
+                self.logger.info("image not in memory; using placeholder")
+
+                # load a plcaeholder image
+                tmp_path = os.path.join(icondir, 'fits.png')
+                thmb_image = RGBImage.RGBImage()
+                thmb_image.load_file(tmp_path)
+                # make sure name is consistent
+                thmb_image.set(name=info.name, path=None)
+
+        self.fv.gui_do(self._make_thumb, chname, thmb_image, info.name,
+                       info.path, thumbkey, info.image_future,
+                       save_thumb=save_thumb,
+                       thumbpath=thumbpath)
+
 
     def _add_image(self, viewer, chname, image):
         channel = self.fv.get_channel(chname)
@@ -228,8 +332,6 @@ class Thumbs(GingaPlugin.GlobalPlugin):
     def remove_image_cb(self, viewer, chname, name, path):
         if not self.gui_up:
             return
-
-        self.logger.info("removing thumb for %s" % (name))
 
         try:
             # Is this thumbnail already in the list?
@@ -261,10 +363,10 @@ class Thumbs(GingaPlugin.GlobalPlugin):
 
         self.reorder_thumbs()
 
-    def update_thumbs(self, nameList):
+    def update_thumbs(self, name_list):
 
         # Remove old thumbs that are not in the dataset
-        invalid = set(self.thumb_list) - set(nameList)
+        invalid = set(self.thumb_list) - set(name_list)
         if len(invalid) > 0:
             with self.thmblock:
                 for thumbkey in invalid:
@@ -274,7 +376,10 @@ class Thumbs(GingaPlugin.GlobalPlugin):
 
             self.reorder_thumbs()
 
-    def thumbpane_resized_cb(self, widget, width, height):
+    def thumbpane_resized_cb(self, thumbvw, width, height):
+        self.fv.gui_do_oneshot('thumbs-resized', self._resized, width, height)
+
+    def _resized(self, width, height):
         self.logger.info("reordering thumbs width=%d" % (width))
 
         with self.thmblock:
@@ -384,20 +489,22 @@ class Thumbs(GingaPlugin.GlobalPlugin):
             un_hilite_set = old_highlight_set - new_highlight_set
             re_hilite_set = new_highlight_set - old_highlight_set
 
-            # unhighlight thumb labels that should NOT be highlighted any more
-            for thumbkey in un_hilite_set:
-                if thumbkey in self.thumb_dict:
-                    namelbl = self.thumb_dict[thumbkey].get('namelbl')
-                    namelbl.set_color(bg=None, fg=None)
-
             # highlight new labels that should be
             bg = self.settings.get('label_bg_color', 'lightgreen')
             fg = self.settings.get('label_font_color', 'black')
 
+            # unhighlight thumb labels that should NOT be highlighted any more
+            for thumbkey in un_hilite_set:
+                if thumbkey in self.thumb_dict:
+                    namelbl = self.thumb_dict[thumbkey].get('namelbl')
+                    namelbl.color = fg
+
             for thumbkey in re_hilite_set:
                 if thumbkey in self.thumb_dict:
                     namelbl = self.thumb_dict[thumbkey].get('namelbl')
-                    namelbl.set_color(bg=bg, fg=fg)
+                    namelbl.color = bg
+
+        self.c_view.redraw(whence=0)
 
     def redo(self, channel, image):
         """This method is called when an image is set in a channel."""
@@ -507,10 +614,11 @@ class Thumbs(GingaPlugin.GlobalPlugin):
                 if thumbpath is not None:
                     if os.path.exists(thumbpath):
                         os.remove(thumbpath)
-                    self.thumb_generator.save_plain_image_as_file(thumbpath,
-                                                                  format='jpeg')
+                    ## self.thumb_generator.save_plain_image_as_file(thumbpath,
+                    ##                                               format='jpeg')
 
-            imgwin = self.thumb_generator.get_plain_image_as_widget()
+            rgb_img = self.thumb_generator.get_image_as_array()
+            imgwin = RGBImage.RGBImage(rgb_img)
 
         self.update_thumbnail(thumbkey, imgwin, name, metadata)
 
@@ -536,6 +644,51 @@ class Thumbs(GingaPlugin.GlobalPlugin):
 
         self.reorder_thumbs()
 
+    def make_tt(self, viewer, canvas, text, pt, fontsize=10):
+        Text = canvas.get_draw_class('text')
+        Rectangle = canvas.get_draw_class('rectangle')
+        Point = canvas.get_draw_class('point')
+
+        x, y = pt
+        # override x coord so that tooltip can be sure to be somewhat
+        # visible on the canvas
+        tup = viewer.get_pan_rect()
+        x = tup[0][0] + 10
+        mxwd = 0
+        lines = text.split('\n')
+
+        point = Point(x, y, radius=0, color='black', alpha=0.0)
+        rect = Rectangle(x, y, x, y, color='black', fill=True,
+                         fillcolor='lightyellow')
+        crdmap = viewer.get_coordmap('offset')
+        crdmap.refobj = point
+
+        l = [point, rect]
+        a, b = 2, 0
+        for line in lines:
+            text = Text(a, b, text=line, color='black', fontsize=fontsize)
+            text.crdmap = crdmap
+            l.append(text)
+            txt_wd, txt_ht = viewer.renderer.get_dimensions(text)
+            b += txt_ht + 2
+            text.y = b
+            mxwd = max(mxwd, txt_wd)
+        rect.x2 = rect.x1 + mxwd + 2
+        rect.y2 = rect.y1 + b + 4
+
+        Compound = canvas.get_draw_class('compoundobject')
+        obj = Compound(*l)
+        return obj
+
+    def show_tt(self, obj, canvas, event, pt,
+                thumbkey, chname, name, text, tf):
+        tag = '_$tooltip'
+        if tf:
+            tt = self.make_tt(self.c_view, canvas, text, pt)
+            canvas.add(tt, tag=tag)
+        else:
+            canvas.delete_object_by_tag(tag)
+
     def _make_thumb(self, chname, image, name, path, thumbkey,
                     image_future, save_thumb=False, thumbpath=None):
         # This is called by the make_thumbs() as a gui thread
@@ -545,10 +698,12 @@ class Thumbs(GingaPlugin.GlobalPlugin):
 
             # Save a thumbnail for future browsing
             if save_thumb and (thumbpath is not None):
-                self.thumb_generator.save_plain_image_as_file(thumbpath,
-                                                              format='jpeg')
+                ## self.thumb_generator.save_plain_image_as_file(thumbpath,
+                ##                                               format='jpeg')
+                pass
 
-            imgwin = self.thumb_generator.get_plain_image_as_widget()
+            rgb_img = self.thumb_generator.get_image_as_array()
+            imgwin = RGBImage.RGBImage(rgb_img)
 
         # Get metadata for mouse-over tooltip
         header = image.get_header()
@@ -560,7 +715,7 @@ class Thumbs(GingaPlugin.GlobalPlugin):
         self.insert_thumbnail(imgwin, thumbkey, thumbname,
                               chname, name, path, thumbpath, metadata,
                               image_future)
-        self.fv.update_pending(timeout=0.001)
+        #self.fv.update_pending(timeout=0.001)
 
     def get_thumbpath(self, path, makedir=True):
         if path is None:
@@ -590,6 +745,23 @@ class Thumbs(GingaPlugin.GlobalPlugin):
 
         return thumbpath
 
+    def _calc_thumb_pos(self, row, col):
+        # TODO: should really be text ht
+        text_ht = self.thumb_sep
+
+        # calc in canvas coords
+        twd_plus = self.thumb_width + text_ht + self.thumb_sep
+        xt = self.thumb_sep + col * twd_plus
+        yt = self._cmyoff + (row * twd_plus) + text_ht
+
+        # convert to data coords
+        crdmap = self.c_view.get_coordmap('canvas')
+        xt, yt = crdmap.to_data(xt, yt)
+
+        xi = xt
+        yi = yt
+        return (xt, yt, xi, yi)
+
     def insert_thumbnail(self, imgwin, thumbkey, thumbname, chname, name, path,
                          thumbpath, metadata, image_future):
 
@@ -597,36 +769,64 @@ class Thumbs(GingaPlugin.GlobalPlugin):
         # make a context menu
         menu = self._mk_context_menu(thumbkey, chname, name, path, image_future)
 
-        thumbw = Widgets.Image(native_image=imgwin, menu=menu,
-                               style='clickable')
-        thumbw.resize(self.thumb_width, self.thumb_width)
-
-        # set the load callback
-        thumbw.add_callback('activated',
-                            lambda w: self.load_file(thumbkey, chname, name,
-                                                     path, image_future))
-
         # make a tool tip
         text = self.query_thumb(thumbkey, name, metadata)
-        thumbw.set_tooltip(text)
 
-        vbox = Widgets.VBox()
-        vbox.set_margins(0, 0, 0, 0)
-        vbox.set_spacing(0)
-        namelbl = Widgets.Label(text=thumbname, halign='left')
-        vbox.add_widget(namelbl, stretch=0)
-        vbox.add_widget(thumbw, stretch=0)
-        # special hack for Qt widgets
-        vbox.cfg_expand(0, 0)
+        canvas = self.c_view.get_canvas()
+        Image = canvas.get_draw_class('image')
+        Text = canvas.get_draw_class('text')
+        Compound = canvas.get_draw_class('compoundobject')
+        fg = self.settings.get('label_font_color', 'black')
+        fontsize = self.settings.get('label_font_size', 10)
 
-        bnch = Bunch.Bunch(widget=vbox, image=thumbw,
-                           name=name, imname=name, namelbl=namelbl,
-                           chname=chname, path=path, thumbpath=thumbpath,
-                           image_future=image_future)
+        # Shorten thumbnail label, if requested
+        label_length = self.settings.get('label_length', None)
+        label_cutoff = self.settings.get('label_cutoff', 'right')
+
+        if label_length is not None:
+            thumbname = iohelper.shorten_name(thumbname, label_length,
+                                              side=label_cutoff)
+            # TEMP
+            #thumbname = thumbname[:label_length]
 
         with self.thmblock:
+            row, col = self.thumb_row_count, self.thumb_col_count
+            self.thumb_col_count = (self.thumb_col_count + 1) % self.thumb_num_cols
+            if self.thumb_col_count == 0:
+                self.thumb_row_count += 1
+
+            xt, yt, xi, yi = self._calc_thumb_pos(row, col)
+            l2 = []
+            namelbl = Text(xt, yt, thumbname, color=fg, fontsize=fontsize,
+                           coord='data')
+            l2.append(namelbl)
+
+            image = Image(xi, yi, imgwin, alpha=1.0,
+                          linewidth=1, color='black', coord='data')
+            l2.append(image)
+
+            obj = Compound(*l2, coord='data')
+            obj.pickable = True
+            obj.opaque = True
+
+            bnch = Bunch.Bunch(widget=obj, image=image,
+                               name=name, imname=name, namelbl=namelbl,
+                               chname=chname, path=path, thumbpath=thumbpath,
+                               image_future=image_future)
+
             self.thumb_dict[thumbkey] = bnch
             self.thumb_list.append(thumbkey)
+
+            # set the load callback
+            obj.add_callback('pick-down',
+                             lambda *args: self.load_file(thumbkey, chname,
+                                                          name,
+                                                          path, image_future))
+            # set callbacks for tool tips
+            obj.add_callback('pick-enter', self.show_tt,
+                             thumbkey, chname, name, text, True)
+            obj.add_callback('pick-leave', self.show_tt,
+                             thumbkey, chname, name, text, False)
 
             sort_order = self.settings.get('sort_order', None)
             if sort_order:
@@ -634,32 +834,40 @@ class Thumbs(GingaPlugin.GlobalPlugin):
                 self.reorder_thumbs()
                 return
 
-            self.w.thumbs.add_widget(vbox,
-                                     self.thumb_row_count, self.thumb_col_count)
-            self.thumb_col_count = (self.thumb_col_count + 1) % self.thumb_num_cols
-            if self.thumb_col_count == 0:
-                self.thumb_row_count += 1
+            # add thumb to canvas
+            canvas.add(obj)
 
-        self._auto_scroll()
+        self.c_view.redraw(whence=0)
+
+        # reset limits
+        xm, ym, x_, y_ = self._calc_thumb_pos(0, 0)
+        self.c_view.set_limits([(xm, ym), (xi, yi)], coord='data')
+
+        self._auto_scroll(xi, yi)
         self.logger.debug("added thumb for %s" % (name))
 
-    def _auto_scroll(self):
+    def _auto_scroll(self, xi, yi):
         # force scroll to bottom of thumbs, if checkbox is set
         scrollp = self.w.auto_scroll.get_state()
         if scrollp:
-            self.fv.update_pending()
-            self.w.thumbs_scroll.scroll_to_end()
+            # override X parameter because we only want to scroll vertically
+            pan_x, pan_y = self.c_view.get_pan()
+            self.c_view.panset_xy(pan_x, yi)
 
     def clear_widget(self):
         """
         Clears the thumbnail display widget of all thumbnails, but does
         not remove them from the thumb_dict or thumb_list.
         """
-        with self.thmblock:
-            self.w.thumbs.remove_all()
+        canvas = self.c_view.get_canvas()
+        canvas.delete_all_objects()
+        self.c_view.redraw(whence=0)
 
     def reorder_thumbs(self):
         self.logger.debug("Reordering thumb grid")
+        canvas = self.c_view.get_canvas()
+
+        xi, yi = None, None
         with self.thmblock:
             self.clear_widget()
 
@@ -668,14 +876,26 @@ class Thumbs(GingaPlugin.GlobalPlugin):
             self.thumb_row_count = 0
             for thumbkey in self.thumb_list:
                 bnch = self.thumb_dict[thumbkey]
-                self.w.thumbs.add_widget(bnch.widget,
-                                         self.thumb_row_count, self.thumb_col_count)
+
+                row, col = self.thumb_row_count, self.thumb_col_count
                 self.thumb_col_count = ((self.thumb_col_count + 1) %
-                                        self.thumb_num_cols)
+                                      self.thumb_num_cols)
                 if self.thumb_col_count == 0:
                     self.thumb_row_count += 1
 
-        self._auto_scroll()
+                xt, yt, xi, yi = self._calc_thumb_pos(row, col)
+                bnch.namelbl.x, bnch.namelbl.y = xt, yt
+                bnch.image.x, bnch.image.y = xi, yi
+
+                canvas.add(bnch.widget, redraw=False)
+
+        self.c_view.redraw(whence=0)
+
+        if xi is not None:
+            xm, ym, x_, y_ = self._calc_thumb_pos(0, 0)
+            self.c_view.set_limits([(xm, ym), (xi, yi)], coord='data')
+            self._auto_scroll(xi, yi)
+
         self.logger.debug("Reordering done")
 
     def query_thumb(self, thumbkey, name, metadata):
@@ -715,62 +935,10 @@ class Thumbs(GingaPlugin.GlobalPlugin):
                 return
 
             self.logger.info("updating thumbnail '%s'" % (name))
-            bnch.image._set_image(imgwin)
+            bnch.image.set_image(imgwin)
             self.logger.debug("update finished.")
 
-    def add_image_info_cb(self, viewer, channel, info):
-
-        save_thumb = self.settings.get('cache_thumbs', False)
-
-        # Do we already have this thumb loaded?
-        chname = channel.name
-        thumbkey = self.get_thumb_key(chname, info.name, info.path)
-        thumbpath = self.get_thumbpath(info.path)
-
-        with self.thmblock:
-            try:
-                bnch = self.thumb_dict[thumbkey]
-                # if these are not equal then the mtime must have
-                # changed on the file, better reload and regenerate
-                if bnch.thumbpath == thumbpath:
-                    return
-            except KeyError:
-                pass
-
-        # Is there a cached thumbnail image on disk we can use?
-        thmb_image = RGBImage.RGBImage()
-        loaded = False
-        if (thumbpath is not None) and os.path.exists(thumbpath):
-            #save_thumb = False
-            try:
-                # try to load the thumbnail image
-                thmb_image.load_file(thumbpath)
-                # make sure name is consistent
-                thmb_image.set(name=info.name)
-                loaded = True
-
-            except Exception as e:
-                self.logger.warning("Error loading thumbnail: %s" % (str(e)))
-
-        if not loaded:
-            # no luck loading thumbnail, try to load the full image
-            try:
-                thmb_image = channel.get_loaded_image(info.name)
-
-            except KeyError:
-                self.logger.info("image not in memory; using placeholder")
-
-                # load a plcaeholder image
-                tmp_path = os.path.join(icondir, 'fits.png')
-                thmb_image = RGBImage.RGBImage()
-                thmb_image.load_file(tmp_path)
-                # make sure name is consistent
-                thmb_image.set(name=info.name, path=None)
-
-        self.fv.gui_do(self._make_thumb, chname, thmb_image, info.name,
-                       info.path, thumbkey, info.image_future,
-                       save_thumb=save_thumb,
-                       thumbpath=thumbpath)
+        self.c_view.redraw(whence=0)
 
     def __str__(self):
         return 'thumbs'

--- a/ginga/rv/plugins/Thumbs.py
+++ b/ginga/rv/plugins/Thumbs.py
@@ -51,8 +51,6 @@ class Thumbs(GingaPlugin.GlobalPlugin):
         self.thumb_num_cols = 1
         self.thumb_row_count = 0
         self.thumb_col_count = 0
-        # distance in pixels between thumbs
-        self.thumb_sep = 15
         self._wd = 300
         self._ht = 400
         self._cmyoff = 10
@@ -68,9 +66,10 @@ class Thumbs(GingaPlugin.GlobalPlugin):
                                    tt_keywords=tt_keywords,
                                    mouseover_name_key='NAME',
                                    thumb_length=192,
+                                   thumb_sep=15,
                                    sort_order=None,
                                    label_length=14,
-                                   label_cutoff='right',
+                                   label_cutoff=None,
                                    highlight_tracks_keyboard_focus=True,
                                    label_font_color='white',
                                    label_font_size=10,
@@ -78,6 +77,8 @@ class Thumbs(GingaPlugin.GlobalPlugin):
         self.settings.load(onError='silent')
         # max length of thumb on the long side
         self.thumb_width = self.settings.get('thumb_length', 192)
+        # distance in pixels between thumbs
+        self.thumb_sep = self.settings.get('thumb_sep', 15)
 
         # Build our thumb generator
         tg = CanvasView(logger=self.logger)
@@ -780,13 +781,14 @@ class Thumbs(GingaPlugin.GlobalPlugin):
 
         # Shorten thumbnail label, if requested
         label_length = self.settings.get('label_length', None)
-        label_cutoff = self.settings.get('label_cutoff', 'right')
+        label_cutoff = self.settings.get('label_cutoff', None)
 
         if label_length is not None:
-            ## thumbname = iohelper.shorten_name(thumbname, label_length,
-            ##                                   side=label_cutoff)
-            # TEMP
-            thumbname = thumbname[:label_length]
+            if label_cutoff is not None:
+                thumbname = iohelper.shorten_name(thumbname, label_length,
+                                                  side=label_cutoff)
+            else:
+                thumbname = thumbname[:label_length]
 
         with self.thmblock:
             row, col = self.thumb_row_count, self.thumb_col_count

--- a/ginga/rv/plugins/Thumbs.py
+++ b/ginga/rv/plugins/Thumbs.py
@@ -661,6 +661,11 @@ class Thumbs(GingaPlugin.GlobalPlugin):
             metadata[kwd] = header.get(kwd, 'N/A')
 
         thumbname = name
+        # assign a name in the metadata if we don't have one yet
+        name_key = self.settings.get('mouseover_name_key', 'NAME')
+        if metadata.setdefault(name_key, thumbname) == 'N/A':
+            metadata[name_key] = thumbname
+
         self.insert_thumbnail(imgwin, thumbkey, thumbname,
                               chname, name, path, thumbpath, metadata,
                               image_info)

--- a/ginga/rv/plugins/Thumbs.py
+++ b/ginga/rv/plugins/Thumbs.py
@@ -5,6 +5,7 @@
 # Please see the file LICENSE.txt for details.
 #
 import os
+import time
 import threading
 
 from ginga import GingaPlugin
@@ -35,8 +36,7 @@ class Thumbs(GingaPlugin.GlobalPlugin):
     Clicking on a thumbnail navigates you directly to that image in the
     associated channel.  Hovering the cursor over a thumbnail will show a
     tool tip that contains a couple of useful pieces of metadata from the
-    image.  Right-clicking on a thumbnail brings up a context menu with
-    options for displaying or removing an image.
+    image.
 
     The "Auto Scroll" checkbox, if checked, will cause the Thumbs pan to
     scroll to the active image.
@@ -64,7 +64,7 @@ class Thumbs(GingaPlugin.GlobalPlugin):
         self.settings.add_defaults(cache_thumbs=False,
                                    cache_location='local',
                                    auto_scroll=True,
-                                   rebuild_wait=4.0,
+                                   rebuild_wait=0.5,
                                    tt_keywords=tt_keywords,
                                    mouseover_name_key='NAME',
                                    thumb_length=192,
@@ -79,6 +79,7 @@ class Thumbs(GingaPlugin.GlobalPlugin):
         # max length of thumb on the long side
         self.thumb_width = self.settings.get('thumb_length', 192)
 
+        # Build our thumb generator
         tg = CanvasView(logger=self.logger)
         tg.configure_surface(self.thumb_width, self.thumb_width)
         tg.enable_autozoom('on')
@@ -91,7 +92,7 @@ class Thumbs(GingaPlugin.GlobalPlugin):
 
         self.thmbtask = fv.get_timer()
         self.thmbtask.set_callback('expired', self.redo_delay_timer)
-        self.lagtime = self.settings.get('rebuild_wait', 4.0)
+        self.lagtime = self.settings.get('rebuild_wait', 0.5)
         self.thmblock = threading.RLock()
 
         # this will hold the thumbnails pane viewer
@@ -142,6 +143,7 @@ class Thumbs(GingaPlugin.GlobalPlugin):
         c_v.add_callback('scroll', self.scroll_cb)
         canvas.set_draw_mode('pick')
         canvas.ui_set_active(True)
+        self.canvas = canvas
 
         bd = c_v.get_bindings()
         bd.enable_pan(True)
@@ -205,12 +207,25 @@ class Thumbs(GingaPlugin.GlobalPlugin):
         thumbkey = (chname, imname, path)
         return thumbkey
 
-    def add_image_cb(self, viewer, chname, image, image_info):
+    def add_image_cb(self, viewer, chname, image, info):
+
+        # Get any previously stored thumb information in the image info
+        thumb_extra = info.setdefault('thumb_extras', Bunch.Bunch())
+
+        # Get metadata for mouse-over tooltip
+        metadata = self._get_tooltip_metadata(info, image)
+
+        # Update the tooltip, in case of new or changed metadata
+        text = self._mk_tooltip_text(metadata)
+        thumb_extra.tooltip = text
+
         if not self.gui_up:
             return False
 
         channel = self.fv.get_channel(chname)
-        self.redo_delay(channel.fitsimage)
+
+        if thumb_extra.get('time_update', None) is None:
+            self.fv.gui_do(self.redo_thumbnail_image, channel, image, info)
 
     def add_image_info_cb(self, viewer, channel, info):
 
@@ -233,39 +248,10 @@ class Thumbs(GingaPlugin.GlobalPlugin):
             except KeyError:
                 self.logger.debug("we don't seem to have this thumb--generating thumb")
 
-        # Is there a cached thumbnail image on disk we can use?
-        thmb_image = RGBImage.RGBImage()
-        loaded = False
-        if (thumbpath is not None) and os.path.exists(thumbpath):
-            #save_thumb = False
-            try:
-                # try to load the thumbnail image
-                thmb_image.load_file(thumbpath)
-                # make sure name is consistent
-                thmb_image.set(name=info.name)
-                loaded = True
+        thmb_image = self._get_thumb_image(channel, info, None)
 
-            except Exception as e:
-                self.logger.warning("Error loading thumbnail: %s" % (str(e)))
-
-        if not loaded:
-            # no luck loading thumbnail, try to load a cached image
-            try:
-                thmb_image = channel.get_loaded_image(info.name)
-
-            except KeyError:
-                self.logger.info("image not in memory; using placeholder")
-
-                # load a plcaeholder image
-                tmp_path = os.path.join(icondir, 'fits.png')
-                thmb_image = RGBImage.RGBImage()
-                thmb_image.load_file(tmp_path)
-                # make sure name is consistent
-                thmb_image.set(name=info.name, path=None)
-
-        self.fv.gui_do(self._make_thumb, chname, thmb_image, info.name,
-                       info.path, thumbkey, info, save_thumb=save_thumb,
-                       thumbpath=thumbpath)
+        self.fv.gui_do(self._make_thumb, chname, thmb_image, info, thumbkey,
+                       save_thumb=save_thumb, thumbpath=thumbpath)
 
 
     def _add_image(self, viewer, chname, image):
@@ -339,10 +325,11 @@ class Thumbs(GingaPlugin.GlobalPlugin):
         self.fv.gui_do_oneshot('thumbs-reorder', self.reorder_thumbs)
         return False
 
-    def load_file(self, thumbkey, chname, name, path, image_future):
+    def load_file(self, thumbkey, chname, info):
         self.logger.debug("loading image: %s" % (str(thumbkey)))
-        self.fv.switch_name(chname, name, path=path,
-                            image_future=image_future)
+        # TODO: deal with channel object directly?
+        self.fv.switch_name(chname, info.name, path=info.path,
+                            image_future=info.image_future)
 
     def clear(self):
         with self.thmblock:
@@ -411,12 +398,6 @@ class Thumbs(GingaPlugin.GlobalPlugin):
     def redo_delay_timer(self, timer):
         self.fv.gui_do(self.redo_thumbnail, timer.data.fitsimage)
 
-    def copy_attrs(self, fitsimage):
-        # Reflect transforms, colormap, etc.
-        fitsimage.copy_attributes(self.thumb_generator,
-                                  ['transforms', 'cutlevels',
-                                   'rgbmap'])
-
     def update_highlights(self, old_highlight_set, new_highlight_set):
         """Unhighlight the thumbnails represented by `old_highlight_set`
         and highlight the ones represented by new_highlight_set.
@@ -443,7 +424,7 @@ class Thumbs(GingaPlugin.GlobalPlugin):
                     namelbl = self.thumb_dict[thumbkey].get('namelbl')
                     namelbl.color = bg
 
-        self.c_view.redraw(whence=0)
+        self.c_view.redraw(whence=3)
 
     def redo(self, channel, image):
         """This method is called when an image is set in a channel."""
@@ -501,43 +482,46 @@ class Thumbs(GingaPlugin.GlobalPlugin):
         with self.thmblock:
             return thumbkey in self.thumb_dict
 
-    def redo_thumbnail(self, fitsimage, save_thumb=None):
+    def redo_thumbnail(self, viewer, save_thumb=None):
         self.logger.debug("redoing thumbnail...")
         # Get the thumbnail image
-        image = fitsimage.get_image()
+        image = viewer.get_image()
         if image is None:
             return
 
+        imname = image.get('name', None)
+        if imname is None:
+            return
+
+        chname = self.fv.get_channel_name(viewer)
+        channel = self.fv.get_channel(chname)
+        try:
+            info = channel[imname]
+        except KeyError:
+            # don't generate a thumbnail without info
+            return
+
+        self.redo_thumbnail_image(channel, image, info, save_thumb=save_thumb)
+
+
+    def redo_thumbnail_image(self, channel, image, info, save_thumb=None):
         # image is flagged not to make a thumbnail?
         nothumb = image.get('nothumb', False)
         if nothumb:
             return
 
+        self.logger.debug("redoing thumbnail...")
         if save_thumb is None:
             save_thumb = self.settings.get('cache_thumbs', False)
 
-        chname = self.fv.get_channel_name(fitsimage)
+        # Get any previously stored thumb information in the image info
+        thumb_extra = info.setdefault('thumb_extras', Bunch.Bunch())
 
         # Get metadata for mouse-over tooltip
-        header = image.get_header()
-        metadata = {}
-        for kwd in self.keywords:
-            metadata[kwd] = header.get(kwd, 'N/A')
+        metadata = self._get_tooltip_metadata(info, image)
 
-        # Look up our version of the thumb
-        idx = image.get('idx', None)
-        path = image.get('path', None)
-        if path is not None:
-            path = os.path.abspath(path)
-            name = self.fv.name_image_from_path(path, idx=idx)
-        else:
-            name = 'NoName'
-
-        # get image name
-        name = image.get('name', name)
-        metadata[self.settings.get('mouseover_name_key', 'NAME')] = name
-
-        thumbkey = self.get_thumb_key(chname, name, path)
+        chname = channel.name
+        thumbkey = self.get_thumb_key(chname, info.name, info.path)
         with self.thmblock:
             if thumbkey not in self.thumb_dict:
                 # No memory of this thumbnail, so regenerate it
@@ -546,26 +530,18 @@ class Thumbs(GingaPlugin.GlobalPlugin):
 
             # Generate new thumbnail
             self.logger.debug("generating new thumbnail")
-            fitsimage.copy_attributes(self.thumb_generator,
-                                      ['transforms', 'cutlevels',
-                                       'rgbmap'])
-
-            thumb_np = image.get_thumbnail(self.thumb_width)
-            self.thumb_generator.set_data(thumb_np)
+            thmb_image = self._regen_thumb_image(image, channel.fitsimage)
+            thumb_extra.time_update = time.time()
 
             # Save a thumbnail for future browsing
-            if save_thumb and path is not None:
-                thumbpath = self.get_thumbpath(path)
+            if save_thumb and info.path is not None:
+                thumbpath = self.get_thumbpath(info.path)
                 if thumbpath is not None:
                     if os.path.exists(thumbpath):
                         os.remove(thumbpath)
-                    ## self.thumb_generator.save_plain_image_as_file(thumbpath,
-                    ##                                               format='jpeg')
+                    thmb_image.save_as_file(thumbpath)
 
-            rgb_img = self.thumb_generator.get_image_as_array()
-            imgwin = RGBImage.RGBImage(rgb_img)
-
-        self.update_thumbnail(thumbkey, imgwin, name, metadata)
+        self.update_thumbnail(thumbkey, thmb_image, metadata)
 
     def delete_channel_cb(self, viewer, channel):
         """Called when a channel is deleted from the main interface.
@@ -574,43 +550,61 @@ class Thumbs(GingaPlugin.GlobalPlugin):
         # TODO: delete thumbs for this channel!
         self.logger.info("deleting thumbs for channel '%s'" % (chname_del))
         with self.thmblock:
-            newThumbList = []
+            new_thumb_list = []
             un_hilite_set = set([])
             for thumbkey in self.thumb_list:
                 chname = thumbkey[0]
                 if chname != chname_del:
-                    newThumbList.append(thumbkey)
+                    new_thumb_list.append(thumbkey)
                 else:
                     del self.thumb_dict[thumbkey]
                     un_hilite_set.add(thumbkey)
-            self.thumb_list = newThumbList
+            self.thumb_list = new_thumb_list
             self._tkf_highlight -= un_hilite_set  # Unhighlight
 
         self.fv.gui_do_oneshot('thumbs-reorder', self.reorder_thumbs)
 
-    def make_tt(self, viewer, canvas, text, pt, fontsize=10):
-        Text = canvas.get_draw_class('text')
-        Rectangle = canvas.get_draw_class('rectangle')
-        Point = canvas.get_draw_class('point')
+    def _get_tooltip_metadata(self, info, image, keywords=None):
+        # Get metadata for mouse-over tooltip
+        header = {}
+        if image is not None:
+            header = image.get_header()
 
-        x, y = pt
-        # override x coord so that tooltip can be sure to be somewhat
-        # visible on the canvas
+        if keywords is None:
+            keywords = self.keywords
+        metadata = {kwd: header.get(kwd, 'N/A')
+                    for kwd in keywords}
+
+        # assign a name in the metadata if we don't have one yet
+        name_key = self.settings.get('mouseover_name_key', 'NAME')
+        if metadata.setdefault(name_key, info.name) == 'N/A':
+            metadata[name_key] = info.name
+
+        return metadata
+
+    def make_tt(self, viewer, canvas, text, pt, obj, fontsize=10):
+        x1, y1, x2, y2 = obj.get_llur()
+
+        # Determine pop-up position on canvas.  Try to align a little below
+        # the thumbnail image and offset a bit based on column
         tup = viewer.get_pan_rect()
-        x = tup[0][0] + 10
+        col = obj.data.col
+        x = tup[0][0] + 10 + col * 20
+        y = y1 + 10
         mxwd = 0
         lines = text.split('\n')
 
-        point = Point(x, y, radius=0, color='black', alpha=0.0)
-        rect = Rectangle(x, y, x, y, color='black', fill=True,
-                         fillcolor='lightyellow')
+        point = canvas.dc.Point(x, y, radius=0, color='black', alpha=0.0)
+        rect = canvas.dc.Rectangle(x, y, x, y, color='black', fill=True,
+                                   fillcolor='lightyellow')
         crdmap = viewer.get_coordmap('offset')
         crdmap.refobj = point
 
         l = [point, rect]
         a, b = 2, 0
         for line in lines:
-            text = Text(a, b, text=line, color='black', fontsize=fontsize)
+            text = canvas.dc.Text(a, b, text=line, color='black',
+                                  fontsize=fontsize)
             text.crdmap = crdmap
             l.append(text)
             txt_wd, txt_ht = viewer.renderer.get_dimensions(text)
@@ -620,14 +614,13 @@ class Thumbs(GingaPlugin.GlobalPlugin):
         rect.x2 = rect.x1 + mxwd + 2
         rect.y2 = rect.y1 + b + 4
 
-        Compound = canvas.get_draw_class('compoundobject')
-        obj = Compound(*l)
+        obj = canvas.dc.CompoundObject(*l)
         return obj
 
     def show_tt(self, obj, canvas, event, pt,
-                thumbkey, chname, name, image_info, tf):
+                thumbkey, chname, info, tf):
 
-        text = image_info.thumb_extras.tooltip
+        text = info.thumb_extras.tooltip
 
         tag = '_$tooltip'
         try:
@@ -635,40 +628,88 @@ class Thumbs(GingaPlugin.GlobalPlugin):
         except KeyError:
             pass
         if tf:
-            tt = self.make_tt(self.c_view, canvas, text, pt)
+            tt = self.make_tt(self.c_view, canvas, text, pt, obj)
             canvas.add(tt, tag=tag)
 
-    def _make_thumb(self, chname, image, name, path, thumbkey,
-                    image_info, save_thumb=False, thumbpath=None):
-        # This is called by the make_thumbs() as a gui thread
-        with self.thmblock:
-            thumb_np = image.get_thumbnail(self.thumb_width)
-            self.thumb_generator.set_data(thumb_np)
+    def _regen_thumb_image(self, image, viewer):
+        self.logger.debug("generating new thumbnail")
+        if viewer is not None:
+            viewer.copy_attributes(self.thumb_generator,
+                                   ['transforms', 'cutlevels', 'rgbmap'])
 
-            # Save a thumbnail for future browsing
-            if save_thumb and (thumbpath is not None):
-                ## self.thumb_generator.save_plain_image_as_file(thumbpath,
-                ##                                               format='jpeg')
+        thumb_np = image.get_thumbnail(self.thumb_width)
+        self.thumb_generator.set_data(thumb_np)
+
+        rgb_img = self.thumb_generator.get_image_as_array()
+        thmb_image = RGBImage.RGBImage(rgb_img)
+        return thmb_image
+
+    def _get_thumb_image(self, channel, info, image):
+
+        # Get any previously stored thumb information in the image info
+        thumb_extra = info.setdefault('thumb_extras', Bunch.Bunch())
+
+        # Choice [A]: is there a thumb image attached to the image info?
+        if 'rgbimg' in thumb_extra:
+            # yes
+            return thumb_extra.rgbimg
+
+        thumbpath = self.get_thumbpath(info.path)
+
+        # Choice [B]: is the full image available to make a thumbnail?
+        if image is None:
+            try:
+                image = channel.get_loaded_image(info.name)
+
+            except KeyError:
                 pass
 
-            rgb_img = self.thumb_generator.get_image_as_array()
-            imgwin = RGBImage.RGBImage(rgb_img)
+        if image is not None:
+            try:
+                thmb_image = self._regen_thumb_image(image, None)
+                thumb_extra.rgbimg = thmb_image
+                thumb_extra.time_update = time.time()
+                return thmb_image
+
+            except Exception as e:
+                self.logger.warning("Error generating thumbnail: %s" % (str(e)))
+
+        thmb_image = RGBImage.RGBImage()
+        thmb_image.set(name=info.name)
+
+        # Choice [C]: is there a cached thumbnail image on disk we can use?
+        if (thumbpath is not None) and os.path.exists(thumbpath):
+            try:
+                # try to load the thumbnail image
+                thmb_image.load_file(thumbpath)
+                thumb_extra.rgbimg = thmb_image
+                return thmb_image
+
+            except Exception as e:
+                self.logger.warning("Error loading thumbnail: %s" % (str(e)))
+
+        # Choice [D]: load a placeholder image
+        tmp_path = os.path.join(icondir, 'fits.png')
+        thmb_image.load_file(tmp_path)
+        thmb_image.set(path=None)
+
+        return thmb_image
+
+    def _make_thumb(self, chname, thmb_image, info, thumbkey,
+                    save_thumb=False, thumbpath=None):
+
+        # This is called by the plugin FBrowser.make_thumbs() as
+        # a gui thread
+        with self.thmblock:
+            # Save a thumbnail for future browsing
+            if save_thumb and (thumbpath is not None):
+                thmb_image.save_as_file(thumbpath)
 
         # Get metadata for mouse-over tooltip
-        header = image.get_header()
-        metadata = {}
-        for kwd in self.keywords:
-            metadata[kwd] = header.get(kwd, 'N/A')
+        metadata = self._get_tooltip_metadata(info, None)
 
-        thumbname = name
-        # assign a name in the metadata if we don't have one yet
-        name_key = self.settings.get('mouseover_name_key', 'NAME')
-        if metadata.setdefault(name_key, thumbname) == 'N/A':
-            metadata[name_key] = thumbname
-
-        self.insert_thumbnail(imgwin, thumbkey, thumbname,
-                              chname, name, path, thumbpath, metadata,
-                              image_info)
+        self.insert_thumbnail(thmb_image, thumbkey, chname,
+                              thumbpath, metadata, info)
 
     def get_thumbpath(self, path, makedir=True):
         if path is None:
@@ -715,29 +756,25 @@ class Thumbs(GingaPlugin.GlobalPlugin):
         yi = yt
         return (xt, yt, xi, yi)
 
-    def insert_thumbnail(self, imgwin, thumbkey, thumbname, chname, name, path,
-                         thumbpath, metadata, image_info):
+    def insert_thumbnail(self, imgwin, thumbkey, chname,
+                         thumbpath, metadata, info):
 
+        thumbname = info.name
         self.logger.debug("inserting thumb %s" % (thumbname))
         # make a context menu
-        image_future = image_info.image_future
-        menu = self._mk_context_menu(thumbkey, chname, name, path,
-                                     image_future)
+        menu = self._mk_context_menu(thumbkey, chname, info)
 
         # Get any previously stored thumb information in the image info
-        thumb_extra = image_info.setdefault('thumb_extras', Bunch.Bunch())
+        thumb_extra = info.setdefault('thumb_extras', Bunch.Bunch())
 
         # If there is no previously made tooltip, then generate one
         if 'tooltip' in thumb_extra:
             text = thumb_extra.tooltip
         else:
-            text = self.query_thumb(thumbkey, name, metadata)
+            text = self._mk_tooltip_text(metadata)
             thumb_extra.tooltip = text
 
         canvas = self.c_view.get_canvas()
-        Image = canvas.get_draw_class('image')
-        Text = canvas.get_draw_class('text')
-        Compound = canvas.get_draw_class('compoundobject')
         fg = self.settings.get('label_font_color', 'black')
         fontsize = self.settings.get('label_font_size', 10)
 
@@ -759,22 +796,23 @@ class Thumbs(GingaPlugin.GlobalPlugin):
 
             xt, yt, xi, yi = self._calc_thumb_pos(row, col)
             l2 = []
-            namelbl = Text(xt, yt, thumbname, color=fg, fontsize=fontsize,
-                           coord='data')
+            namelbl = canvas.dc.Text(xt, yt, thumbname, color=fg,
+                                     fontsize=fontsize, coord='data')
             l2.append(namelbl)
 
-            image = Image(xi, yi, imgwin, alpha=1.0,
-                          linewidth=1, color='black', coord='data')
+            image = canvas.dc.Image(xi, yi, imgwin, alpha=1.0,
+                                    linewidth=1, color='black', coord='data')
             l2.append(image)
 
-            obj = Compound(*l2, coord='data')
+            obj = canvas.dc.CompoundObject(*l2, coord='data')
             obj.pickable = True
             obj.opaque = True
+            obj.set_data(row=row, col=col)
 
-            bnch = Bunch.Bunch(widget=obj, image=image, info=image_info,
-                               name=name, imname=name, namelbl=namelbl,
-                               chname=chname, path=path, thumbpath=thumbpath,
-                               image_future=image_future)
+            bnch = Bunch.Bunch(widget=obj, image=image, info=info,
+                               namelbl=namelbl,
+                               chname=chname,
+                               thumbpath=thumbpath)
 
             self.thumb_dict[thumbkey] = bnch
             self.thumb_list.append(thumbkey)
@@ -782,18 +820,14 @@ class Thumbs(GingaPlugin.GlobalPlugin):
             # set the load callback
             obj.add_callback('pick-down',
                              lambda *args: self.load_file(thumbkey, chname,
-                                                          name,
-                                                          path, image_future))
+                                                          info))
             # set callbacks for tool tips
             obj.add_callback('pick-enter', self.show_tt,
-                             thumbkey, chname, name, image_info, True)
+                             thumbkey, chname, info, True)
             obj.add_callback('pick-leave', self.show_tt,
-                             thumbkey, chname, name, image_info, False)
+                             thumbkey, chname, info, False)
 
-            # add thumb to canvas
-            canvas.add(obj)
-
-        #self.c_view.redraw(whence=0)
+            # thumb will be added to canvas later in reorder_thumbs()
 
         sort_order = self.settings.get('sort_order', None)
         if sort_order:
@@ -801,7 +835,7 @@ class Thumbs(GingaPlugin.GlobalPlugin):
 
         self.fv.gui_do_oneshot('thumbs-reorder', self.reorder_thumbs)
 
-        self.logger.debug("added thumb for %s" % (name))
+        self.logger.debug("added thumb for %s" % (info.name))
 
     def _auto_scroll(self, xi, yi):
         # force scroll to bottom of thumbs, if checkbox is set
@@ -843,10 +877,9 @@ class Thumbs(GingaPlugin.GlobalPlugin):
                 xt, yt, xi, yi = self._calc_thumb_pos(row, col)
                 bnch.namelbl.x, bnch.namelbl.y = xt, yt
                 bnch.image.x, bnch.image.y = xi, yi
+                bnch.widget.set_data(row=row, col=col)
 
                 canvas.add(bnch.widget, redraw=False)
-
-        self.c_view.redraw(whence=0)
 
         if xi is not None:
             xi += self.thumb_width
@@ -854,36 +887,43 @@ class Thumbs(GingaPlugin.GlobalPlugin):
             self.c_view.set_limits([(xm, ym), (xi, yi)], coord='data')
             self._auto_scroll(xi, yi)
 
+        self.c_view.redraw(whence=0)
+
         self.logger.debug("Reordering done")
 
-    def query_thumb(self, thumbkey, name, metadata):
+    def _mk_tooltip_text(self, metadata):
         result = []
         for kwd in self.keywords:
             try:
                 text = kwd + ': ' + str(metadata[kwd])
+
             except Exception as e:
-                self.logger.warning("Couldn't determine %s name: %s" % (
+                self.logger.debug("Couldn't get keyword '%s' value: %s" % (
                     kwd, str(e)))
                 text = "%s: N/A" % (kwd)
             result.append(text)
 
         return '\n'.join(result)
 
-    def _mk_context_menu(self, thumbkey, chname, name, path, image_future):
+    def _mk_context_menu(self, thumbkey, chname, info):
+        """NOTE: currently not used, but left here to be reincorporated
+        at some point.
+        """
         menu = Widgets.Menu()
         item = menu.add_name("Display")
         item.add_callback('activated',
                           lambda w: self.load_file(
-                              thumbkey, chname, name, path, image_future))
+                              thumbkey, chname, info.name, info.path,
+                              info.image_future))
         menu.add_separator()
         item = menu.add_name("Remove")
         item.add_callback('activated',
                           lambda w: self.fv.remove_image_by_name(
-                              chname, name, impath=path))
+                              chname, info.name, impath=info.path))
 
         return menu
 
-    def update_thumbnail(self, thumbkey, imgwin, name, metadata):
+    def update_thumbnail(self, thumbkey, thmb_image, metadata):
         with self.thmblock:
             try:
                 bnch = self.thumb_dict[thumbkey]
@@ -892,19 +932,24 @@ class Thumbs(GingaPlugin.GlobalPlugin):
                                   "thumbs" % (str(thumbkey)))
                 return
 
-            image_info = bnch.info
+            info = bnch.info
             # Get any previously stored thumb information in the image info
-            thumb_extra = image_info.setdefault('thumb_extras', Bunch.Bunch())
+            thumb_extra = info.setdefault('thumb_extras', Bunch.Bunch())
 
             # Update the tooltip, in case of new or changed metadata
-            text = self.query_thumb(thumbkey, name, metadata)
+            text = self._mk_tooltip_text(metadata)
             thumb_extra.tooltip = text
 
-            self.logger.info("updating thumbnail '%s'" % (name))
-            bnch.image.set_image(imgwin)
+            self.logger.info("updating thumbnail '%s'" % (info.name))
+            # TODO: figure out why set_image() causes corruption of the
+            # redraw here.  Instead we force a manual redraw.
+            #bnch.image.set_image(thmb_image)
+            bnch.image.image = thmb_image
+            thumb_extra.rgbimg = thmb_image
+
+            self.c_view.redraw(whence=0)
             self.logger.debug("update finished.")
 
-        self.c_view.redraw(whence=0)
 
     def __str__(self):
         return 'thumbs'

--- a/ginga/rv/plugins/Thumbs.py
+++ b/ginga/rv/plugins/Thumbs.py
@@ -751,13 +751,16 @@ class Thumbs(GingaPlugin.GlobalPlugin):
         xt = self._cmxoff + (col * twd_hplus)
         yt = self._cmyoff + (row * twd_vplus) + text_ht
 
+        # position of image
+        xi = xt
+        yi = yt + 6
+
         # convert to data coords
         crdmap = self.c_view.get_coordmap('window')
-        xt, yt = crdmap.to_data((xt, yt))
+        xtd, ytd = crdmap.to_data((xt, yt))
+        xid, yid = crdmap.to_data((xi, yi))
 
-        xi = xt
-        yi = yt
-        return (xt, yt, xi, yi)
+        return (xtd, ytd, xid, yid)
 
     def insert_thumbnail(self, imgwin, thumbkey, chname,
                          thumbpath, metadata, info):


### PR DESCRIPTION
This adds Display/Move/Copy/Remove buttons to the bottom of the Contents UI.  Behavior of the Contents treeview is different.  First of all, selecting a file does not display it.  Secondly, multiple files can be selected, and using the standard Shift or Ctrl click the selection can be modified.  An action is selected by clicking one of the buttons at the bottom of the UI.  Move/Copy/Remove are all backed by pop-up dialogs to confirm the operation.

EDIT: Fix #107