### PR TITLE
Update Travis YML and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ MANIFEST
 # Sphinx
 doc/api
 doc/manual/api/
+doc/manual/plugins_global/api/
 doc/manual/plugins_local/api/
 doc/_build
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,8 +59,8 @@ matrix:
         # may run for a long time
         # *** TODO: The `-w` option doesn't work with `python setup.py build_sphinx` yet for `ginga` ... removing it for now
         - python: 2.7
-          # env: SETUP_CMD='build_sphinx -w'
-          env: SETUP_CMD='build_sphinx' PIP_DEPENDENCIES='sphinx_rtd_theme'
+          # env: SETUP_CMD='build_docs -w'
+          env: SETUP_CMD='build_docs' PIP_DEPENDENCIES='sphinx_rtd_theme'
 
         # Try Astropy development version
         # NOTE: Uncomment this if global version is stable, not dev
@@ -86,7 +86,7 @@ matrix:
           env: NUMPY_VERSION=1.9
 
         # Try numpy pre-release
-        - python: 3.5
+        - python: 3.6
           env: NUMPY_VERSION=prerelease
 
         # Do a PEP8 test with pycodestyle


### PR DESCRIPTION
Saw this in test log:
```
/home/travis/build/ejeschke/ginga/astropy_helpers/astropy_helpers/commands/build_sphinx.py:246:
    AstropyDeprecationWarning: The "build_sphinx" command is now deprecated.
    Use"build_docs" instead.

  '"build_docs" instead.', AstropyDeprecationWarning)
```

Also added Python 3.6 to one of the tests and updated `.gitignore`.