### PR TITLE
Speed up LineProfile calculation etc

### DIFF
--- a/ginga/rv/plugins/LineProfile.py
+++ b/ginga/rv/plugins/LineProfile.py
@@ -86,19 +86,21 @@ class LineProfile(GingaPlugin.LocalPlugin):
         top = Widgets.VBox()
         top.set_border_width(4)
 
-        vbox, sw, orientation = Widgets.get_oriented_box(container)
-        vbox.set_margins(4, 4, 4, 4)
-        vbox.set_spacing(2)
+        box, sw, orientation = Widgets.get_oriented_box(container)
+        box.set_border_width(4)
+        box.set_spacing(2)
+
+        paned = Widgets.Splitter(orientation=orientation)
 
         self.plot = plots.Plot(logger=self.logger,
-                               width=400, height=300)
+                               width=400, height=400)
         ax = self.plot.add_axis()
-        ax.grid(False)
+        ax.grid(True)
         self._ax2 = self.plot.ax.twiny()
 
         w = Plot.PlotWidget(self.plot)
-        w.resize(400, 300)
-        vbox.add_widget(w, stretch=0)
+        w.resize(400, 400)
+        paned.add_widget(Widgets.hadjust(w, orientation))
 
         fr = Widgets.Frame("Axes controls")
         self.hbox_axes = Widgets.HBox()
@@ -106,7 +108,7 @@ class LineProfile(GingaPlugin.LocalPlugin):
         self.hbox_axes.set_spacing(1)
         fr.set_widget(self.hbox_axes)
 
-        vbox.add_widget(fr, stretch=0)
+        box.add_widget(fr, stretch=0)
 
         captions = (('marks', 'combobox',
                      'New Mark Type:', 'label', 'Mark Type', 'combobox'),
@@ -173,13 +175,18 @@ class LineProfile(GingaPlugin.LocalPlugin):
 
         fr = Widgets.Frame("Mark controls")
         fr.set_widget(vbox2)
-        vbox.add_widget(fr, stretch=1)
+        box.add_widget(fr, stretch=0)
 
-        # scroll bars will allow lots of content to be accessed
-        top.add_widget(sw, stretch=1)
+        box.add_widget(Widgets.Label(''), stretch=1)
+        paned.add_widget(sw)
+        # hack to set a reasonable starting position for the splitter
+        paned.set_sizes([400, 500])
+
+        top.add_widget(paned, stretch=5)
 
         # A button box that is always visible at the bottom
         btns = Widgets.HBox()
+        btns.set_border_width(4)
         btns.set_spacing(3)
 
         # Add a close button for the convenience of the user

--- a/ginga/rv/plugins/LineProfile.py
+++ b/ginga/rv/plugins/LineProfile.py
@@ -309,11 +309,8 @@ class LineProfile(GingaPlugin.LocalPlugin):
                 data = mddata
             # Broadcast region mask to 3D
             mask = self.image.get_shape_mask(obj)  # 2D only, True = enclosed
-            mask3d = np.zeros(data.shape, dtype=np.bool)
-            mask3d[:, :, :] = mask[np.newaxis, :, :]  # z, y, x
-            masked_data = np.ma.masked_array(data, mask=~mask3d)
-            masked_mean = masked_data.mean(axis=(1, 2))
-            plot_y_axis_data = masked_mean[~masked_mean.mask].data
+            plot_y_axis_data = [data[i][mask].mean()
+                                for i in range(data.shape[0])]
 
         # If few enough data points, add marker
         if len(plot_y_axis_data) <= 10:

--- a/ginga/rv/plugins/LineProfile.py
+++ b/ginga/rv/plugins/LineProfile.py
@@ -102,6 +102,16 @@ class LineProfile(GingaPlugin.LocalPlugin):
         w.resize(400, 400)
         paned.add_widget(Widgets.hadjust(w, orientation))
 
+        captions = (('Plot All', 'checkbutton'), )
+        w, b = Widgets.build_info(captions, orientation=orientation)
+        self.w.update(b)
+
+        b.plot_all.set_state(False)
+        b.plot_all.add_callback('activated', lambda *args: self.redraw_mark())
+        b.plot_all.set_tooltip("Plot all marks")
+
+        box.add_widget(w, stretch=0)
+
         fr = Widgets.Frame("Axes controls")
         self.hbox_axes = Widgets.HBox()
         self.hbox_axes.set_border_width(4)
@@ -207,6 +217,8 @@ class LineProfile(GingaPlugin.LocalPlugin):
         self.build_axes()
 
     def build_axes(self):
+        self.selected_axis = None
+
         if (not self.gui_up) or (self.hbox_axes is None):
             return
         self.hbox_axes.remove_all()
@@ -234,7 +246,6 @@ class LineProfile(GingaPlugin.LocalPlugin):
             # Add filler
             self.hbox_axes.add_widget(Widgets.Label(''), stretch=1)
         else:
-            self.selected_axis = None
             self.hbox_axes.add_widget(Widgets.Label('No NAXIS info'))
 
     def axes_callback_handler(self, chkbox, pos):
@@ -270,23 +281,19 @@ class LineProfile(GingaPlugin.LocalPlugin):
 
         self.redraw_mark()
 
-    def _plot(self, tag):
+    def _plot(self, tags):
         self.clear_plot()
 
         if self.selected_axis is None:
             return
-
-        obj = self.canvas.get_object_by_tag(tag)
-        if hasattr(obj, 'objects'):
-            obj = obj.objects[0]
 
         mddata = self.image.get_mddata()  # ..., z2, z1, y, x
         naxes = mddata.ndim
         i_sel = abs(self.selected_axis - naxes)
         i_x = naxes - 1
         i_y = naxes - 2
-        axes_slice = self.image.revnaxis + [0, 0]
 
+        # Also sets axis labels
         plot_x_axis_data = self.get_axis(self.selected_axis)
 
         # Image may lack the required keywords, or some trouble
@@ -294,50 +301,79 @@ class LineProfile(GingaPlugin.LocalPlugin):
         if plot_x_axis_data is None:
             return
 
-        # Cutting through surface ignores drawn shape but uses its center.
-        # A line through higher dim uses the same algorithm.
-        if i_sel in (i_x, i_y) or obj.kind == 'point':
-            xcen, ycen = obj.get_center_pt()
-            # Build N-dim slice
-            axes_slice[i_x] = int(round(xcen))
-            axes_slice[i_y] = int(round(ycen))
-            axes_slice[i_sel] = slice(None, None, None)
-            plot_y_axis_data = mddata[axes_slice]
+        is_surface_cut = i_sel in (i_x, i_y)
+        plotted_first = False
 
-        # TODO: Add more stats choices? Only calc mean for now.
-        # Do some stats of data in selected region.
-        else:
-            # Collapse to 3D cube
-            if naxes > 3:
-                for j in (i_x, i_y, i_sel):
-                    axes_slice[j] = slice(None, None, None)
-                data = mddata[axes_slice]  # z, y, x
+        for tag in tags:
+            if tag == self._new_mark:
+                continue
+
+            obj = self.canvas.get_object_by_tag(tag)
+            if hasattr(obj, 'objects'):
+                obj = obj.objects[0]
+
+            axes_slice = self.image.revnaxis + [0, 0]
+
+            # Cutting through surface ignores drawn shape but uses its center.
+            # A line through higher dim uses the same algorithm.
+            if is_surface_cut or obj.kind == 'point':
+                xcen, ycen = obj.get_center_pt()
+                # Build N-dim slice
+                axes_slice[i_x] = int(round(xcen))
+                axes_slice[i_y] = int(round(ycen))
+                axes_slice[i_sel] = slice(None, None, None)
+                try:
+                    plot_y_axis_data = mddata[axes_slice]
+                except IndexError:
+                    continue
+
+            # TODO: Add more stats choices? Only calc mean for now.
+            # Do some stats of data in selected region.
             else:
-                data = mddata
-            # Broadcast region mask to 3D
-            mask = self.image.get_shape_mask(obj)  # 2D only, True = enclosed
-            plot_y_axis_data = [data[i][mask].mean()
-                                for i in range(data.shape[0])]
+                # Collapse to 3D cube
+                if naxes > 3:
+                    for j in (i_x, i_y, i_sel):
+                        axes_slice[j] = slice(None, None, None)
+                    data = mddata[axes_slice]  # z, y, x
+                else:
+                    data = mddata
+                # Mask is 2D only (True = enclosed)
+                mask = self.image.get_shape_mask(obj)
+                try:
+                    plot_y_axis_data = [data[i][mask].mean()
+                                        for i in range(data.shape[0])]
+                except IndexError:
+                    continue
 
-        # If few enough data points, add marker
-        if len(plot_y_axis_data) <= 10:
-            marker = 'x'
-        else:
-            marker = None
+            # If few enough data points, add marker
+            if len(plot_y_axis_data) <= 10:
+                marker = 'x'
+            else:
+                marker = None
+
+            if not plotted_first:
+                lines = self.plot.plot(
+                    plot_x_axis_data, plot_y_axis_data, marker=marker,
+                    label=tag, xtitle=self.x_lbl, ytitle=self.y_lbl)
+                plotted_first = True
+            else:  # Overplot
+                lines = self.plot.ax.plot(
+                    plot_x_axis_data, plot_y_axis_data, marker=marker,
+                    label=tag)
+
+            # Highlight data point from active slice.
+            if not is_surface_cut:
+                i = self.image.revnaxis[i_sel]
+                self.plot.ax.plot(
+                    plot_x_axis_data[i], plot_y_axis_data[i], marker='o',
+                    ls='', color=lines[0].get_color())
+
+        if not plotted_first:  # Nothing was plotted
+            return
 
         # https://github.com/matplotlib/matplotlib/issues/3633/
         ax2 = self._ax2
         ax2.patch.set_visible(False)
-
-        self.clear_plot()
-        self.plot.plot(plot_x_axis_data, plot_y_axis_data,
-                       xtitle=self.x_lbl, ytitle=self.y_lbl, marker=marker)
-
-        # Highlight data point from active slice.
-        if i_sel not in (i_x, i_y):
-            i = self.image.revnaxis[i_sel]
-            self.plot.ax.plot(plot_x_axis_data[i], plot_y_axis_data[i],
-                              marker='o', ls='')
 
         # Top axis to show pixel location across X
         ax2.cla()
@@ -345,6 +381,8 @@ class LineProfile(GingaPlugin.LocalPlugin):
         ax2.set_xlim((xx1 - self._crval) / self._cdelt + self._crpix - 1,
                      (xx2 - self._crval) / self._cdelt + self._crpix - 1)
         ax2.set_xlabel('Index')
+
+        self.plot.ax.legend(loc='best')
         self.plot.draw()
 
     def get_axis(self, i):
@@ -550,11 +588,13 @@ class LineProfile(GingaPlugin.LocalPlugin):
             self.redraw_mark()
 
     def redraw_mark(self):
-        tag = self.mark_selected
-        if tag == self._new_mark:
+        plot_all = self.w.plot_all.get_state()
+        if plot_all:
+            self._plot([tag for tag in self.marks if tag != self._new_mark])
+        elif self.mark_selected != self._new_mark:
+            self._plot([self.mark_selected])
+        else:
             self.clear_plot()
-            return
-        self._plot(tag)
 
     def mark_select_cb(self, w, index):
         tag = self.marks[index]

--- a/ginga/util/plots.py
+++ b/ginga/util/plots.py
@@ -9,11 +9,12 @@ from astropy.utils.introspection import minversion
 
 import matplotlib as mpl
 from matplotlib.figure import Figure
-# fix issue of negative numbers rendering incorrectly with default font
-mpl.rcParams['axes.unicode_minus'] = False
 
 from ginga.util import iqcalc
 from ginga.misc import Callback
+
+# fix issue of negative numbers rendering incorrectly with default font
+mpl.rcParams['axes.unicode_minus'] = False
 
 MPL_GE_2_0 = minversion(mpl, '2.0')
 
@@ -75,7 +76,7 @@ class Plot(Callback.Callbacks):
             pass
         ax = self.ax
         for item in ([ax.title, ax.xaxis.label, ax.yaxis.label] +
-             ax.get_xticklabels() + ax.get_yticklabels()):
+                     ax.get_xticklabels() + ax.get_yticklabels()):
             item.set_fontsize(self.fontsize)
 
     def clear(self):
@@ -106,7 +107,7 @@ class Plot(Callback.Callbacks):
         self.set_titles(xtitle=xtitle, ytitle=ytitle, title=title,
                         rtitle=rtitle)
         self.ax.grid(True)
-        self.ax.plot(xarr, yarr, **kwdargs)
+        lines = self.ax.plot(xarr, yarr, **kwdargs)
 
         for item in self.ax.get_xticklabels() + self.ax.get_yticklabels():
             item.set_fontsize(self.fontsize)
@@ -119,9 +120,11 @@ class Plot(Callback.Callbacks):
         #self.fig.tight_layout()
 
         self.draw()
+        return lines
 
     def get_data(self):
             return self.fig, self.xdata, self.ydata
+
 
 class HistogramPlot(Plot):
 
@@ -225,11 +228,9 @@ class ContourPlot(Plot):
             # Create a contour plot
             self.xdata = numpy.arange(x1, x2, 1)
             self.ydata = numpy.arange(y1, y2, 1)
-            colors = [ 'black' ] * num_contours
-            cs = self.ax.contour(self.xdata, self.ydata, data, num_contours,
-                                 colors=colors
-                                 #cmap=self.cmap
-                                 )
+            colors = ['black'] * num_contours
+            self.ax.contour(self.xdata, self.ydata, data, num_contours,
+                            colors=colors)  # cmap=self.cmap
             ## self.ax.clabel(cs, inline=1, fontsize=10,
             ##                fmt='%5.3f', color='cyan')
             # Mark the center of the object
@@ -266,7 +267,7 @@ class ContourPlot(Plot):
         ##                     num_contours=num_contours)
         cx, cy = x - x1, y - y1
         self.plot_contours_data(cx, cy, img_data,
-                            num_contours=num_contours)
+                                num_contours=num_contours)
 
     def plot_panzoom(self):
         ht, wd = len(self.ydata), len(self.xdata)
@@ -313,7 +314,7 @@ class ContourPlot(Plot):
     def plot_scroll(self, event):
         # Matplotlib only gives us the number of steps of the scroll,
         # positive for up and negative for down.
-        direction = None
+        #direction = None
         if event.step > 0:
             #delta = 0.9
             self.plot_zoomlevel += 1.0
@@ -370,14 +371,15 @@ class RadialPlot(Plot):
         try:
             ht, wd = img_data.shape
             off_x, off_y = x1, y1
-            maxval = numpy.nanmax(img_data)
+            #maxval = numpy.nanmax(img_data)
 
             # create arrays of radius and value
             r = []
             v = []
             for i in range(0, wd):
                 for j in range(0, ht):
-                    r.append( numpy.sqrt( (off_x + i - x)**2 + (off_y + j - y)**2 ) )
+                    r.append(numpy.sqrt((off_x + i - x) ** 2 +
+                                        (off_y + j - y) ** 2))
                     v.append(img_data[j, i])
             r, v = numpy.array(r), numpy.array(v)
 
@@ -401,6 +403,7 @@ class RadialPlot(Plot):
         except Exception as e:
             self.logger.error("Error making radial plot: %s" % (
                 str(e)))
+
 
 class FWHMPlot(Plot):
 
@@ -505,7 +508,7 @@ class SurfacePlot(Plot):
         X, Y = numpy.meshgrid(X, Y)
 
         try:
-            from mpl_toolkits.mplot3d import Axes3D
+            from mpl_toolkits.mplot3d import Axes3D  # noqa
             from matplotlib.ticker import LinearLocator, FormatStrFormatter
 
             if MPL_GE_2_0:
@@ -551,4 +554,4 @@ class SurfacePlot(Plot):
             self.logger.error("Error making surface plot: %s" % (
                 str(e)))
 
-#END
+# END


### PR DESCRIPTION
Speed up `LineProfile` calculation by getting rid of Numpy masked array overhead. Fix #493.

I thought using masked array was a elegant solution but it is not feasible for large data cube. 😢 I probably over-designed it originally... Timing info available at https://gist.github.com/pllim/d0999e1c00d4ee45ccba2585c0b8146f .

Also fix #492.

c/c @bhilbert4 @aliciacanipe