### PR TITLE
[WIP] Stop override of plugin docstrings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ MANIFEST
 # Sphinx
 doc/api
 doc/manual/api/
+doc/manual/plugins_global/api/
 doc/manual/plugins_local/api/
 doc/_build
 

--- a/doc/manual/plugins_global/changehistory.rst
+++ b/doc/manual/plugins_global/changehistory.rst
@@ -13,4 +13,7 @@ a change log would appear here if a new image is added to a mosaic via the
 Mosaic plugin. Like :ref:`sec-plugins-contents`, the log is sorted by channel,
 and then by image name.
 
-.. automodule:: ginga.rv.plugins.ChangeHistory
+.. exec::
+
+    from ginga.util.toolbox import generate_cfg_example
+    print(generate_cfg_example('plugin_ChangeHistory', package='ginga'))

--- a/doc/rtd-pip-requirements
+++ b/doc/rtd-pip-requirements
@@ -1,5 +1,6 @@
 numpy
 matplotlib
 Cython
+docutils
 astropy-helpers
 astropy

--- a/ginga/rv/plugins/ChangeHistory.py
+++ b/ginga/rv/plugins/ChangeHistory.py
@@ -19,8 +19,8 @@ class ChangeHistory(GingaPlugin.GlobalPlugin):
 
     This plugin is used to log any changes to data buffer. For example,
     a change log would appear here if a new image is added to a mosaic via the
-    `Mosaic` plugin. Like `Contents`, the log is sorted by channel, and then
-    by image name.
+    ``Mosaic`` plugin. Like ``Contents``, the log is sorted by channel, and
+    then by image name.
 
     Notes
     -----
@@ -28,7 +28,7 @@ class ChangeHistory(GingaPlugin.GlobalPlugin):
     New history can be added, but old history cannot be deleted,
     unless the image/channel itself is deleted.
 
-    The `redo()` method picks up a ``'modified'`` event and displays
+    The ``redo()`` method picks up a ``'modified'`` event and displays
     related metadata here. The metadata is obtained as follows:
 
     .. code-block:: python
@@ -275,10 +275,3 @@ class ChangeHistory(GingaPlugin.GlobalPlugin):
 
     def __str__(self):
         return 'changehistory'
-
-
-# Replace module docstring with config doc for auto insert by Sphinx.
-# In the future, if we need the real docstring, we can append instead of
-# overwrite.
-from ginga.util.toolbox import generate_cfg_example  # noqa
-__doc__ = generate_cfg_example('plugin_ChangeHistory', package='ginga')


### PR DESCRIPTION
Stop override of plugin docstrings so `WBrowser` can display its native docstring when RTD download option failed. This should not change the visual of current RTD rendered doc.

Fix #464

TODO:
- [ ] Investigate the best way to insert config contents into RST.
- [ ] Implement this for all other affected plugins.
- [ ] Figure out a way to reduce redundancy between plugin RST and docstring management?