### PR TITLE
First step toward generalizing transforms to N dimensions

### DIFF
--- a/ginga/Bindings.py
+++ b/ginga/Bindings.py
@@ -541,14 +541,14 @@ class ImageViewBindings(object):
         arr = np.array([(mnwd, mnht), (mxwd, mnht),
                         (mxwd, mxht), (mnwd, mxht)],
                        dtype=np.float)
-        x, y = tr.to_(arr.T[0], arr.T[1])
+        x, y = tr.to_(arr).T
 
         rx1, rx2 = np.min(x), np.max(x)
         ry1, ry2 = np.min(y), np.max(y)
 
         rect = viewer.get_pan_rect()
         arr = np.array(rect, dtype=np.float)
-        x, y = tr.to_(arr.T[0], arr.T[1])
+        x, y = tr.to_(arr).T
 
         qx1, qx2 = np.min(x), np.max(x)
         qy1, qy2 = np.min(y), np.max(y)
@@ -594,7 +594,7 @@ class ImageViewBindings(object):
         arr = np.array([(mnwd, mnht), (mxwd, mnht),
                         (mxwd, mxht), (mnwd, mxht)],
                        dtype=np.float)
-        x, y = tr.to_(arr.T[0], arr.T[1])
+        x, y = tr.to_(arr).T
 
         rx1, rx2 = np.min(x), np.max(x)
         ry1, ry2 = np.min(y), np.max(y)
@@ -602,7 +602,7 @@ class ImageViewBindings(object):
         crd_x = rx1 + (pct_x * (rx2 - rx1))
         crd_y = ry1 + (pct_y * (ry2 - ry1))
 
-        pan_x, pan_y = tr.from_(crd_x, crd_y)
+        pan_x, pan_y = tr.from_((crd_x, crd_y))
         self.logger.debug("crd=%f,%f pan=%f,%f" % (
             crd_x, crd_y, pan_x, pan_y))
 

--- a/ginga/ImageView.py
+++ b/ginga/ImageView.py
@@ -5,7 +5,7 @@
 # Please see the file LICENSE.txt for details.
 #
 """This module handles image viewers."""
-import numpy
+import numpy as np
 import math
 import logging
 import threading
@@ -20,7 +20,6 @@ from ginga import cmap, imap, colors, trcalc, version
 from ginga.canvas import coordmap, transform
 from ginga.canvas.types.layer import DrawingCanvas
 from ginga.util import rgb_cms
-from ginga.util.six.moves import map
 
 __all__ = ['ImageViewBase']
 
@@ -1366,7 +1365,7 @@ class ImageViewBase(Callback.Callbacks):
         imgwin_wd, imgwin_ht = self.get_window_size()
 
         # create RGBA array for output
-        outarr = numpy.zeros((imgwin_ht, imgwin_wd, depth), dtype='uint8')
+        outarr = np.zeros((imgwin_ht, imgwin_wd, depth), dtype='uint8')
 
         # fill image array with the background color
         r, g, b = self.img_bg
@@ -1431,8 +1430,7 @@ class ImageViewBase(Callback.Callbacks):
 
         # convert to data coordinates
         crdmap = self.get_coordmap(coord)
-        limits = list(map(lambda pt: crdmap.data_to(pt[0], pt[1]),
-                          limits))
+        limits = crdmap.data_to(limits)
 
         return limits
 
@@ -1450,8 +1448,7 @@ class ImageViewBase(Callback.Callbacks):
 
             # convert to data coordinates
             crdmap = self.get_coordmap(coord)
-            limits = list(map(lambda pt: crdmap.to_data(pt[0], pt[1]),
-                              limits))
+            limits = crdmap.to_data(limits)
 
         self._limits = limits
         self.make_callback('limits-set', limits)
@@ -1492,12 +1489,12 @@ class ImageViewBase(Callback.Callbacks):
 
             # create backing image
             depth = len(order)
-            rgba = numpy.zeros((ht, wd, depth), dtype=numpy.uint8)
+            rgba = np.zeros((ht, wd, depth), dtype=np.uint8)
             self._rgbarr = rgba
 
         if (whence <= 2.0) or (self._rgbarr2 is None):
             # Apply any RGB image overlays
-            self._rgbarr2 = numpy.copy(self._rgbarr)
+            self._rgbarr2 = np.copy(self._rgbarr)
             self.overlay_images(self.private_canvas, self._rgbarr2,
                                 whence=whence)
 
@@ -1514,7 +1511,7 @@ class ImageViewBase(Callback.Callbacks):
             # if not applied earlier
             rotimg = self.apply_transforms(rotimg,
                                            self.t_['rot_deg'])
-            rotimg = numpy.ascontiguousarray(rotimg)
+            rotimg = np.ascontiguousarray(rotimg)
 
             self._rgbobj = RGBMap.RGBPlanes(rotimg, order)
 
@@ -1564,7 +1561,7 @@ class ImageViewBase(Callback.Callbacks):
         b2 = max(yul, yur, ylr, yll)
 
         # constrain to integer indexes
-        x1, y1, x2, y2 = int(a1), int(b1), int(round(a2)), int(round(b2))
+        x1, y1, x2, y2 = int(a1), int(b1), int(np.round(a2)), int(np.round(b2))
         x1 = max(0, x1)
         y1 = max(0, y1)
 
@@ -1644,7 +1641,7 @@ class ImageViewBase(Callback.Callbacks):
         if rot_deg != 0:
             # This is the slowest part of the rendering--install the OpenCv or pyopencl
             # packages to speed it up
-            data = numpy.ascontiguousarray(data)
+            data = np.ascontiguousarray(data)
             data = trcalc.rotate_clip(data, -rot_deg, out=data,
                                       logger=self.logger)
 
@@ -1654,7 +1651,7 @@ class ImageViewBase(Callback.Callbacks):
         if self._invert_y:
             # Flip Y for natural natural Y-axis inversion between FITS coords
             # and screen coords
-            data = numpy.flipud(data)
+            data = np.flipud(data)
 
         self.logger.debug("rotate time %.3f sec, total reshape %.3f sec" % (
             split2_time - split_time, split2_time - start_time))
@@ -1770,7 +1767,8 @@ class ImageViewBase(Callback.Callbacks):
         if center is not None:
             self.logger.warn("`center` keyword is ignored and will be deprecated")
 
-        return self.tform['data_to_window'].from_(win_x, win_y)
+        arr_pts = np.asarray((win_x, win_y)).T
+        return self.tform['data_to_window'].from_(arr_pts).T
 
     def offset_to_data(self, off_x, off_y, center=None):
         """Get the closest coordinates in the data array to those
@@ -1790,7 +1788,8 @@ class ImageViewBase(Callback.Callbacks):
         if center is not None:
             self.logger.warn("`center` keyword is ignored and will be deprecated")
 
-        return self.tform['data_to_cartesian'].from_(off_x, off_y)
+        arr_pts = np.asarray((off_x, off_y)).T
+        return self.tform['data_to_cartesian'].from_(arr_pts).T
 
     def get_canvas_xy(self, data_x, data_y, center=None):
         """Reverse of :meth:`get_data_xy`.
@@ -1799,7 +1798,8 @@ class ImageViewBase(Callback.Callbacks):
         if center is not None:
             self.logger.warn("`center` keyword is ignored and will be deprecated")
 
-        return self.tform['data_to_window'].to_(data_x, data_y)
+        arr_pts = np.asarray((data_x, data_y)).T
+        return self.tform['data_to_window'].to_(arr_pts).T
 
     def data_to_offset(self, data_x, data_y, center=None):
         """Reverse of :meth:`offset_to_data`.
@@ -1808,7 +1808,8 @@ class ImageViewBase(Callback.Callbacks):
         if center is not None:
             self.logger.warn("`center` keyword is ignored and will be deprecated")
 
-        return self.tform['data_to_cartesian'].to_(data_x, data_y)
+        arr_pts = np.asarray((data_x, data_y)).T
+        return self.tform['data_to_cartesian'].to_(arr_pts).T
 
     def offset_to_window(self, off_x, off_y):
         """Convert data offset to window coordinates.
@@ -1824,11 +1825,13 @@ class ImageViewBase(Callback.Callbacks):
             Offset in window coordinates in the form of ``(x, y)``.
 
         """
-        return self.tform['cartesian_to_window'].to_(off_x, off_y)
+        arr_pts = np.asarray((off_x, off_y)).T
+        return self.tform['cartesian_to_window'].to_(arr_pts).T
 
     def window_to_offset(self, win_x, win_y):
         """Reverse of :meth:`offset_to_window`."""
-        return self.tform['cartesian_to_window'].from_(win_x, win_y)
+        arr_pts = np.asarray((win_x, win_y)).T
+        return self.tform['cartesian_to_window'].from_(arr_pts).T
 
     def canvascoords(self, data_x, data_y, center=None):
         """Same as :meth:`get_canvas_xy`.
@@ -1838,7 +1841,8 @@ class ImageViewBase(Callback.Callbacks):
             self.logger.warn("`center` keyword is ignored and will be deprecated")
 
         # data->canvas space coordinate conversion
-        return self.tform['data_to_window'].to_(data_x, data_y)
+        arr_pts = np.asarray((data_x, data_y)).T
+        return self.tform['data_to_window'].to_(arr_pts).T
 
     def get_data_pct(self, xpct, ypct):
         """Calculate new data size for the given axis ratios.
@@ -1872,12 +1876,9 @@ class ImageViewBase(Callback.Callbacks):
             from lower-left to lower-right.
 
         """
-        points = []
         wd, ht = self.get_window_size()
-        for x, y in ((0, 0), (wd-1, 0), (wd-1, ht-1), (0, ht-1)):
-            c, d = self.get_data_xy(x, y)
-            points.append((c, d))
-        return points
+        arr_pts = np.asarray([(0, 0), (wd-1, 0), (wd-1, ht-1), (0, ht-1)])
+        return self.tform['data_to_window'].from_(arr_pts)
 
     def get_data(self, data_x, data_y):
         """Get the data value at the given position.
@@ -1921,8 +1922,8 @@ class ImageViewBase(Callback.Callbacks):
         """
         dx = abs(x2 - x1)
         dy = abs(y2 - y1)
-        dist = math.sqrt(dx*dx + dy*dy)
-        dist = round(dist)
+        dist = np.sqrt(dx*dx + dy*dy)
+        dist = np.round(dist)
         return dist
 
     def _sanity_check_scale(self, scale_x, scale_y):

--- a/ginga/canvas/CanvasObject.py
+++ b/ginga/canvas/CanvasObject.py
@@ -361,10 +361,11 @@ class CanvasObjectBase(Callback.Callbacks):
 
         # convert points
         data_pts = self.get_data_points()
-        self.points = tomap.data_to(data_pts)
 
         # set our map to the new map
         self.crdmap = tomap
+
+        self.set_data_points(data_pts)
 
     # TODO: move these into utility module?
     #####
@@ -494,16 +495,27 @@ class CanvasObjectBase(Callback.Callbacks):
         crdmap = viewer.get_coordmap('native')
         return crdmap.data_to(points)
 
-    def get_bbox(self):
+    def get_llur_pts(self, points):
+        points = np.asarray(points)
+        t_ = points.T
+        x1, y1 = t_[0].min(), t_[1].min()
+        x2, y2 = t_[0].max(), t_[1].max()
+        return (x1, y1, x2, y2)
+
+    def get_bbox(self, points=None):
         """
-        Get lower-left and upper-right coordinates of the bounding box
-        of this compound object.
+        Get bounding box of this object.
 
         Returns
         -------
-        x1, y1, x2, y2: a 4-tuple of the lower-left and upper-right coords
+        (p1, p2, p3, p4): a 4-tuple of the points in data coordinates,
+        beginning with the lower-left and proceeding counter-clockwise.
         """
-        x1, y1, x2, y2 = self.get_llur()
+        if points is None:
+            x1, y1, x2, y2 = self.get_llur()
+        else:
+            x1, y1, x2, y2 = self.get_llur_pts(points)
+
         return ((x1, y1), (x1, y2), (x2, y2), (x2, y1))
 
 

--- a/ginga/canvas/CanvasObject.py
+++ b/ginga/canvas/CanvasObject.py
@@ -491,7 +491,7 @@ class CanvasObjectBase(Callback.Callbacks):
             ctr_x, ctr_y = self.get_center_pt()
             points = trcalc.rotate_coord(points, self.rot_deg, (ctr_x, ctr_y))
 
-        crdmap = viewer.get_coordmap('canvas')
+        crdmap = viewer.get_coordmap('native')
         return crdmap.data_to(points)
 
     def get_bbox(self):

--- a/ginga/canvas/CanvasObject.py
+++ b/ginga/canvas/CanvasObject.py
@@ -4,13 +4,11 @@
 # This is open-source software licensed under a BSD license.
 # Please see the file LICENSE.txt for details.
 #
-import math
-import numpy
+import numpy as np
 from collections import namedtuple
 
 from ginga.misc import Callback, Bunch
 from ginga import trcalc, colors
-from ginga.util.six.moves import map
 
 from . import coordmap
 
@@ -116,7 +114,7 @@ class CanvasObjectBase(Callback.Callbacks):
         return False
 
     def contains_arr(self, x_arr, y_arr):
-        contains = numpy.asarray([False] * len(x_arr))
+        contains = np.asarray([False] * len(x_arr))
         return contains
 
     def contains(self, x, y):
@@ -170,25 +168,25 @@ class CanvasObjectBase(Callback.Callbacks):
             return cpt
 
         cpoints = tuple([ _map_cpt(points[i], cpoints[i])
-                    for i in range(len(points)) ])
+                          for i in range(len(points)) ])
         self.draw_caps(cr, 'ball', cpoints)
 
     def calc_radius(self, viewer, p1, p2):
         x1, y1 = p1
         x2, y2 = p2
         # TODO: the accuracy of this calculation of radius might be improved?
-        radius = math.sqrt(abs(y2 - y1)**2 + abs(x2 - x1)**2)
+        radius = np.sqrt(abs(y2 - y1)**2 + abs(x2 - x1)**2)
         return (x1, y1, radius)
 
     def calc_vertexes(self, start_cx, start_cy, end_cx, end_cy,
                      arrow_length=10, arrow_degrees=0.35):
 
-        angle = math.atan2(end_cy - start_cy, end_cx - start_cx) + math.pi
+        angle = np.arctan2(end_cy - start_cy, end_cx - start_cx) + np.pi
 
-        cx1 = end_cx + arrow_length * math.cos(angle - arrow_degrees);
-        cy1 = end_cy + arrow_length * math.sin(angle - arrow_degrees);
-        cx2 = end_cx + arrow_length * math.cos(angle + arrow_degrees);
-        cy2 = end_cy + arrow_length * math.sin(angle + arrow_degrees);
+        cx1 = end_cx + arrow_length * np.cos(angle - arrow_degrees);
+        cy1 = end_cy + arrow_length * np.sin(angle - arrow_degrees);
+        cx2 = end_cx + arrow_length * np.cos(angle + arrow_degrees);
+        cy2 = end_cy + arrow_length * np.sin(angle + arrow_degrees);
 
         return (cx1, cy1, cx2, cy2)
 
@@ -215,25 +213,25 @@ class CanvasObjectBase(Callback.Callbacks):
 
         Points are returned in *data* coordinates.
         """
-        points = list(map(lambda pt: self.crdmap.to_data(pt[0], pt[1]),
-                          self.points))
+        points = self.crdmap.to_data(self.points)
         return points
 
     def get_data_points(self, points=None):
         if points is None:
             points = self.points
-        points = list(map(lambda pt: self.crdmap.to_data(pt[0], pt[1]),
-                          points))
+        points = self.crdmap.to_data(points)
         return points
 
     def set_data_points(self, points):
-        points = list(map(lambda pt: self.crdmap.data_to(pt[0], pt[1]),
-                          points))
-        self.points = points
+        """
+        Input points must be in data coordinates, will be converted
+        to the coordinate space of the object.
+        """
+        self.points = np.asarray(self.crdmap.data_to(points))
 
     def rotate(self, theta_deg, xoff=0, yoff=0):
-        points = numpy.asarray(self.get_data_points(), dtype=numpy.double)
-        points = trcalc.rotate_coord(points, theta_deg, [xoff, yoff])
+        points = np.asarray(self.get_data_points(), dtype=np.double)
+        points = trcalc.rotate_coord(points, theta_deg, (xoff, yoff))
         self.set_data_points(points)
 
     def rotate_by(self, theta_deg):
@@ -242,15 +240,12 @@ class CanvasObjectBase(Callback.Callbacks):
 
     def rerotate_by(self, theta_deg, detail):
         ref_x, ref_y = detail.center_pos
-        points = numpy.asarray(detail.points, dtype=numpy.double)
-        points = trcalc.rotate_coord(points, theta_deg, [ref_x, ref_y])
+        points = np.asarray(detail.points, dtype=np.double)
+        points = trcalc.rotate_coord(points, theta_deg, (ref_x, ref_y))
         self.set_data_points(points)
 
     def move_delta(self, xoff, yoff):
-        ## self.points = list(map(
-        ##     lambda pt: self.crdmap.offset_pt(pt, xoff, yoff),
-        ##     self.points))
-        points = numpy.asarray(self.get_data_points(), dtype=numpy.double)
+        points = np.asarray(self.get_data_points(), dtype=np.double)
         points.T[0] += xoff
         points.T[1] += yoff
         self.set_data_points(points)
@@ -263,26 +258,27 @@ class CanvasObjectBase(Callback.Callbacks):
         return(len(self.points))
 
     def set_point_by_index(self, i, pt):
-        points = self.get_data_points()
-        points[i] = pt
-        self.set_data_points(points)
+        #self.points[i] = self.crdmap.data_to(pt)
+        # Can we eventually use something like the above?
+        points = np.asarray(self.points, dtype=np.float)
+        points[i] = self.crdmap.data_to(pt)
+        self.points = points
 
     def get_point_by_index(self, i):
-        points = self.get_data_points()
-        return points[i]
+        return self.crdmap.to_data(self.points[i])
 
     def scale_by(self, scale_x, scale_y):
         ctr_x, ctr_y = self.get_center_pt()
-        pts = numpy.asarray(self.get_data_points(), dtype=numpy.double)
-        pts[:, 0] = (pts[:, 0] - ctr_x) * scale_x + ctr_x
-        pts[:, 1] = (pts[:, 1] - ctr_y) * scale_y + ctr_y
+        pts = np.asarray(self.get_data_points(), dtype=np.double)
+        pts = np.add(np.multiply(np.subtract(pts, (ctr_x, ctr_y)),
+                                 (scale_x, scale_y)), (ctr_x, ctr_y))
         self.set_data_points(pts)
 
     def rescale_by(self, scale_x, scale_y, detail):
         ctr_x, ctr_y = detail.center_pos
-        pts = numpy.asarray(detail.points, dtype=numpy.double)
-        pts[:, 0] = (pts[:, 0] - ctr_x) * scale_x + ctr_x
-        pts[:, 1] = (pts[:, 1] - ctr_y) * scale_y + ctr_y
+        pts = np.asarray(detail.points, dtype=np.double)
+        pts = np.add(np.multiply(np.subtract(pts, (ctr_x, ctr_y)),
+                                 (scale_x, scale_y)), (ctr_x, ctr_y))
         self.set_data_points(pts)
 
     def setup_edit(self, detail):
@@ -294,10 +290,10 @@ class CanvasObjectBase(Callback.Callbacks):
         ctr_x, ctr_y = detail.center_pos
         start_x, start_y = detail.start_pos
         # calc angle of starting point wrt origin
-        deg1 = math.degrees(math.atan2(start_y - ctr_y,
-                                       start_x - ctr_x))
+        deg1 = np.degrees(np.arctan2(start_y - ctr_y,
+                                     start_x - ctr_x))
         # calc angle of current point wrt origin
-        deg2 = math.degrees(math.atan2(y - ctr_y, x - ctr_x))
+        deg2 = np.degrees(np.arctan2(y - ctr_y, x - ctr_x))
         delta_deg = deg2 - deg1
         return delta_deg
 
@@ -307,10 +303,10 @@ class CanvasObjectBase(Callback.Callbacks):
         start_x, start_y = detail.start_pos
         dx, dy = start_x - ctr_x, start_y - ctr_y
         # calc distance of starting point wrt origin
-        dist1 = math.sqrt(dx**2.0 + dy**2.0)
+        dist1 = np.sqrt(dx**2.0 + dy**2.0)
         dx, dy = x - ctr_x, y - ctr_y
         # calc distance of current point wrt origin
-        dist2 = math.sqrt(dx**2.0 + dy**2.0)
+        dist2 = np.sqrt(dx**2.0 + dy**2.0)
         scale_f = dist2 / dist1
         return scale_f
 
@@ -341,36 +337,31 @@ class CanvasObjectBase(Callback.Callbacks):
             xc, yc = self.get_center_pt()
             # get data coordinates of a point radius away from center
             # under current coordmap
-            x1, y1 = frommap.to_data(xc, yc)
-            x2, y2 = frommap.to_data(xc + self.radius, yc)
-            x3, y3 = frommap.to_data(xc, yc + self.radius)
+            x1, y1 = frommap.to_data((xc, yc))
+            x2, y2 = frommap.to_data((xc + self.radius, yc))
+            x3, y3 = frommap.to_data((xc, yc + self.radius))
             # now convert these data coords to native coords in tomap
-            nx1, ny1 = tomap.data_to(x1, y1)
-            nx2, ny2 = tomap.data_to(x2, y2)
-            nx3, ny3 = tomap.data_to(x3, y3)
+            nx1, ny1 = tomap.data_to((x1, y1))
+            nx2, ny2 = tomap.data_to((x2, y2))
+            nx3, ny3 = tomap.data_to((x3, y3))
             # recalculate radius using new coords
-            self.radius = math.sqrt((nx2 - nx1)**2 + (ny3 - ny1)**2)
+            self.radius = np.sqrt((nx2 - nx1)**2 + (ny3 - ny1)**2)
 
         elif hasattr(self, 'xradius'):
             # similar to above case, but there are 2 radii
             xc, yc = self.get_center_pt()
-            x1, y1 = frommap.to_data(xc, yc)
-            x2, y2 = frommap.to_data(xc + self.xradius, yc)
-            x3, y3 = frommap.to_data(xc, yc + self.yradius)
-            nx1, ny1 = tomap.data_to(x1, y1)
-            nx2, ny2 = tomap.data_to(x2, y2)
-            nx3, ny3 = tomap.data_to(x3, y3)
-            self.xradius = math.fabs(nx2 - nx1)
-            self.yradius = math.fabs(ny3 - ny1)
+            x1, y1 = frommap.to_data((xc, yc))
+            x2, y2 = frommap.to_data((xc + self.xradius, yc))
+            x3, y3 = frommap.to_data((xc, yc + self.yradius))
+            nx1, ny1 = tomap.data_to((x1, y1))
+            nx2, ny2 = tomap.data_to((x2, y2))
+            nx3, ny3 = tomap.data_to((x3, y3))
+            self.xradius = np.fabs((nx2 - nx1))
+            self.yradius = np.fabs((ny3 - ny1))
 
         # convert points
-        for i in range(self.get_num_points()):
-            # convert each point by going to data coords under old map
-            # and then to native coords in the new map
-            x, y = self.get_point_by_index(i)
-            data_x, data_y = frommap.to_data(x, y)
-            new_x, new_y = tomap.data_to(data_x, data_y)
-            self.set_point_by_index(i, (new_x, new_y))
+        data_pts = self.get_data_points()
+        self.points = tomap.data_to(data_pts)
 
         # set our map to the new map
         self.crdmap = tomap
@@ -383,9 +374,9 @@ class CanvasObjectBase(Callback.Callbacks):
         Return True if point (a, b) is within the circle defined by
         a center at point (x, y) and within canvas_radius.
         """
-        dx = numpy.fabs(x - a_arr) * scale_x
-        dy = numpy.fabs(y - b_arr) * scale_y
-        new_radius = numpy.sqrt(dx**2 + dy**2)
+        dx = np.fabs(x - a_arr) * scale_x
+        dy = np.fabs(y - b_arr) * scale_y
+        new_radius = np.sqrt(dx**2 + dy**2)
         res = (new_radius <= canvas_radius)
         return res
 
@@ -425,16 +416,16 @@ class CanvasObjectBase(Callback.Callbacks):
         r = canvas_radius
         xmin, xmax = min(x1, x2) - r, max(x1, x2) + r
         ymin, ymax = min(y1, y2) - r, max(y1, y2) + r
-        div = numpy.sqrt((x2 - x1)**2 + (y2 - y1)**2)
+        div = np.sqrt((x2 - x1)**2 + (y2 - y1)**2)
 
-        d = numpy.fabs((x2 - x1)*(y1 - b_arr) - (x1 - a_arr)*(y2 - y1)) / div
+        d = np.fabs((x2 - x1)*(y1 - b_arr) - (x1 - a_arr)*(y2 - y1)) / div
 
         ## contains = (xmin <= a_arr <= xmax) and (ymin <= b_arr <= ymax) and \
         ##            (d <= canvas_radius)
-        contains = numpy.logical_and(
-            numpy.logical_and(xmin <= a_arr, a_arr <= xmax),
-            numpy.logical_and(d <= canvas_radius,
-                              numpy.logical_and(ymin <= b_arr, b_arr <= ymax)))
+        contains = np.logical_and(
+            np.logical_and(xmin <= a_arr, a_arr <= xmax),
+            np.logical_and(d <= canvas_radius,
+                              np.logical_and(ymin <= b_arr, b_arr <= ymax)))
         return contains
 
     def within_line(self, viewer, a_arr, b_arr, x1, y1, x2, y2,
@@ -454,11 +445,11 @@ class CanvasObjectBase(Callback.Callbacks):
     def get_center_pt(self):
         """Return the geometric average of points as data_points.
         """
-        P = numpy.asarray(self.get_data_points(), dtype=numpy.double)
+        P = np.asarray(self.get_data_points(), dtype=np.double)
         x = P[:, 0]
         y = P[:, 1]
-        ctr_x = numpy.sum(x) / float(len(x))
-        ctr_y = numpy.sum(y) / float(len(y))
+        ctr_x = np.sum(x) / float(len(x))
+        ctr_y = np.sum(y) / float(len(y))
         return ctr_x, ctr_y
 
     def get_reference_pt(self):
@@ -491,19 +482,17 @@ class CanvasObjectBase(Callback.Callbacks):
         return (move_pt, scale_pt, rotate_pt)
 
     def get_cpoints(self, viewer, points=None, no_rotate=False):
+        # If points are passed, they are assumed to be in data space
         if points is None:
             points = self.get_points()
-
-        points = numpy.asarray(points)
 
         if (not no_rotate) and hasattr(self, 'rot_deg') and self.rot_deg != 0.0:
             # rotate vertices according to rotation
             ctr_x, ctr_y = self.get_center_pt()
             points = trcalc.rotate_coord(points, self.rot_deg, (ctr_x, ctr_y))
 
-        cpoints = tuple(map(lambda p: self.canvascoords(viewer, p[0], p[1]),
-                            points))
-        return cpoints
+        crdmap = viewer.get_coordmap('canvas')
+        return crdmap.data_to(points)
 
     def get_bbox(self):
         """

--- a/ginga/canvas/CompoundMixin.py
+++ b/ginga/canvas/CompoundMixin.py
@@ -5,7 +5,7 @@
 # Please see the file LICENSE.txt for details.
 #
 import sys, traceback
-import numpy
+import numpy as np
 
 from ginga.util.six.moves import map, zip, reduce, filter
 from ginga.canvas import coordmap
@@ -29,7 +29,7 @@ class CompoundMixin(object):
         if not hasattr(self, 'coord'):
             self.coord = None
         self.opaque = False
-        self._contains_reduce = numpy.logical_or
+        self._contains_reduce = np.logical_or
 
     def get_llur(self):
         """
@@ -40,7 +40,7 @@ class CompoundMixin(object):
         -------
         x1, y1, x2, y2: a 4-tuple of the lower-left and upper-right coords
         """
-        points = numpy.array(list(map(lambda obj: obj.get_llur(),
+        points = np.array(list(map(lambda obj: obj.get_llur(),
                                       self.objects)))
         t_ = points.T
         x1, y1 = min(t_[0].min(), t_[0].min()), min(t_[1].min(), t_[3].min())
@@ -53,14 +53,14 @@ class CompoundMixin(object):
 
     def contains_arr(self, x_arr, y_arr):
         if len(self.objects) == 0:
-            return numpy.full(x_arr.shape, False, dtype=numpy.bool)
+            return np.full(x_arr.shape, False, dtype=np.bool)
 
         return reduce(self._contains_reduce,
                       map(lambda obj: obj.contains_arr(x_arr, y_arr),
                           self.objects))
 
     def contains(self, x, y):
-        x_arr, y_arr = numpy.array([x]), numpy.array([y])
+        x_arr, y_arr = np.array([x]), np.array([y])
         res = self.contains_arr(x_arr, y_arr)
         return res[0]
 
@@ -235,10 +235,10 @@ class CompoundMixin(object):
     def get_reference_pt(self):
         # Reference point for a compound object is the average of all
         # it's contituents reference points
-        points = numpy.asarray([ obj.get_reference_pt()
+        points = np.asarray([ obj.get_reference_pt()
                                  for obj in self.objects ])
         t_ = points.T
-        x, y = numpy.average(t_[0]), numpy.average(t_[1])
+        x, y = np.average(t_[0]), np.average(t_[1])
         return (x, y)
 
     def move_to(self, xdst, ydst):

--- a/ginga/canvas/DrawingMixin.py
+++ b/ginga/canvas/DrawingMixin.py
@@ -180,7 +180,7 @@ class DrawingMixin(object):
         obj = None
 
         # update the context with current position
-        x, y = cxt.crdmap.data_to(data_x, data_y)
+        x, y = cxt.crdmap.data_to((data_x, data_y))
         cxt.setvals(x=x, y=y, data_x=data_x, data_y=data_y)
 
         draw_class = cxt.draw_class
@@ -208,7 +208,7 @@ class DrawingMixin(object):
         # get the drawing coordinate type (default 'data')
         crdtype = self.t_drawparams.get('coord', 'data')
         crdmap = viewer.get_coordmap(crdtype)
-        x, y = crdmap.data_to(data_x, data_y)
+        x, y = crdmap.data_to((data_x, data_y))
 
         klass = self.draw_dict.get(self.t_drawtype, None)
 
@@ -254,10 +254,10 @@ class DrawingMixin(object):
 
         cxt = self._draw_cxt
         if self.t_drawtype in ('polygon', 'freepolygon', 'path', 'freepath'):
-            x, y = cxt.crdmap.data_to(data_x, data_y)
+            x, y = cxt.crdmap.data_to((data_x, data_y))
             cxt.points.append((x, y))
         elif self.t_drawtype == 'beziercurve' and len(cxt.points) < 3:
-            x, y = cxt.crdmap.data_to(data_x, data_y)
+            x, y = cxt.crdmap.data_to((data_x, data_y))
             cxt.points.append((x, y))
 
         self._draw_update(data_x, data_y, cxt, force_update=True)
@@ -541,7 +541,7 @@ class DrawingMixin(object):
             if insert is not None:
                 self.logger.debug("inserting point")
                 # Point near a line
-                pt = obj.crdmap.data_to(data_x, data_y)
+                pt = obj.crdmap.data_to((data_x, data_y))
                 obj.insert_pt(insert, pt)
                 self.process_drawing()
             else:
@@ -677,12 +677,12 @@ class DrawingMixin(object):
 
         # leaving an object
         for obj in newly_out:
-            pt = obj.crdmap.data_to(data_x, data_y)
+            pt = obj.crdmap.data_to((data_x, data_y))
             obj.make_callback('pick-leave', canvas, event, pt)
 
         # entering an object
         for obj in newly_in:
-            pt = obj.crdmap.data_to(data_x, data_y)
+            pt = obj.crdmap.data_to((data_x, data_y))
             obj.make_callback('pick-enter', canvas, event, pt)
 
         # pick down/up
@@ -690,7 +690,7 @@ class DrawingMixin(object):
             self.logger.debug("%s event in %s obj at x, y = %d, %d" % (
                 cb_name, obj.kind, data_x, data_y))
 
-            pt = obj.crdmap.data_to(data_x, data_y)
+            pt = obj.crdmap.data_to((data_x, data_y))
             obj.make_callback(cb_name, canvas, event, pt)
 
         return True

--- a/ginga/canvas/coordmap.py
+++ b/ginga/canvas/coordmap.py
@@ -59,8 +59,6 @@ class CanvasMapper(BaseMapper):
             viewer = self.viewer
 
         cvs_arr = np.asarray(cvs_pts)
-        cvs_arr = viewer.tform['canvas_to_window'].from_(cvs_arr)
-        # flip Y axis for certain backends
         return viewer.tform['data_to_window'].from_(cvs_arr)
 
     def data_to(self, data_pts, viewer=None):
@@ -68,9 +66,7 @@ class CanvasMapper(BaseMapper):
             viewer = self.viewer
 
         data_arr = np.asarray(data_pts)
-        cvs_arr = viewer.tform['data_to_window'].to_(data_arr)
-        # flip Y axis for certain backends
-        return viewer.tform['canvas_to_window'].to_(cvs_arr)
+        return viewer.tform['data_to_window'].to_(data_arr)
 
     def offset_pt(self, pts, offset):
         return np.add(pts, offset)

--- a/ginga/canvas/coordmap.py
+++ b/ginga/canvas/coordmap.py
@@ -74,7 +74,7 @@ class NativeMapper(BaseMapper):
 
     def rotate_pt(self, pts, theta, offset):
         # TODO?  Not sure if it is needed with this mapper type
-        return x, y
+        return pts
 
 
 class WindowMapper(BaseMapper):
@@ -103,7 +103,7 @@ class WindowMapper(BaseMapper):
 
     def rotate_pt(self, pts, theta, offset):
         # TODO?  Not sure if it is needed with this mapper type
-        return x, y
+        return pts
 
 
 class CartesianMapper(BaseMapper):

--- a/ginga/canvas/coordmap.py
+++ b/ginga/canvas/coordmap.py
@@ -4,6 +4,8 @@
 # This is open-source software licensed under a BSD license.
 # Please see the file LICENSE.txt for details.
 #
+import numpy as np
+
 from ginga import trcalc
 from ginga.util import wcs
 from ginga.util.six.moves import map
@@ -23,23 +25,23 @@ class BaseMapper(object):
     def to_canvas(self, canvas_x, canvas_y):
         raise CoordMapError("this method is deprecated")
 
-    def to_data(self, canvas_x, canvas_y):
+    def to_data(self, pts):
         raise CoordMapError("subclass should override this method")
 
-    def data_to(self, data_x, data_y):
+    def data_to(self, pts):
         raise CoordMapError("subclass should override this method")
 
-    def offset_pt(self, pt, xoff, yoff):
+    def offset_pt(self, pts, offset):
         """
-        Offset a point specified by `pt`, by the offsets (`xoff`, `yoff`).
+        Offset a point specified by `pt`, by the offsets `offset`.
         Coordinates are assumed to be in the space defined by this mapper.
         """
         raise CoordMapError("subclass should override this method")
 
-    def rotate_pt(self, x, y, theta, xoff=0, yoff=0):
+    def rotate_pt(self, pts, theta, offset=None):
         """
-        Rotate a point specified by (`x`, `y`) by the angle `theta` (in degrees)
-        around the point indicated by (`xoff`, `yoff`).
+        Rotate a point specified by `pt` by the angle `theta` (in degrees)
+        around the point indicated by `offset`.
         Coordinates are assumed to be in the space defined by this mapper.
         """
         raise CoordMapError("subclass should override this method")
@@ -52,29 +54,28 @@ class CanvasMapper(BaseMapper):
         super(CanvasMapper, self).__init__()
         self.viewer = viewer
 
-    def to_data(self, canvas_x, canvas_y, viewer=None):
+    def to_data(self, cvs_pts, viewer=None):
         if viewer is None:
             viewer = self.viewer
 
-        canvas_x, canvas_y = viewer.tform['canvas_to_window'].from_(canvas_x,
-                                                                    canvas_y)
+        cvs_arr = np.asarray(cvs_pts)
+        cvs_arr = viewer.tform['canvas_to_window'].from_(cvs_arr)
         # flip Y axis for certain backends
-        return viewer.tform['data_to_window'].from_(canvas_x, canvas_y)
+        return viewer.tform['data_to_window'].from_(cvs_arr)
 
-    def data_to(self, data_x, data_y, viewer=None):
+    def data_to(self, data_pts, viewer=None):
         if viewer is None:
             viewer = self.viewer
 
-        canvas_x, canvas_y = viewer.tform['data_to_window'].to_(data_x,
-                                                                data_y)
+        data_arr = np.asarray(data_pts)
+        cvs_arr = viewer.tform['data_to_window'].to_(data_arr)
         # flip Y axis for certain backends
-        return viewer.tform['canvas_to_window'].to_(canvas_x, canvas_y)
+        return viewer.tform['canvas_to_window'].to_(cvs_arr)
 
-    def offset_pt(self, pt, xoff, yoff):
-        x, y = pt
-        return x + xoff, y + yoff
+    def offset_pt(self, pts, offset):
+        return np.add(pts, offset)
 
-    def rotate_pt(self, x, y, theta, xoff=0, yoff=0):
+    def rotate_pt(self, pts, theta, offset):
         # TODO?  Not sure if it is needed with this mapper type
         return x, y
 
@@ -87,22 +88,26 @@ class CartesianMapper(BaseMapper):
         super(CartesianMapper, self).__init__()
         self.viewer = viewer
 
-    def to_data(self, crt_x, crt_y, viewer=None):
+    def to_data(self, crt_pts, viewer=None):
         if viewer is None:
             viewer = self.viewer
-        return viewer.tform['data_to_cartesian'].from_(crt_x, crt_y)
+        crt_arr = np.asarray(crt_pts)
+        return viewer.tform['data_to_cartesian'].from_(crt_arr)
 
-    def data_to(self, data_x, data_y, viewer=None):
+    def data_to(self, data_pts, viewer=None):
         if viewer is None:
             viewer = self.viewer
-        return viewer.tform['data_to_cartesian'].to_(data_x, data_y)
+        data_arr = np.asarray(data_pts)
+        return viewer.tform['data_to_cartesian'].to_(data_arr)
 
-    def offset_pt(self, pt, xoff, yoff):
-        x, y = pt
-        return x + xoff, y + yoff
+    def offset_pt(self, pts, offset):
+        return np.add(pts, offset)
 
-    def rotate_pt(self, x, y, theta, xoff=0, yoff=0):
-        return trcalc.rotate_pt(x, y, theta, xoff=xoff, yoff=yoff)
+    def rotate_pt(self, pts, theta, offset):
+        x, y = np.asarray(pts).T
+        xoff, yoff = np.transpose(offset)
+        rot_x, rot_y = trcalc.rotate_pt(x, y, theta, xoff=xoff, yoff=yoff)
+        return np.asarray((rot_x, rot_y)).T
 
 
 class DataMapper(BaseMapper):
@@ -113,18 +118,20 @@ class DataMapper(BaseMapper):
         super(DataMapper, self).__init__()
         self.viewer = viewer
 
-    def to_data(self, data_x, data_y, viewer=None):
-        return data_x, data_y
+    def to_data(self, data_pts, viewer=None):
+        return data_pts
 
-    def data_to(self, data_x, data_y, viewer=None):
-        return data_x, data_y
+    def data_to(self, data_pts, viewer=None):
+        return data_pts
 
-    def offset_pt(self, pt, xoff, yoff):
-        x, y = pt
-        return x + xoff, y + yoff
+    def offset_pt(self, pts, offset):
+        return np.add(pts, offset)
 
-    def rotate_pt(self, x, y, theta, xoff=0, yoff=0):
-        return trcalc.rotate_pt(x, y, theta, xoff=xoff, yoff=yoff)
+    def rotate_pt(self, pts, theta, offset):
+        x, y = np.asarray(pts).T
+        xoff, yoff = np.transpose(offset)
+        rot_x, rot_y = trcalc.rotate_pt(x, y, theta, xoff=xoff, yoff=yoff)
+        return np.asarray((rot_x, rot_y)).T
 
 
 class OffsetMapper(BaseMapper):
@@ -138,33 +145,29 @@ class OffsetMapper(BaseMapper):
         self.viewer = viewer
         self.refobj = refobj
 
-    def calc_offsets(self, points):
-        ref_x, ref_y = self.refobj.get_reference_pt()
-        #return map(lambda x, y: x - ref_x, y - ref_y, points)
-        def _cvt(pt):
-            x, y = pt
-            return x - ref_x, y - ref_y
-        return map(_cvt, points)
+    def calc_offsets(self, pts):
+        ref_pt = self.refobj.get_reference_pt()
+        return np.subtract(pts, ref_pt)
 
-    def to_data(self, delta_x, delta_y, viewer=None):
+    def to_data(self, delta_pt, viewer=None):
         if viewer is None:
             viewer = self.viewer
-        ref_x, ref_y = self.refobj.get_reference_pt()
-        data_x, data_y = self.refobj.crdmap.to_data(ref_x, ref_y, viewer=viewer)
-        return data_x + delta_x, data_y + delta_y
+        ref_pt = self.refobj.get_reference_pt()
+        data_pt = self.refobj.crdmap.to_data(ref_pt, viewer=viewer)
+        return np.add(data_pt, delta_pt)
 
-    def data_to(self, data_x, data_y, viewer=None):
-        ref_x, ref_y = self.refobj.get_reference_pt()
-        return data_x - ref_x, data_y - ref_y
+    def data_to(self, data_pts, viewer=None):
+        ref_pt = self.refobj.get_reference_pt()
+        return np.subtract(data_pts, ref_pt)
 
-    def offset_pt(self, pt, xoff, yoff):
+    def offset_pt(self, pts, offset):
         # A no-op because this object's points are always considered
         # relative to the reference object
         return pt
 
-    def rotate_pt(self, x, y, theta, xoff=0, yoff=0):
+    def rotate_pt(self, pts, theta, offset):
         # TODO?  Not sure if it is needed with this mapper type
-        return x, y
+        return pts
 
 
 class WCSMapper(BaseMapper):
@@ -177,31 +180,35 @@ class WCSMapper(BaseMapper):
         self.viewer = viewer
         self.data_mapper = data_mapper
 
-    def to_data(self, lon, lat, viewer=None):
+    def to_data(self, wcs_pts, viewer=None):
         if viewer is None:
             viewer = self.viewer
-        return viewer.tform['wcs_to_data'].to_(lon, lat)
+        return viewer.tform['wcs_to_data'].to_(wcs_pts)
 
-    def data_to(self, data_x, data_y, viewer=None):
+    def data_to(self, data_pts, viewer=None):
         if viewer is None:
             viewer = self.viewer
-        return viewer.tform['wcs_to_data'].from_(data_x, data_y)
+        data_arr = np.asarray(data_pts)
+        return viewer.tform['wcs_to_data'].from_(data_arr)
 
-    def offset_pt(self, pt, xoff, yoff):
-        x, y = pt
-        return wcs.add_offset_radec(x, y, xoff, yoff)
+    def offset_pt(self, pts, offset):
+        x, y = np.transpose(pts)
+        xoff, yoff = np.transpose(offset)
+        res_arr = wcs.add_offset_radec(x, y, xoff, yoff)
+        return np.transpose(res_arr)
 
-    def rotate_pt(self, x, y, theta, xoff=0, yoff=0):
+    def rotate_pt(self, pts, theta, offset):
         # TODO: rotate in WCS space?
         # rotate in data space
-        xoff, yoff = self.to_data(xoff, yoff)
-        data_x, data_y = self.to_data(x, y)
+        data_off = self.to_data(offset)
+        data_pts = self.to_data(pts)
 
-        rot_x, rot_y = trcalc.rotate_pt(data_x, data_y, theta,
-                                        xoff=xoff, yoff=yoff)
+        xoff, yoff = numpy.transpose(data_off)
+        data_x, data_y = data_pts.T
+        data_rot = trcalc.rotate_pt(data_x, data_y, theta,
+                                    xoff=xoff, yoff=yoff)
 
-        x, y = self.data_to(rot_x, rot_y)
-        return x, y
+        return self.data_to(data_rot.T)
 
 
 #END

--- a/ginga/canvas/transform.py
+++ b/ginga/canvas/transform.py
@@ -275,16 +275,22 @@ class WCSDataTransform(BaseTransform):
         image = self.viewer.get_image()
         if image is None:
             raise TransformError("No image, no WCS")
+        wcs = image.wcs
+        if wcs is None:
+            raise TransformError("No valid WCS found in image")
 
-        return image.wcspt_to_datapt(wcs_pts)
+        return wcs.wcspt_to_datapt(wcs_pts)
 
     def from_(self, data_pts):
         data_pts = np.asarray(data_pts)
         image = self.viewer.get_image()
         if image is None:
             raise TransformError("No image, no WCS")
+        wcs = image.wcs
+        if wcs is None:
+            raise TransformError("No valid WCS found in image")
 
-        return image.datapt_to_wcspt(data_pts)
+        return wcs.datapt_to_wcspt(data_pts)
 
 
 #END

--- a/ginga/canvas/types/astro.py
+++ b/ginga/canvas/types/astro.py
@@ -8,7 +8,7 @@
 from __future__ import absolute_import, division, print_function
 
 import math
-import numpy
+import numpy as np
 
 from ginga.AstroImage import AstroImage
 from ginga.canvas.CanvasObject import (CanvasObjectBase, _bool, _color,
@@ -166,8 +166,8 @@ class Ruler(TwoPointMixin, CanvasObjectBase):
         points = self.get_points()
         x1, y1 = points[0]
         x2, y2 = points[1]
-        cx1, cy1 = self.canvascoords(viewer, x1, y1)
-        cx2, cy2 = self.canvascoords(viewer, x2, y2)
+        cx1, cy1 = viewer.get_canvas_xy(x1, y1)
+        cx2, cy2 = viewer.get_canvas_xy(x2, y2)
 
         text_x, text_y, text_h = self.get_ruler_distances(viewer)
 
@@ -327,7 +327,7 @@ class Compass(OnePointOneRadiusMixin, CanvasObjectBase):
             raise ValueError("No point corresponding to index %d" % (i))
 
     def select_contains(self, viewer, data_x, data_y):
-        xd, yd = self.crdmap.to_data(self.x, self.y)
+        xd, yd = self.crdmap.to_data((self.x, self.y))
         return self.within_radius(viewer, data_x, data_y, xd, yd,
                                   self.cap_radius)
 
@@ -458,7 +458,7 @@ class Crosshair(OnePointMixin, CanvasObjectBase):
         OnePointMixin.__init__(self)
 
     def select_contains(self, viewer, data_x, data_y):
-        xd, yd = self.crdmap.to_data(self.x, self.y)
+        xd, yd = self.crdmap.to_data((self.x, self.y))
         return self.within_radius(viewer, data_x, data_y, xd, yd,
                                   self.cap_radius)
 
@@ -507,14 +507,14 @@ class AnnulusMixin(object):
     def contains(self, x, y):
         """Containment test."""
         obj1, obj2 = self.objects
-        return obj2.contains(x, y) and numpy.logical_not(obj1.contains(x, y))
+        return obj2.contains(x, y) and np.logical_not(obj1.contains(x, y))
 
     def contains_arr(self, x_arr, y_arr):
         """Containment test on arrays."""
         obj1, obj2 = self.objects
         arg1 = obj2.contains_arr(x_arr, y_arr)
-        arg2 = numpy.logical_not(obj1.contains_arr(x_arr, y_arr))
-        return numpy.logical_and(arg1, arg2)
+        arg2 = np.logical_not(obj1.contains_arr(x_arr, y_arr))
+        return np.logical_and(arg1, arg2)
 
     def get_llur(self):
         """Bounded by outer object."""
@@ -620,9 +620,9 @@ class Annulus(AnnulusMixin, OnePointOneRadiusMixin, CompoundObject):
     def get_edit_points(self, viewer):
         points = ((self.x, self.y),
                   self.crdmap.offset_pt((self.x, self.y),
-                                        self.radius, 0),
+                                        (self.radius, 0)),
                   self.crdmap.offset_pt((self.x, self.y),
-                                        self.radius + self.width, 0),
+                                        (self.radius + self.width, 0)),
                   )
         points = self.get_data_points(points=points)
         return [MovePoint(*points[0]),
@@ -758,8 +758,8 @@ class WCSAxes(CompoundObject):
         # Calculate positions of RA/DEC lines
         d_ra = ra_size / (self.num_ra + 1)
         d_dec = dec_size / (self.num_dec + 1)
-        ra_arr = numpy.arange(ra_min + d_ra, ra_max - d_ra * 0.5, d_ra)
-        dec_arr = numpy.arange(dec_min + d_dec, dec_max - d_ra * 0.5, d_dec)
+        ra_arr = np.arange(ra_min + d_ra, ra_max - d_ra * 0.5, d_ra)
+        dec_arr = np.arange(dec_min + d_dec, dec_max - d_ra * 0.5, d_dec)
 
         # RA/DEC step size for each vector
         min_imsize = min(image.width, image.height)
@@ -771,12 +771,12 @@ class WCSAxes(CompoundObject):
 
         for cur_ra in ra_arr:
             crds = [[cur_ra, cur_dec] for cur_dec in
-                    numpy.arange(dec_min, dec_max + d_dec_step, d_dec_step)]
+                    np.arange(dec_min, dec_max + d_dec_step, d_dec_step)]
             lbl = raDegToString(cur_ra)
             objs += self._get_path(viewer, image, crds, lbl, 1)
         for cur_dec in dec_arr:
             crds = [[cur_ra, cur_dec] for cur_ra in
-                    numpy.arange(ra_min, ra_max + d_ra_step, d_ra_step)]
+                    np.arange(ra_min, ra_max + d_ra_step, d_ra_step)]
             lbl = decDegToString(cur_dec)
             objs += self._get_path(viewer, image, crds, lbl, 0)
 
@@ -816,7 +816,7 @@ class WCSAxes(CompoundObject):
                 y = m * x + c + self.txt_off
             else:  # y axis varying
                 y = min(y1, y2) + abs(dy) * 0.45
-                if numpy.isfinite(m):
+                if np.isfinite(m):
                     x = (y - c) / m
                 else:
                     x = min(x1, x2)

--- a/ginga/canvas/types/astro.py
+++ b/ginga/canvas/types/astro.py
@@ -14,7 +14,7 @@ from ginga.AstroImage import AstroImage
 from ginga.canvas.CanvasObject import (CanvasObjectBase, _bool, _color,
                                        Point, MovePoint, ScalePoint,
                                        register_canvas_types, get_canvas_type,
-                                       colors_plus_none)
+                                       colors_plus_none, coord_names)
 from ginga.misc.ParamSet import Param
 from ginga.util import wcs
 from ginga.util.wcs import raDegToString, decDegToString
@@ -38,9 +38,9 @@ class Ruler(TwoPointMixin, CanvasObjectBase):
     @classmethod
     def get_params_metadata(cls):
         return [
-            ## Param(name='coord', type=str, default='data',
-            ##       valid=['data', 'wcs'],
-            ##       description="Set type of coordinates"),
+            Param(name='coord', type=str, default='data',
+                  valid=coord_names,
+                  description="Set type of coordinates"),
             Param(name='x1', type=float, default=0.0, argpos=0,
                   description="First X coordinate of object"),
             Param(name='y1', type=float, default=0.0, argpos=1,
@@ -150,7 +150,7 @@ class Ruler(TwoPointMixin, CanvasObjectBase):
             else:
                 dx = abs(x2 - x1)
                 dy = abs(y2 - y1)
-                dh = math.sqrt(dx**2 + dy**2)
+                dh = np.sqrt(dx**2 + dy**2)
                 text_x = ("%.3f" % dx)
                 text_y = ("%.3f" % dy)
                 text_h = ("%.3f" % dh)
@@ -253,9 +253,9 @@ class Compass(OnePointOneRadiusMixin, CanvasObjectBase):
     @classmethod
     def get_params_metadata(cls):
         return [
-            ## Param(name='coord', type=str, default='data',
-            ##       valid=['data'],
-            ##       description="Set type of coordinates"),
+            Param(name='coord', type=str, default='data',
+                  valid=coord_names,
+                  description="Set type of coordinates"),
             Param(name='x', type=float, default=0.0, argpos=0,
                   description="X coordinate of center of object"),
             Param(name='y', type=float, default=0.0, argpos=1,
@@ -406,9 +406,9 @@ class Crosshair(OnePointMixin, CanvasObjectBase):
     @classmethod
     def get_params_metadata(cls):
         return [
-            ## Param(name='coord', type=str, default='data',
-            ##       valid=['data'],
-            ##       description="Set type of coordinates"),
+            Param(name='coord', type=str, default='data',
+                  valid=coord_names,
+                  description="Set type of coordinates"),
             Param(name='x', type=float, default=0.0, argpos=0,
                   description="X coordinate of center of object"),
             Param(name='y', type=float, default=0.0, argpos=1,
@@ -541,9 +541,9 @@ class Annulus(AnnulusMixin, OnePointOneRadiusMixin, CompoundObject):
     @classmethod
     def get_params_metadata(cls):
         return [
-            ## Param(name='coord', type=str, default='data',
-            ##       valid=['data', 'wcs'],
-            ##       description="Set type of coordinates"),
+            Param(name='coord', type=str, default='data',
+                  valid=coord_names,
+                  description="Set type of coordinates"),
             Param(name='x', type=float, default=0.0, argpos=0,
                   description="X coordinate of center of object"),
             Param(name='y', type=float, default=0.0, argpos=1,
@@ -573,8 +573,8 @@ class Annulus(AnnulusMixin, OnePointOneRadiusMixin, CompoundObject):
 
     @classmethod
     def idraw(cls, canvas, cxt):
-        radius = math.sqrt(abs(cxt.start_x - cxt.x)**2 +
-                           abs(cxt.start_y - cxt.y)**2)
+        radius = np.sqrt(abs(cxt.start_x - cxt.x)**2 +
+                         abs(cxt.start_y - cxt.y)**2)
         return cls(cxt.start_x, cxt.start_y, radius,
                    **cxt.drawparams)
 

--- a/ginga/canvas/types/astro.py
+++ b/ginga/canvas/types/astro.py
@@ -745,7 +745,7 @@ class WCSAxes(CompoundObject):
         xmax = image.width - 1
         ymax = image.height - 1
         try:
-            radec = image.wcs.datapt_to_coords(
+            radec = image.wcs.datapt_to_system(
                 [[0, 0], [0, ymax], [xmax, 0], [xmax, ymax]],
                 naxispath=image.naxispath)
         except Exception:

--- a/ginga/canvas/types/basic.py
+++ b/ginga/canvas/types/basic.py
@@ -1598,7 +1598,7 @@ class XRange(Rectangle):
 
     def get_edit_points(self, viewer):
         win_wd, win_ht = viewer.get_window_size()
-        crdmap = viewer.get_coordmap('canvas')
+        crdmap = viewer.get_coordmap('window')
         dx, dy = crdmap.to_data((0, win_ht // 2))
         pt = self.get_data_points(points=self.get_points())
         return [ MovePoint((pt[0][0] + pt[2][0]) / 2.0, dy),
@@ -1702,7 +1702,7 @@ class YRange(Rectangle):
 
     def get_edit_points(self, viewer):
         win_wd, win_ht = viewer.get_window_size()
-        crdmap = viewer.get_coordmap('canvas')
+        crdmap = viewer.get_coordmap('window')
         dx, dy = crdmap.to_data((win_wd // 2, 0))
         pt = self.get_data_points(points=self.get_points())
         return [ MovePoint(dx, (pt[0][1] + pt[2][1]) / 2.0),

--- a/ginga/canvas/types/basic.py
+++ b/ginga/canvas/types/basic.py
@@ -4,8 +4,7 @@
 # This is open-source software licensed under a BSD license.
 # Please see the file LICENSE.txt for details.
 #
-import math
-import numpy
+import numpy as np
 
 from ginga.canvas.CanvasObject import (CanvasObjectBase, _bool, _color,
                                        Point as XPoint, MovePoint, ScalePoint,
@@ -15,6 +14,7 @@ from ginga.canvas.CanvasObject import (CanvasObjectBase, _bool, _color,
 from ginga import trcalc
 from ginga.misc.ParamSet import Param
 from ginga.util import wcs, bezier
+from ginga.util.six.moves import map
 
 from .mixins import (OnePointMixin, TwoPointMixin, OnePointOneRadiusMixin,
                      OnePointTwoRadiusMixin, PolygonMixin)
@@ -85,7 +85,7 @@ class Text(OnePointMixin, CanvasObjectBase):
         cr.set_font_from_shape(self)
 
         x, y = self.get_data_points()[0]
-        cx, cy = self.canvascoords(viewer, x, y)
+        cx, cy = viewer.get_canvas_xy(x, y)
         cr.draw_text(cx, cy, self.text, rot_deg=self.rot_deg)
 
         if self.showcap:
@@ -166,6 +166,7 @@ class Polygon(PolygonMixin, CanvasObjectBase):
         cr = viewer.renderer.setup_cr(self)
 
         cpoints = self.get_cpoints(viewer)
+
         cr.draw_polygon(cpoints)
 
         if self.showcap:
@@ -233,7 +234,7 @@ class Path(PolygonMixin, CanvasObjectBase):
             if contains is None:
                 contains = res
             else:
-                contains = numpy.logical_or(contains, res)
+                contains = np.logical_or(contains, res)
             x1, y1 = x2, y2
         return contains
 
@@ -242,7 +243,7 @@ class Path(PolygonMixin, CanvasObjectBase):
                                         radius=radius)
 
     def contains(self, data_x, data_y):
-        x_arr, y_arr = numpy.array([data_x]), numpy.array([data_y])
+        x_arr, y_arr = np.array([data_x]), np.array([data_y])
         res = self.contains_arr(x_arr, y_arr)
         return res[0]
 
@@ -338,11 +339,11 @@ class BezierCurve(Path):
         wd, ht = image.get_size()
         if getvalues:
             res = [ data[int(y), int(x)]
-                    if 0 <= x < wd and 0 <= y < ht else numpy.NaN
+                    if 0 <= x < wd and 0 <= y < ht else np.NaN
                     for x, y in self.get_points_on_curve(image) ]
         else:
             res = [ (int(x), int(y))
-                    if 0 <= x < wd and 0 <= y < ht else numpy.NaN
+                    if 0 <= x < wd and 0 <= y < ht else np.NaN
                     for x, y in self.get_points_on_curve(image) ]
         return res
 
@@ -444,13 +445,13 @@ class Box(OnePointTwoRadiusMixin, CanvasObjectBase):
 
     def get_points(self):
         points = (self.crdmap.offset_pt((self.x, self.y),
-                                        -self.xradius, -self.yradius),
+                                        (-self.xradius, -self.yradius)),
                   self.crdmap.offset_pt((self.x, self.y),
-                                        self.xradius, -self.yradius),
+                                        (self.xradius, -self.yradius)),
                   self.crdmap.offset_pt((self.x, self.y),
-                                        self.xradius, self.yradius),
+                                        (self.xradius, self.yradius)),
                   self.crdmap.offset_pt((self.x, self.y),
-                                        -self.xradius, self.yradius),
+                                        (-self.xradius, self.yradius)),
                   )
         points = self.get_data_points(points=points)
         return points
@@ -461,17 +462,17 @@ class Box(OnePointTwoRadiusMixin, CanvasObjectBase):
         x2, y2 = points[2]
 
         # rotate points back to non-rotated cartesian alignment for test
-        xd, yd = self.crdmap.to_data(self.x, self.y)
+        xd, yd = self.crdmap.to_data((self.x, self.y))
         xa, ya = trcalc.rotate_pt(x_arr, y_arr, -self.rot_deg,
                                   xoff=xd, yoff=yd)
 
-        contains = numpy.logical_and(
-            numpy.logical_and(min(x1, x2) <= xa, xa <= max(x1, x2)),
-            numpy.logical_and(min(y1, y2) <= ya, ya <= max(y1, y2)))
+        contains = np.logical_and(
+            np.logical_and(min(x1, x2) <= xa, xa <= max(x1, x2)),
+            np.logical_and(min(y1, y2) <= ya, ya <= max(y1, y2)))
         return contains
 
     def contains(self, data_x, data_y):
-        x_arr, y_arr = numpy.array([data_x]), numpy.array([data_y])
+        x_arr, y_arr = np.array([data_x]), np.array([data_y])
         res = self.contains_arr(x_arr, y_arr)
         return res[0]
 
@@ -559,18 +560,18 @@ class SquareBox(OnePointOneRadiusMixin, CanvasObjectBase):
 
     def get_points(self):
         points = (self.crdmap.offset_pt((self.x, self.y),
-                                        -self.radius, -self.radius),
+                                        (-self.radius, -self.radius)),
                   self.crdmap.offset_pt((self.x, self.y),
-                                        self.radius, -self.radius),
+                                        (self.radius, -self.radius)),
                   self.crdmap.offset_pt((self.x, self.y),
-                                        self.radius, self.radius),
+                                        (self.radius, self.radius)),
                   self.crdmap.offset_pt((self.x, self.y),
-                                        -self.radius, self.radius))
+                                        (-self.radius, self.radius)))
         points = self.get_data_points(points=points)
         return points
 
     def rotate_by(self, theta_deg):
-        new_rot = math.fmod(self.rot_deg + theta_deg, 360.0)
+        new_rot = np.fmod(self.rot_deg + theta_deg, 360.0)
         self.rot_deg = new_rot
         return new_rot
 
@@ -580,17 +581,17 @@ class SquareBox(OnePointOneRadiusMixin, CanvasObjectBase):
         x2, y2 = points[2]
 
         # rotate point back to cartesian alignment for test
-        xd, yd = self.crdmap.to_data(self.x, self.y)
+        xd, yd = self.crdmap.to_data((self.x, self.y))
         xa, ya = trcalc.rotate_pt(x_arr, y_arr, -self.rot_deg,
                                   xoff=xd, yoff=yd)
 
-        contains = numpy.logical_and(
-            numpy.logical_and(min(x1, x2) <= xa, xa <= max(x1, x2)),
-            numpy.logical_and(min(y1, y2) <= ya, ya <= max(y1, y2)))
+        contains = np.logical_and(
+            np.logical_and(min(x1, x2) <= xa, xa <= max(x1, x2)),
+            np.logical_and(min(y1, y2) <= ya, ya <= max(y1, y2)))
         return contains
 
     def contains(self, data_x, data_y):
-        x_arr, y_arr = numpy.array([data_x]), numpy.array([data_y])
+        x_arr, y_arr = np.array([data_x]), np.array([data_y])
         res = self.contains_arr(x_arr, y_arr)
         return res[0]
 
@@ -609,7 +610,7 @@ class SquareBox(OnePointOneRadiusMixin, CanvasObjectBase):
     def get_edit_points(self, viewer):
         points = self.get_data_points(points=(
             self.crdmap.offset_pt((self.x, self.y),
-                                  self.radius, self.radius),
+                                  (self.radius, self.radius)),
             ))
         move_pt, scale_pt, rotate_pt = self.get_move_scale_rotate_pts(viewer)
         return [move_pt,
@@ -703,19 +704,19 @@ class Ellipse(OnePointTwoRadiusMixin, CanvasObjectBase):
     def get_points(self):
         points = ((self.x, self.y),
                   self.crdmap.offset_pt((self.x, self.y),
-                                        self.xradius, 0),
+                                        (self.xradius, 0)),
                   self.crdmap.offset_pt((self.x, self.y),
-                                        0, self.yradius),
+                                        (0, self.yradius)),
                   self.crdmap.offset_pt((self.x, self.y),
-                                        self.xradius, self.yradius),
+                                        (self.xradius, self.yradius)),
                   )
         points = self.get_data_points(points=points)
         return points
 
     def contains_arr(self, x_arr, y_arr):
         # coerce args to floats
-        x_arr = x_arr.astype(numpy.float)
-        y_arr = y_arr.astype(numpy.float)
+        x_arr = x_arr.astype(np.float)
+        y_arr = y_arr.astype(np.float)
 
         points = self.get_points()
         # rotate point back to cartesian alignment for test
@@ -735,15 +736,15 @@ class Ellipse(OnePointTwoRadiusMixin, CanvasObjectBase):
         return contains
 
     def contains(self, data_x, data_y):
-        x_arr, y_arr = numpy.array([data_x]), numpy.array([data_y])
+        x_arr, y_arr = np.array([data_x]), np.array([data_y])
         res = self.contains_arr(x_arr, y_arr)
         return res[0]
 
     def get_llur(self):
         # See http://stackoverflow.com/questions/87734/how-do-you-calculate-the-axis-aligned-bounding-box-of-an-ellipse
-        theta = math.radians(self.rot_deg)
-        sin_theta = math.sin(theta)
-        cos_theta = math.cos(theta)
+        theta = np.radians(self.rot_deg)
+        sin_theta = np.sin(theta)
+        cos_theta = np.cos(theta)
 
         # need to recalculate radius in case of wcs coords
         points = self.get_points()
@@ -755,8 +756,8 @@ class Ellipse(OnePointTwoRadiusMixin, CanvasObjectBase):
         b = yradius * sin_theta
         c = xradius * sin_theta
         d = yradius * cos_theta
-        wd = math.sqrt(a ** 2.0 + b ** 2.0) * 2.
-        ht = math.sqrt(c ** 2.0 + d ** 2.0) * 2.
+        wd = np.sqrt(a ** 2.0 + b ** 2.0) * 2.
+        ht = np.sqrt(c ** 2.0 + d ** 2.0) * 2.
 
         x1, y1 = x - wd * 0.5, y + ht * 0.5
         x2, y2 = x1 + wd, y1 - ht
@@ -874,18 +875,18 @@ class Triangle(OnePointTwoRadiusMixin, CanvasObjectBase):
 
     def get_points(self):
         points = (self.crdmap.offset_pt((self.x, self.y),
-                                        -2*self.xradius, -self.yradius),
+                                        (-2*self.xradius, -self.yradius)),
                   self.crdmap.offset_pt((self.x, self.y),
-                                        2*self.xradius, -self.yradius),
+                                        (2*self.xradius, -self.yradius)),
                   self.crdmap.offset_pt((self.x, self.y),
-                                        0, self.yradius),
+                                        (0, self.yradius)),
                   )
         points = self.get_data_points(points=points)
         return points
 
     def get_llur(self):
-        xd, yd = self.crdmap.to_data(self.x, self.y)
-        points = numpy.asarray(self.get_points(), dtype=numpy.double)
+        xd, yd = self.crdmap.to_data((self.x, self.y))
+        points = np.asarray(self.get_points(), dtype=np.double)
 
         mpts = trcalc.rotate_coord(points, self.rot_deg, [xd, yd])
         t_ = mpts.T
@@ -904,8 +905,8 @@ class Triangle(OnePointTwoRadiusMixin, CanvasObjectBase):
         (x1, y1), (x2, y2), (x3, y3) = self.get_points()
 
         # coerce args to floats
-        x_arr = x_arr.astype(numpy.float)
-        y_arr = y_arr.astype(numpy.float)
+        x_arr = x_arr.astype(np.float)
+        y_arr = y_arr.astype(np.float)
 
         # barycentric coordinate test
         denominator = float((y2 - y3)*(x1 - x3) + (x3 - x2)*(y1 - y3))
@@ -914,14 +915,14 @@ class Triangle(OnePointTwoRadiusMixin, CanvasObjectBase):
         c = 1.0 - a - b
 
         #tf = (0.0 <= a <= 1.0 and 0.0 <= b <= 1.0 and 0.0 <= c <= 1.0)
-        contains = numpy.logical_and(
-            numpy.logical_and(0.0 <= a, a <= 1.0),
-            numpy.logical_and(numpy.logical_and(0.0 <= b, b <= 1.0),
-                              numpy.logical_and(0.0 <= c, c <= 1.0)))
+        contains = np.logical_and(
+            np.logical_and(0.0 <= a, a <= 1.0),
+            np.logical_and(np.logical_and(0.0 <= b, b <= 1.0),
+                              np.logical_and(0.0 <= c, c <= 1.0)))
         return contains
 
     def contains(self, data_x, data_y):
-        x_arr, y_arr = numpy.array([data_x]), numpy.array([data_y])
+        x_arr, y_arr = np.array([data_x]), np.array([data_y])
         res = self.contains_arr(x_arr, y_arr)
         return res[0]
 
@@ -984,8 +985,8 @@ class Circle(OnePointOneRadiusMixin, CanvasObjectBase):
 
     @classmethod
     def idraw(cls, canvas, cxt):
-        radius = math.sqrt(abs(cxt.start_x - cxt.x)**2 +
-                           abs(cxt.start_y - cxt.y)**2 )
+        radius = np.sqrt(abs(cxt.start_x - cxt.x)**2 +
+                         abs(cxt.start_y - cxt.y)**2 )
         return cls(cxt.start_x, cxt.start_y, radius, **cxt.drawparams)
 
     def __init__(self, x, y, radius, color='yellow',
@@ -1002,20 +1003,20 @@ class Circle(OnePointOneRadiusMixin, CanvasObjectBase):
         self.kind = 'circle'
 
     def contains_arr(self, x_arr, y_arr):
-        xd, yd = self.crdmap.to_data(self.x, self.y)
+        xd, yd = self.crdmap.to_data((self.x, self.y))
 
         # need to recalculate radius in case of wcs coords
         points = self.get_data_points(points=(
-            self.crdmap.offset_pt((self.x, self.y), self.radius, 0),
-            self.crdmap.offset_pt((self.x, self.y), 0, self.radius),
+            self.crdmap.offset_pt((self.x, self.y), (self.radius, 0)),
+            self.crdmap.offset_pt((self.x, self.y), (0, self.radius)),
             ))
         (x2, y2), (x3, y3) = points
         xradius = max(x2, xd) - min(x2, xd)
         yradius = max(y3, yd) - min(y3, yd)
 
         # need to make sure to coerce these to floats or it won't work
-        x_arr = x_arr.astype(numpy.float)
-        y_arr = y_arr.astype(numpy.float)
+        x_arr = x_arr.astype(np.float)
+        y_arr = y_arr.astype(np.float)
 
         # See http://math.stackexchange.com/questions/76457/check-if-a-point-is-within-an-ellipse
         res = (((x_arr - xd) ** 2) / xradius ** 2 +
@@ -1024,14 +1025,14 @@ class Circle(OnePointOneRadiusMixin, CanvasObjectBase):
         return contains
 
     def contains(self, data_x, data_y):
-        x_arr, y_arr = numpy.array([data_x]), numpy.array([data_y])
+        x_arr, y_arr = np.array([data_x]), np.array([data_y])
         res = self.contains_arr(x_arr, y_arr)
         return res[0]
 
     def get_edit_points(self, viewer):
         points = self.get_data_points(points=(
             (self.x, self.y),
-            self.crdmap.offset_pt((self.x, self.y), self.radius, 0),
+            self.crdmap.offset_pt((self.x, self.y), (self.radius, 0)),
             ))
         return [MovePoint(*points[0]),
                 ScalePoint(*points[1]),
@@ -1040,9 +1041,9 @@ class Circle(OnePointOneRadiusMixin, CanvasObjectBase):
     def get_llur(self):
         points = self.get_data_points(points=(
             self.crdmap.offset_pt((self.x, self.y),
-                                  -self.radius, -self.radius),
+                                  (-self.radius, -self.radius)),
             self.crdmap.offset_pt((self.x, self.y),
-                                  self.radius, self.radius),
+                                  (self.radius, self.radius)),
             ))
         (x1, y1), (x2, y2) = points
         return self.swapxy(x1, y1, x2, y2)
@@ -1050,7 +1051,7 @@ class Circle(OnePointOneRadiusMixin, CanvasObjectBase):
     def draw(self, viewer):
         points = self.get_data_points(points=(
             (self.x, self.y),
-            self.crdmap.offset_pt((self.x, self.y), 0, self.radius),
+            self.crdmap.offset_pt((self.x, self.y), (0, self.radius)),
             ))
         cpoints = self.get_cpoints(viewer, points=points)
         cx, cy, cradius = self.calc_radius(viewer,
@@ -1123,18 +1124,18 @@ class Point(OnePointOneRadiusMixin, CanvasObjectBase):
         OnePointOneRadiusMixin.__init__(self)
 
     def contains_arr(self, x_arr, y_arr, radius=2.0):
-        xd, yd = self.crdmap.to_data(self.x, self.y)
+        xd, yd = self.crdmap.to_data((self.x, self.y))
         contains = self.point_within_radius(x_arr, y_arr, xd, yd,
                                             radius)
         return contains
 
     def contains(self, data_x, data_y, radius=1):
-        x_arr, y_arr = numpy.array([data_x]), numpy.array([data_y])
+        x_arr, y_arr = np.array([data_x]), np.array([data_y])
         res = self.contains_arr(x_arr, y_arr, radius=radius)
         return res[0]
 
     def select_contains(self, viewer, data_x, data_y):
-        xd, yd = self.crdmap.to_data(self.x, self.y)
+        xd, yd = self.crdmap.to_data((self.x, self.y))
         return self.within_radius(viewer, data_x, data_y, xd, yd,
                                   self.cap_radius)
 
@@ -1146,7 +1147,7 @@ class Point(OnePointOneRadiusMixin, CanvasObjectBase):
     def draw(self, viewer):
         points = self.get_data_points(points=(
             (self.x, self.y),
-            self.crdmap.offset_pt((self.x, self.y), 0, self.radius),
+            self.crdmap.offset_pt((self.x, self.y), (0, self.radius)),
             ))
         cpoints = self.get_cpoints(viewer, points=points)
         cx, cy, cradius = self.calc_radius(viewer,
@@ -1250,9 +1251,9 @@ class Rectangle(TwoPointMixin, CanvasObjectBase):
     def contains_arr(self, x_arr, y_arr):
         x1, y1, x2, y2 = self.get_llur()
 
-        contains = numpy.logical_and(
-            numpy.logical_and(x1 <= x_arr, x_arr <= x2),
-            numpy.logical_and(y1 <= y_arr, y_arr <= y2))
+        contains = np.logical_and(
+            np.logical_and(x1 <= x_arr, x_arr <= x2),
+            np.logical_and(y1 <= y_arr, y_arr <= y2))
         return contains
 
     def contains(self, data_x, data_y):
@@ -1299,8 +1300,8 @@ class Square(Rectangle):
         len_x = cxt.start_x - cxt.x
         len_y = cxt.start_y - cxt.y
         length = max(abs(len_x), abs(len_y))
-        len_x = numpy.sign(len_x) * length
-        len_y = numpy.sign(len_y) * length
+        len_x = np.sign(len_x) * length
+        len_y = np.sign(len_y) * length
         return cls(cxt.start_x, cxt.start_y,
                    cxt.start_x-len_x, cxt.start_y-len_y,
                    **cxt.drawparams)
@@ -1376,7 +1377,7 @@ class Line(TwoPointMixin, CanvasObjectBase):
         return contains
 
     def contains(self, data_x, data_y, radius=1.0):
-        x_arr, y_arr = numpy.array([data_x]), numpy.array([data_y])
+        x_arr, y_arr = np.array([data_x]), np.array([data_y])
         res = self.contains_arr(x_arr, y_arr, radius=radius)
         return res[0]
 
@@ -1391,8 +1392,8 @@ class Line(TwoPointMixin, CanvasObjectBase):
         points = self.get_points()
         x1, y1 = points[0]
         x2, y2 = points[1]
-        cx1, cy1 = self.canvascoords(viewer, x1, y1)
-        cx2, cy2 = self.canvascoords(viewer, x2, y2)
+        cx1, cy1 = viewer.get_canvas_xy(x1, y1)
+        cx2, cy2 = viewer.get_canvas_xy(x2, y2)
 
         cr = viewer.renderer.setup_cr(self)
         cr.draw_line(cx1, cy1, cx2, cy2)
@@ -1493,8 +1494,8 @@ class RightTriangle(TwoPointMixin, CanvasObjectBase):
         x3, y3 = points[2]
 
         # coerce args to floats
-        x_arr = x_arr.astype(numpy.float)
-        y_arr = y_arr.astype(numpy.float)
+        x_arr = x_arr.astype(np.float)
+        y_arr = y_arr.astype(np.float)
 
         # barycentric coordinate test
         denominator = float((y2 - y3)*(x1 - x3) + (x3 - x2)*(y1 - y3))
@@ -1503,14 +1504,14 @@ class RightTriangle(TwoPointMixin, CanvasObjectBase):
         c = 1.0 - a - b
 
         #tf = (0.0 <= a <= 1.0 and 0.0 <= b <= 1.0 and 0.0 <= c <= 1.0)
-        contains = numpy.logical_and(
-            numpy.logical_and(0.0 <= a, a <= 1.0),
-            numpy.logical_and(numpy.logical_and(0.0 <= b, b <= 1.0),
-                              numpy.logical_and(0.0 <= c, c <= 1.0)))
+        contains = np.logical_and(
+            np.logical_and(0.0 <= a, a <= 1.0),
+            np.logical_and(np.logical_and(0.0 <= b, b <= 1.0),
+                              np.logical_and(0.0 <= c, c <= 1.0)))
         return contains
 
     def contains(self, data_x, data_y):
-        x_arr, y_arr = numpy.array([data_x]), numpy.array([data_y])
+        x_arr, y_arr = np.array([data_x]), np.array([data_y])
         res = self.contains_arr(x_arr, y_arr)
         return res[0]
 
@@ -1587,7 +1588,7 @@ class XRange(Rectangle):
     def contains_arr(self, x_arr, y_arr):
         x1, y1, x2, y2 = self.get_llur()
 
-        contains = numpy.logical_and(x1 <= x_arr, x_arr <= x2)
+        contains = np.logical_and(x1 <= x_arr, x_arr <= x2)
         return contains
 
     def contains(self, data_x, data_y):
@@ -1598,7 +1599,7 @@ class XRange(Rectangle):
     def get_edit_points(self, viewer):
         win_wd, win_ht = viewer.get_window_size()
         crdmap = viewer.get_coordmap('canvas')
-        dx, dy = crdmap.to_data(0, win_ht // 2)
+        dx, dy = crdmap.to_data((0, win_ht // 2))
         pt = self.get_data_points(points=self.get_points())
         return [ MovePoint((pt[0][0] + pt[2][0]) / 2.0, dy),
                  EditPoint(pt[0][0], dy),
@@ -1691,7 +1692,7 @@ class YRange(Rectangle):
     def contains_arr(self, x_arr, y_arr):
         x1, y1, x2, y2 = self.get_llur()
 
-        contains = numpy.logical_and(y1 <= y_arr, y_arr <= y2)
+        contains = np.logical_and(y1 <= y_arr, y_arr <= y2)
         return contains
 
     def contains(self, data_x, data_y):
@@ -1702,7 +1703,7 @@ class YRange(Rectangle):
     def get_edit_points(self, viewer):
         win_wd, win_ht = viewer.get_window_size()
         crdmap = viewer.get_coordmap('canvas')
-        dx, dy = crdmap.to_data(win_wd // 2, 0)
+        dx, dy = crdmap.to_data((win_wd // 2, 0))
         pt = self.get_data_points(points=self.get_points())
         return [ MovePoint(dx, (pt[0][1] + pt[2][1]) / 2.0),
                  EditPoint(dx, pt[0][1]),

--- a/ginga/canvas/types/image.py
+++ b/ginga/canvas/types/image.py
@@ -9,7 +9,7 @@ import numpy as np
 from ginga.canvas.CanvasObject import (CanvasObjectBase, _bool, _color,
                                        Point, MovePoint, ScalePoint,
                                        register_canvas_types,
-                                       colors_plus_none)
+                                       colors_plus_none, coord_names)
 from ginga.misc.ParamSet import Param
 from ginga.misc import Bunch
 from ginga import trcalc
@@ -26,9 +26,9 @@ class Image(OnePointMixin, CanvasObjectBase):
     @classmethod
     def get_params_metadata(cls):
         return [
-            ## Param(name='coord', type=str, default='data',
-            ##       valid=['data'],
-            ##       description="Set type of coordinates"),
+            Param(name='coord', type=str, default='data',
+                  valid=coord_names,
+                  description="Set type of coordinates"),
             Param(name='x', type=float, default=0.0, argpos=0,
                   description="X coordinate of corner of object"),
             Param(name='y', type=float, default=0.0, argpos=1,
@@ -319,9 +319,9 @@ class NormImage(Image):
     @classmethod
     def get_params_metadata(cls):
         return [
-            ## Param(name='coord', type=str, default='data',
-            ##       valid=['data'],
-            ##       description="Set type of coordinates"),
+            Param(name='coord', type=str, default='data',
+                  valid=coord_names,
+                  description="Set type of coordinates"),
             Param(name='x', type=float, default=0.0, argpos=0,
                   description="X coordinate of corner of object"),
             Param(name='y', type=float, default=0.0, argpos=1,

--- a/ginga/canvas/types/image.py
+++ b/ginga/canvas/types/image.py
@@ -4,7 +4,7 @@
 # This is open-source software licensed under a BSD license.
 # Please see the file LICENSE.txt for details.
 #
-import numpy
+import numpy as np
 
 from ginga.canvas.CanvasObject import (CanvasObjectBase, _bool, _color,
                                        Point, MovePoint, ScalePoint,
@@ -149,12 +149,12 @@ class Image(OnePointMixin, CanvasObjectBase):
             ((x0, y0), (x1, y1), (x2, y2), (x3, y3)) = viewer.get_pan_rect()
             xmin = int(min(x0, x1, x2, x3))
             ymin = int(min(y0, y1, y2, y3))
-            xmax = int(numpy.ceil(max(x0, x1, x2, x3)))
-            ymax = int(numpy.ceil(max(y0, y1, y2, y3)))
+            xmax = int(np.ceil(max(x0, x1, x2, x3)))
+            ymax = int(np.ceil(max(y0, y1, y2, y3)))
 
             # destination location in data_coords
             #dst_x, dst_y = self.x, self.y + ht
-            dst_x, dst_y = self.crdmap.to_data(self.x, self.y)
+            dst_x, dst_y = self.crdmap.to_data((self.x, self.y))
 
             a1, b1, a2, b2 = 0, 0, self.image.width, self.image.height
 
@@ -206,8 +206,8 @@ class Image(OnePointMixin, CanvasObjectBase):
             # dst position in the pre-transformed array should be calculated
             # from the center of the array plus offsets
             ht, wd, dp = dstarr.shape
-            cvs_x = int(round(wd / 2.0  + off_x))
-            cvs_y = int(round(ht / 2.0  + off_y))
+            cvs_x = int(np.round(wd / 2.0  + off_x))
+            cvs_y = int(np.round(ht / 2.0  + off_y))
             cache.cvs_pos = (cvs_x, cvs_y)
 
         # composite the image into the destination array at the
@@ -239,7 +239,7 @@ class Image(OnePointMixin, CanvasObjectBase):
         return (width, height)
 
     def get_coords(self):
-        x1, y1 = self.crdmap.to_data(self.x, self.y)
+        x1, y1 = self.crdmap.to_data((self.x, self.y))
         wd, ht = self.get_scaled_wdht()
         x2, y2 = x1 + wd, y1 + ht
         return (x1, y1, x2, y2)
@@ -388,11 +388,11 @@ class NormImage(Image):
             ((x0, y0), (x1, y1), (x2, y2), (x3, y3)) = viewer.get_pan_rect()
             xmin = int(min(x0, x1, x2, x3))
             ymin = int(min(y0, y1, y2, y3))
-            xmax = int(numpy.ceil(max(x0, x1, x2, x3)))
-            ymax = int(numpy.ceil(max(y0, y1, y2, y3)))
+            xmax = int(np.ceil(max(x0, x1, x2, x3)))
+            ymax = int(np.ceil(max(y0, y1, y2, y3)))
 
             # destination location in data_coords
-            dst_x, dst_y = self.crdmap.to_data(self.x, self.y)
+            dst_x, dst_y = self.crdmap.to_data((self.x, self.y))
 
             a1, b1, a2, b2 = 0, 0, self.image.width, self.image.height
 
@@ -431,8 +431,8 @@ class NormImage(Image):
             # dst position in the pre-transformed array should be calculated
             # from the center of the array plus offsets
             ht, wd, dp = dstarr.shape
-            cvs_x = int(round(wd / 2.0  + off_x))
-            cvs_y = int(round(ht / 2.0  + off_y))
+            cvs_x = int(np.round(wd / 2.0  + off_x))
+            cvs_y = int(np.round(ht / 2.0  + off_y))
             cache.cvs_pos = (cvs_x, cvs_y)
 
         if self.rgbmap is not None:
@@ -446,8 +446,8 @@ class NormImage(Image):
             newdata = self.apply_visuals(viewer, cache.cutout, 0, vmax)
 
             # result becomes an index array fed to the RGB mapper
-            if not numpy.issubdtype(newdata.dtype, numpy.dtype('uint')):
-                newdata = newdata.astype(numpy.uint)
+            if not np.issubdtype(newdata.dtype, np.dtype('uint')):
+                newdata = newdata.astype(np.uint)
             idx = newdata
 
             self.logger.debug("shape of index is %s" % (str(idx.shape)))

--- a/ginga/canvas/types/mixins.py
+++ b/ginga/canvas/types/mixins.py
@@ -281,11 +281,7 @@ class PolygonMixin(object):
         return ctr_x, ctr_y
 
     def get_llur(self):
-        points = np.asarray(self.get_data_points())
-        t_ = points.T
-        x1, y1 = t_[0].min(), t_[1].min()
-        x2, y2 = t_[0].max(), t_[1].max()
-        return (x1, y1, x2, y2)
+        return self.get_llur_pts(self.get_data_points())
 
     def contains_arr(self, x_arr, y_arr):
         # NOTE: we use a version of the ray casting algorithm

--- a/ginga/canvas/types/mixins.py
+++ b/ginga/canvas/types/mixins.py
@@ -23,7 +23,7 @@ class OnePointMixin(object):
 
     def __set_points(self, pts):
         pts = np.asarray(pts)
-        self.x, self.y = pts[0, 0], pts[0, 1]
+        self.x, self.y = pts[0]
 
     points = property(__get_points, __set_points)
 
@@ -63,8 +63,8 @@ class TwoPointMixin(object):
 
     def __set_points(self, pts):
         pts = np.asarray(pts)
-        self.x1, self.y1 = pts[0, 0], pts[0, 1]
-        self.x2, self.y2 = pts[1, 0], pts[1, 1]
+        self.x1, self.y1 = pts[0]
+        self.x2, self.y2 = pts[1]
 
     points = property(__get_points, __set_points)
 

--- a/ginga/canvas/types/utils.py
+++ b/ginga/canvas/types/utils.py
@@ -83,6 +83,7 @@ class ColorBar(CanvasObjectBase):
         loval, hival = viewer.get_cut_levels()
 
         cr = viewer.renderer.setup_cr(self)
+        tr = viewer.tform['window_to_native']
 
         # Calculate reasonable spacing for range numbers
         cr.set_font(self.font, self.fontsize, color=self.color,
@@ -140,7 +141,8 @@ class ColorBar(CanvasObjectBase):
             cr.set_fill(color, alpha=self.fillalpha)
 
             cx1, cy1, cx2, cy2 = x, y_base, x+wd, y_base+clr_ht
-            cr.draw_polygon(((cx1, cy1), (cx2, cy1), (cx2, cy2), (cx1, cy2)))
+            cr.draw_polygon(tr.to_(((cx1, cy1), (cx2, cy1),
+                                    (cx2, cy2), (cx1, cy2))))
 
             # Draw range scale if we are supposed to
             if self.showrange and i in _interval:
@@ -166,25 +168,30 @@ class ColorBar(CanvasObjectBase):
 
             x = 0
             cx1, cy1, cx2, cy2 = x, y_top - scale_ht, x+pxwd, y_top
-            cr.draw_polygon(((cx1, cy1), (cx2, cy1), (cx2, cy2), (cx1, cy2)))
+            cp = tr.to_(((cx1, cy1), (cx2, cy1), (cx2, cy2), (cx1, cy2)))
+            cr.draw_polygon(cp)
 
             cr.set_line(color=self.color, linewidth=1, alpha=self.alpha)
-            cr.draw_line(cx1, cy1, cx2, cy1)
+            #cr.draw_line(cx1, cy1, cx2, cy1)
+            cr.draw_line(cp[0][0], cp[0][1], cp[1][0], cp[1][1])
 
             cr.set_font(self.font, self.fontsize, color=self.color,
                     alpha=self.alpha)
             for (cx, cy, cyy, text) in range_pts:
+                cp = tr.to_(((cx, cy), (cx, cy+self.tick_ht), (cx, cyy-2)))
                 # tick
-                cr.draw_line(cx, cy, cx, cy+self.tick_ht)
+                #cr.draw_line(cx, cy, cx, cy+self.tick_ht)
+                cr.draw_line(cp[0][0], cp[0][1], cp[1][0], cp[1][1])
                 # number
-                cr.draw_text(cx, cyy-2, text)
+                #cr.draw_text(cx, cyy-2, text)
+                cr.draw_text(cp[2][0], cp[2][1], text)
 
         # draw optional border
         if self.linewidth > 0:
             cr.set_fill(self.bgcolor, alpha=0.0)
             cx1, cy1, cx2, cy2 = 0, y_base, wd, y_top
             cpoints = ((cx1, cy1), (cx2, cy1), (cx2, cy2), (cx1, cy2))
-            cr.draw_polygon(cpoints)
+            cr.draw_polygon(tr.to_(cpoints))
 
 
 class DrawableColorBar(Rectangle):
@@ -263,6 +270,7 @@ class DrawableColorBar(Rectangle):
         loval, hival = viewer.get_cut_levels()
 
         cr = viewer.renderer.setup_cr(self)
+        tr = viewer.tform['window_to_native']
 
         # Calculate reasonable spacing for range numbers
         cr.set_font(self.font, self.fontsize, color=self.color,
@@ -316,7 +324,8 @@ class DrawableColorBar(Rectangle):
             cr.set_fill(color, alpha=self.fillalpha)
 
             cx1, cy1, cx2, cy2 = x, y_base, x+wd, y_base+clr_ht
-            cr.draw_polygon(((cx1, cy1), (cx2, cy1), (cx2, cy2), (cx1, cy2)))
+            cr.draw_polygon(tr.to_(((cx1, cy1), (cx2, cy1),
+                                    (cx2, cy2), (cx1, cy2))))
 
             # Draw range scale if we are supposed to
             if self.showrange and i in _interval:
@@ -341,25 +350,30 @@ class DrawableColorBar(Rectangle):
             cr.set_line(self.bgcolor, linewidth=0)
 
             cx1, cy1, cx2, cy2 = x_base, y_top - scale_ht, x_top, y_top
-            cr.draw_polygon(((cx1, cy1), (cx2, cy1), (cx2, cy2), (cx1, cy2)))
+            cp = tr.to_(((cx1, cy1), (cx2, cy1), (cx2, cy2), (cx1, cy2)))
+            cr.draw_polygon(cp)
 
             cr.set_line(color=self.color, linewidth=1, alpha=self.alpha)
-            cr.draw_line(cx1, cy1, cx2, cy1)
+            #cr.draw_line(cx1, cy1, cx2, cy1)
+            cr.draw_line(cp[0][0], cp[0][1], cp[1][0], cp[1][1])
 
             cr.set_font(self.font, self.fontsize, color=self.color,
                     alpha=self.alpha)
             for (cx, cy, cyy, text) in range_pts:
+                cp = tr.to_(((cx, cy), (cx, cy+self.tick_ht), (cx, cyy-2)))
                 # tick
-                cr.draw_line(cx, cy, cx, cy+self.tick_ht)
+                #cr.draw_line(cx, cy, cx, cy+self.tick_ht)
+                cr.draw_line(cp[0][0], cp[0][1], cp[1][0], cp[1][1])
                 # number
-                cr.draw_text(cx, cyy-2, text)
+                #cr.draw_text(cx, cyy-2, text)
+                cr.draw_text(cp[2][0], cp[2][1], text)
 
         # draw optional border
         if self.linewidth > 0:
             cr.set_fill(self.bgcolor, alpha=0.0)
             cx1, cy1, cx2, cy2 = x_base, y_base, x_top, y_top
             cpoints = ((cx1, cy1), (cx2, cy1), (cx2, cy2), (cx1, cy2))
-            cr.draw_polygon(cpoints)
+            cr.draw_polygon(tr.to_(cpoints))
 
 
 class ModeIndicator(CanvasObjectBase):
@@ -419,6 +433,7 @@ class ModeIndicator(CanvasObjectBase):
             return
 
         cr = viewer.renderer.setup_cr(self)
+        tr = viewer.tform['window_to_native']
 
         if mode_type == 'locked':
             text = '%s [L]' % (mode)
@@ -446,12 +461,14 @@ class ModeIndicator(CanvasObjectBase):
         cr.set_fill('black', alpha=self.fillalpha)
 
         cx1, cy1, cx2, cy2 = x_base, y_base, x_base + box_wd, y_base + box_ht
-        cr.draw_polygon(((cx1, cy1), (cx2, cy1), (cx2, cy2), (cx1, cy2)))
+        cr.draw_polygon(tr.to_(((cx1, cy1), (cx2, cy1),
+                                (cx2, cy2), (cx1, cy2))))
 
         # draw fg
         cr.set_line(color=self.color, linewidth=1, alpha=self.alpha)
 
         cx, cy = x_base + self.xpad, y_base + txt_ht + self.ypad
+        cx, cy = tr.to_((cx, cy))
         cr.draw_text(cx, cy, text)
 
 
@@ -498,6 +515,7 @@ class FocusIndicator(CanvasObjectBase):
             return
 
         cr = viewer.renderer.setup_cr(self)
+        tr = viewer.tform['window_to_native']
 
         wd, ht = viewer.get_window_size()
         lw = self.linewidth
@@ -507,8 +525,8 @@ class FocusIndicator(CanvasObjectBase):
         cr.set_line(color=self.color, linewidth=lw, alpha=self.alpha,
                     style=self.linestyle)
 
-        points = ((off, off), (wd-off, off), (wd-off, ht-off), (off, ht-off))
-        cr.draw_polygon(points)
+        cpoints = ((off, off), (wd-off, off), (wd-off, ht-off), (off, ht-off))
+        cr.draw_polygon(tr.to_(cpoints))
 
     def focus_cb(self, viewer, onoff):
         has_focus = self.has_focus

--- a/ginga/examples/gw/clocks.py
+++ b/ginga/examples/gw/clocks.py
@@ -96,13 +96,13 @@ class Clock(object):
         # text object for the time
         self.time_txt = Text(x, y, text='', color=self.color,
                              font=self.font, fontsize=self.largesize,
-                             coord='canvas')
+                             coord='window')
         self.canvas.add(self.time_txt, tag='_time', redraw=False)
 
         # for supplementary info (date, timezone, etc)
         self.suppl_txt = Text(x, height-10, text='', color=self.color,
                               font=self.font, fontsize=self.smallsize,
-                              coord='canvas')
+                              coord='window')
         self.canvas.add(self.suppl_txt, tag='_suppl', redraw=False)
 
         self.canvas.update_canvas(whence=3)

--- a/ginga/examples/qt/example2_qt.py
+++ b/ginga/examples/qt/example2_qt.py
@@ -9,6 +9,8 @@ from __future__ import print_function
 import sys, os
 import logging
 from ginga.qtw.QtHelp import QtGui, QtCore
+from ginga.util import wcsmod
+wcsmod.use('astropy')
 
 from ginga import AstroImage, colors
 from ginga.qtw.ImageViewQt import CanvasView
@@ -32,7 +34,7 @@ class FitsViewer(QtGui.QMainWindow):
         fi.enable_autozoom('on')
         fi.set_zoom_algorithm('rate')
         fi.set_zoomrate(1.4)
-        fi.show_pan_mark(True)
+        #fi.show_pan_mark(True)
         #fi.enable_draw(False)
         fi.add_callback('drag-drop', self.drop_file_cb)
         fi.add_callback('cursor-changed', self.cursor_cb)

--- a/ginga/examples/qt/example2_qt.py
+++ b/ginga/examples/qt/example2_qt.py
@@ -9,8 +9,6 @@ from __future__ import print_function
 import sys, os
 import logging
 from ginga.qtw.QtHelp import QtGui, QtCore
-from ginga.util import wcsmod
-wcsmod.use('astropy')
 
 from ginga import AstroImage, colors
 from ginga.qtw.ImageViewQt import CanvasView

--- a/ginga/gw/Readout.py
+++ b/ginga/gw/Readout.py
@@ -29,7 +29,7 @@ class Readout(object):
         xoff, yoff = 4, 4
         self.text_obj = Text(xoff, height-yoff, text='',
                              color='lightgreen', fontsize=14,
-                             coord='canvas')
+                             coord='window')
         canvas.add(self.text_obj, redraw=False)
 
         self.maxx = 0

--- a/ginga/mplw/CanvasRenderMpl.py
+++ b/ginga/mplw/CanvasRenderMpl.py
@@ -8,7 +8,7 @@ import matplotlib.patches as patches
 import matplotlib.lines as lines
 import matplotlib.text as text
 from matplotlib.path import Path as MplPath
-import numpy
+import numpy as np
 
 from . import MplHelp
 from ginga.canvas.mixins import *
@@ -99,7 +99,7 @@ class RenderContext(object):
         self.cr.init(closed=True, transform=None)
         self.cr.update_patch(self.pen, self.brush)
 
-        xy = numpy.array(cpoints)
+        xy = np.asarray(cpoints)
 
         p = patches.Polygon(xy, **self.cr.kwdargs)
         self.cr.axes.add_patch(p)
@@ -152,7 +152,7 @@ class RenderContext(object):
         self.cr.init(closed=False, transform=None)
         self.cr.update_patch(self.pen, None)
 
-        xy = numpy.array(cpoints)
+        xy = np.asarray(cpoints)
 
         p = patches.Polygon(xy, **self.cr.kwdargs)
         self.cr.axes.add_patch(p)

--- a/ginga/mplw/CanvasRenderMpl.py
+++ b/ginga/mplw/CanvasRenderMpl.py
@@ -1,9 +1,6 @@
 #
 # CanvasRenderMpl.py -- for rendering into a ImageViewMpl widget
 #
-# Eric Jeschke (eric@naoj.org)
-#
-# Copyright (c) Eric R. Jeschke.  All rights reserved.
 # This is open-source software licensed under a BSD license.
 # Please see the file LICENSE.txt for details.
 

--- a/ginga/mplw/FigureCanvasQt.py
+++ b/ginga/mplw/FigureCanvasQt.py
@@ -2,9 +2,6 @@
 # GingaCanvasQt.py -- classes for the display of FITS files in
 #                             Matplotlib FigureCanvas
 #
-# Eric Jeschke (eric@naoj.org)
-#
-# Copyright (c)  Eric R. Jeschke.  All rights reserved.
 # This is open-source software licensed under a BSD license.
 # Please see the file LICENSE.txt for details.
 from __future__ import print_function

--- a/ginga/mplw/ImageViewMpl.py
+++ b/ginga/mplw/ImageViewMpl.py
@@ -19,6 +19,9 @@ import matplotlib.lines as lines
 
 from ginga import ImageView
 from ginga import Mixins, Bindings, colors
+# This import is necessary to register the 'ginga' projection
+# used via matplotlib, even though the module is not directly
+# referenced within this code
 from . import transform
 from ginga.mplw.CanvasRenderMpl import CanvasRenderer
 from ginga.mplw.MplHelp import Timer

--- a/ginga/mplw/ImageViewMpl.py
+++ b/ginga/mplw/ImageViewMpl.py
@@ -19,7 +19,7 @@ import matplotlib.lines as lines
 
 from ginga import ImageView
 from ginga import Mixins, Bindings, colors
-# This import is necessary to register the 'ginga' projection
+# NOTE: this import is necessary to register the 'ginga' projection
 # used via matplotlib, even though the module is not directly
 # referenced within this code
 from . import transform
@@ -83,7 +83,10 @@ class ImageViewMpl(ImageView.ImageViewBase):
         """Call this with the matplotlib Figure() object."""
         self.figure = figure
 
-        ax = self.figure.add_axes((0, 0, 1, 1), frame_on=False)
+        ax = self.figure.add_axes((0, 0, 1, 1), frame_on=False,
+                                  #viewer=self,
+                                  #projection='ginga'
+                                  )
         #ax = fig.add_subplot(111)
         self.ax_img = ax
         # We don't want the axes cleared every time plot() is called
@@ -99,7 +102,10 @@ class ImageViewMpl(ImageView.ImageViewBase):
         # Add an overlapped axis for drawing graphics
         newax = self.figure.add_axes(self.ax_img.get_position(),
                                      sharex=ax, sharey=ax,
-                                     frameon=False)
+                                     frameon=False,
+                                     #viewer=self,
+                                     #projection='ginga'
+                                     )
         newax.hold(True)
         newax.autoscale(enable=False)
         newax.get_xaxis().set_visible(False)
@@ -268,7 +274,6 @@ class ImageViewMpl(ImageView.ImageViewBase):
 
     def add_axes(self):
         ax = self.figure.add_axes(self.ax_img.get_position(),
-                                  #sharex=self.ax_img, sharey=self.ax_img,
                                   frameon=False,
                                   viewer=self,
                                   projection='ginga')

--- a/ginga/mplw/transform.py
+++ b/ginga/mplw/transform.py
@@ -2,9 +2,6 @@
 # transform.py -- a custom projection for supporting matplotlib plotting
 #                          on ginga
 #
-# Eric Jeschke (eric@naoj.org)
-#
-# Copyright (c)  Eric R. Jeschke.  All rights reserved.
 # This is open-source software licensed under a BSD license.
 # Please see the file LICENSE.txt for details.
 #
@@ -229,7 +226,9 @@ class GingaAxes(Axes):
             if self.viewer is None:
                 return xy
 
-            res = np.dstack(self.viewer.get_canvas_xy(xy.T[0], xy.T[1]))[0]
+            #res = np.dstack(self.viewer.get_canvas_xy(xy.T[0], xy.T[1]))[0]
+            tr = self.viewer.tform['data_to_window']
+            res = tr.to_(xy)
             #print(("transform out:", res))
             return res
 
@@ -278,7 +277,9 @@ class GingaAxes(Axes):
             if self.viewer is None:
                 return xy
 
-            res = np.dstack(self.viewer.get_data_xy(xy.T[0], xy.T[1]))[0]
+            #res = np.dstack(self.viewer.get_data_xy(xy.T[0], xy.T[1]))[0]
+            tr = self.viewer.tform['data_to_window']
+            res = tr.from_(xy)
             #print "transform out:", res
             return res
 

--- a/ginga/mplw/transform.py
+++ b/ginga/mplw/transform.py
@@ -226,7 +226,7 @@ class GingaAxes(Axes):
             if self.viewer is None:
                 return xy
 
-            tr = self.viewer.tform['data_to_window']
+            tr = self.viewer.tform['data_to_native']
             res = tr.to_(xy)
             return res
 
@@ -275,7 +275,7 @@ class GingaAxes(Axes):
             if self.viewer is None:
                 return xy
 
-            tr = self.viewer.tform['data_to_window']
+            tr = self.viewer.tform['data_to_native']
             res = tr.from_(xy)
             return res
 

--- a/ginga/mplw/transform.py
+++ b/ginga/mplw/transform.py
@@ -208,6 +208,7 @@ class GingaAxes(Axes):
         input_dims = 2
         output_dims = 2
         is_separable = False
+        has_inverse = True
         viewer = None
         #pass_through = True
 
@@ -222,14 +223,11 @@ class GingaAxes(Axes):
 
             The input and output are Nx2 numpy arrays.
             """
-            #print(("transform in:", xy))
             if self.viewer is None:
                 return xy
 
-            #res = np.dstack(self.viewer.get_canvas_xy(xy.T[0], xy.T[1]))[0]
             tr = self.viewer.tform['data_to_window']
             res = tr.to_(xy)
-            #print(("transform out:", res))
             return res
 
         # This is where things get interesting.  With this projection,
@@ -270,17 +268,15 @@ class GingaAxes(Axes):
         input_dims = 2
         output_dims = 2
         is_separable = False
+        has_inverse = True
         viewer = None
 
         def transform_non_affine(self, xy):
-            #print "transform in:", xy
             if self.viewer is None:
                 return xy
 
-            #res = np.dstack(self.viewer.get_data_xy(xy.T[0], xy.T[1]))[0]
             tr = self.viewer.tform['data_to_window']
             res = tr.from_(xy)
-            #print "transform out:", res
             return res
 
         transform_non_affine.__doc__ = Transform.transform_non_affine.__doc__

--- a/ginga/qtw/CanvasRenderQt.py
+++ b/ginga/qtw/CanvasRenderQt.py
@@ -118,7 +118,9 @@ class RenderContext(object):
 
     def draw_polygon(self, cpoints):
         qpoints = list(map(lambda p: QtCore.QPoint(p[0], p[1]),
-                            (cpoints + (cpoints[0],))))
+                           cpoints))
+        p = cpoints[0]
+        qpoints.append(QtCore.QPoint(p[0], p[1]))
         qpoly = QPolygon(qpoints)
 
         self.cr.drawPolygon(qpoly)

--- a/ginga/rv/plugins/Catalogs.py
+++ b/ginga/rv/plugins/Catalogs.py
@@ -374,9 +374,9 @@ class Catalogs(GingaPlugin.LocalPlugin):
             else:
                 # if the object drawn is a circle, calculate the box
                 # enclosed by the circle
-                ctr_x, ctr_y = obj.crdmap.to_data(obj.x, obj.y)
+                ctr_x, ctr_y = obj.crdmap.to_data((obj.x, obj.y))
                 ra_ctr, dec_ctr = image.pixtoradec(ctr_x, ctr_y)
-                dst_x, dst_y = obj.crdmap.to_data(obj.x + obj.radius, obj.y)
+                dst_x, dst_y = obj.crdmap.to_data((obj.x + obj.radius, obj.y))
                 ra_dst, dec_dst = image.pixtoradec(dst_x, dst_y)
                 radius_deg = wcs.deltaStarsRaDecDeg(ra_ctr, dec_ctr,
                                                     ra_dst, dec_dst)

--- a/ginga/rv/plugins/ColorMapPicker.py
+++ b/ginga/rv/plugins/ColorMapPicker.py
@@ -203,10 +203,10 @@ class ColorMapPicker(GingaPlugin.GlobalPlugin):
             x1, y1 = self._cmxoff, i * (ht + sep)
             x2, y2 = x1 + wd, y1 + ht
             cbar = ColorBar(x1, y1, x2, y2, cm_name=name, showrange=False,
-                            rgbmap=rgbmap, coord='canvas')
+                            rgbmap=rgbmap, coord='window')
             l2.append(cbar)
             l2.append(Text(x2+sep, y2, name, color='white', fontsize=16,
-                           coord='canvas'))
+                           coord='window'))
 
         Compound = canvas.get_draw_class('compoundobject')
         obj = Compound(*l2)

--- a/ginga/rv/plugins/Drawing.py
+++ b/ginga/rv/plugins/Drawing.py
@@ -56,7 +56,7 @@ class Drawing(GingaPlugin.LocalPlugin):
         self.drawtypes = list(canvas.get_drawtypes())
         self.drawcolors = draw_colors
         self.linestyles = ['solid', 'dash']
-        self.coordtypes = ['data', 'wcs', 'cartesian', 'canvas']
+        self.coordtypes = ['data', 'wcs', 'cartesian', 'window']
         # contains all parameters to be passed to the constructor
         self.draw_args = []
         self.draw_kwdargs = {}

--- a/ginga/rv/plugins/Drawing.py
+++ b/ginga/rv/plugins/Drawing.py
@@ -81,7 +81,6 @@ class Drawing(GingaPlugin.LocalPlugin):
         fr = Widgets.Frame("Drawing")
 
         captions = (("Draw type:", 'label', "Draw type", 'combobox'),
-                    ("Coord type:", 'label', "Coord type", 'combobox'),
                     )
         w, b = Widgets.build_info(captions)
         self.w.update(b)
@@ -91,14 +90,7 @@ class Drawing(GingaPlugin.LocalPlugin):
             combobox.append_text(name)
         index = self.drawtypes.index(default_drawtype)
         combobox.set_index(index)
-        combobox.add_callback('activated', lambda w, idx: self.set_drawparams_cb())
-
-        combobox = b.coord_type
-        for name in self.coordtypes:
-            combobox.append_text(name)
-        index = 0
-        combobox.set_index(index)
-        combobox.add_callback('activated', lambda w, idx: self.set_drawparams_cb())
+        combobox.add_callback('activated', lambda w, idx: self.set_drawtype_cb())
 
         fr.set_widget(w)
         vbox.add_widget(fr, stretch=0)
@@ -224,14 +216,15 @@ class Drawing(GingaPlugin.LocalPlugin):
         self.logger.info("drew a %s" % (obj.kind))
         return True
 
+    def set_drawtype_cb(self):
+        if self.canvas.get_draw_mode() != 'draw':
+            self.canvas.set_draw_mode('draw')
+        self.w.btn_draw.set_state(True)
+        self.set_mode_cb('draw', True)
+
     def set_drawparams_cb(self):
-        ## if self.canvas.get_draw_mode() != 'draw':
-        ##     # if we are in edit mode then don't initialize draw gui
-        ##     return
         index = self.w.draw_type.get_index()
         kind = self.drawtypes[index]
-        index = self.w.coord_type.get_index()
-        coord = self.coordtypes[index]
 
         # remove old params
         self.w.drawvbox.remove_all()
@@ -259,21 +252,15 @@ class Drawing(GingaPlugin.LocalPlugin):
         self.w.rotate_by.set_enabled(False)
 
         args, kwdargs = self.draw_params.get_params()
-        if kind != 'compass':
-            kwdargs['coord'] = coord
-        self.logger.info("changing params to: %s" % (str(kwdargs)))
+        self.logger.debug("changing params to: %s" % (str(kwdargs)))
         self.canvas.set_drawtype(kind, **kwdargs)
 
     def draw_params_changed_cb(self, paramObj, params):
         index = self.w.draw_type.get_index()
         kind = self.drawtypes[index]
-        index = self.w.coord_type.get_index()
-        coord = self.coordtypes[index]
 
         args, kwdargs = self.draw_params.get_params()
-        if kind != 'compass':
-            kwdargs['coord'] = coord
-        self.logger.info("changing params to: %s" % (str(kwdargs)))
+        self.logger.debug("changing params to: %s" % (str(kwdargs)))
         self.canvas.set_drawtype(kind, **kwdargs)
 
     def edit_cb(self, fitsimage, obj):

--- a/ginga/rv/plugins/Drawing.py
+++ b/ginga/rv/plugins/Drawing.py
@@ -259,17 +259,21 @@ class Drawing(GingaPlugin.LocalPlugin):
         self.w.rotate_by.set_enabled(False)
 
         args, kwdargs = self.draw_params.get_params()
-        #self.logger.debug("changing params to: %s" % str(kwdargs))
         if kind != 'compass':
             kwdargs['coord'] = coord
+        self.logger.info("changing params to: %s" % (str(kwdargs)))
         self.canvas.set_drawtype(kind, **kwdargs)
 
     def draw_params_changed_cb(self, paramObj, params):
         index = self.w.draw_type.get_index()
         kind = self.drawtypes[index]
+        index = self.w.coord_type.get_index()
+        coord = self.coordtypes[index]
 
         args, kwdargs = self.draw_params.get_params()
-        #self.logger.debug("changing params to: %s" % str(kwdargs))
+        if kind != 'compass':
+            kwdargs['coord'] = coord
+        self.logger.info("changing params to: %s" % (str(kwdargs)))
         self.canvas.set_drawtype(kind, **kwdargs)
 
     def edit_cb(self, fitsimage, obj):
@@ -287,8 +291,8 @@ class Drawing(GingaPlugin.LocalPlugin):
         if hasattr(obj, 'coord'):
             tomap = self.fitsimage.get_coordmap(obj.coord)
             if obj.crdmap != tomap:
-                #self.logger.debug("coordmap has changed to '%s'--converting mapper" % (
-                #    str(tomap)))
+                self.logger.debug("coordmap has changed to '%s'--converting mapper" % (
+                    str(tomap)))
                 # user changed type of mapper; convert coordinates to
                 # new mapper and update widgets
                 obj.convert_mapper(tomap)

--- a/ginga/rv/plugins/PixTable.py
+++ b/ginga/rv/plugins/PixTable.py
@@ -384,7 +384,7 @@ class PixTable(GingaPlugin.LocalPlugin):
         ex_txt = Text(0, 0, text='5', fontsize=self.fontsize, font=self.font)
         font_wd, font_ht = self.fitsimage.renderer.get_dimensions(ex_txt)
         max_wd = self.maxdigits + 2
-        crdmap = self.pixview.get_coordmap('canvas')
+        crdmap = self.pixview.get_coordmap('window')
 
         rows = []
         objs = []
@@ -428,7 +428,7 @@ class PixTable(GingaPlugin.LocalPlugin):
         canvas.add(CompoundObject(*objs), redraw=False)
 
         # set limits for scrolling
-        self.pixview.set_limits(((0, 0), (max_x, y)), coord='canvas')
+        self.pixview.set_limits(((0, 0), (max_x, y)), coord='window')
 
     def set_cutout_size_cb(self, w, val):
         index = w.get_index()

--- a/ginga/rv/plugins/PixTable.py
+++ b/ginga/rv/plugins/PixTable.py
@@ -401,7 +401,7 @@ class PixTable(GingaPlugin.LocalPlugin):
                 if (row == col) and (row == self.pixtbl_radius):
                     color = 'pink'
 
-                dx, dy = crdmap.to_data(x, y)
+                dx, dy = crdmap.to_data((x, y))
                 text_obj = Text(dx, dy, text='', font=self.font,
                                 color=color, fontsize=self.fontsize,
                                 coord='data')
@@ -415,7 +415,7 @@ class PixTable(GingaPlugin.LocalPlugin):
         # add summary row(s)
         x = (font_wd + 2) + 4
         y += font_ht+20
-        dx, dy = crdmap.to_data(x, y)
+        dx, dy = crdmap.to_data((x, y))
         s1 = Text(dx, dy, text='', font=self.font,
                   color=color, fontsize=self.fontsize,
                   coord='data')

--- a/ginga/trcalc.py
+++ b/ginga/trcalc.py
@@ -5,7 +5,7 @@
 # Please see the file LICENSE.txt for details.
 #
 import math
-import numpy
+import numpy as np
 import time
 
 interpolation_methods = ['basic']
@@ -93,8 +93,8 @@ def rotate_pt(x_arr, y_arr, theta_deg, xoff=0, yoff=0):
     # TODO: use opencv acceleration if available
     a_arr = x_arr - xoff
     b_arr = y_arr - yoff
-    cos_t = numpy.cos(numpy.radians(theta_deg))
-    sin_t = numpy.sin(numpy.radians(theta_deg))
+    cos_t = np.cos(np.radians(theta_deg))
+    sin_t = np.sin(np.radians(theta_deg))
     ap = (a_arr * cos_t) - (b_arr * sin_t)
     bp = (a_arr * sin_t) + (b_arr * cos_t)
     return (ap + xoff, bp + yoff)
@@ -102,11 +102,11 @@ def rotate_pt(x_arr, y_arr, theta_deg, xoff=0, yoff=0):
 rotate_arr = rotate_pt
 
 def rotate_coord(coord, theta_deg, offsets):
-    arr = numpy.asarray(coord)
+    arr = np.asarray(coord)
     # TODO: handle dimensional rotation N>2
     x_arr, y_arr = rotate_pt(arr.T[0], arr.T[1], theta_deg,
                              xoff=offsets[0], yoff=offsets[1])
-    arr = numpy.column_stack((x_arr, y_arr))
+    arr = np.asarray((x_arr, y_arr)).T
     return arr
 
 def rotate_clip(data_np, theta_deg, rotctr_x=None, rotctr_y=None,
@@ -153,7 +153,7 @@ def rotate_clip(data_np, theta_deg, rotctr_x=None, rotctr_y=None,
         if logger is not None:
             logger.debug("rotating with OpenCL")
         # opencl is very close, sometimes better, sometimes worse
-        if (data_np.dtype == numpy.uint8) and (len(data_np.shape) == 3):
+        if (data_np.dtype == np.uint8) and (len(data_np.shape) == 3):
             # special case for 3D RGB images
             newdata = trcalc_cl.rotate_clip_uint32(data_np, theta_deg,
                                                    rotctr_x, rotctr_y,
@@ -166,11 +166,11 @@ def rotate_clip(data_np, theta_deg, rotctr_x=None, rotctr_y=None,
     else:
         if logger is not None:
             logger.debug("rotating with numpy")
-        yi, xi = numpy.mgrid[0:ht, 0:wd]
+        yi, xi = np.mgrid[0:ht, 0:wd]
         xi -= rotctr_x
         yi -= rotctr_y
-        cos_t = numpy.cos(numpy.radians(theta_deg))
-        sin_t = numpy.sin(numpy.radians(theta_deg))
+        cos_t = np.cos(np.radians(theta_deg))
+        sin_t = np.sin(np.radians(theta_deg))
 
         if have_numexpr:
             ap = ne.evaluate("(xi * cos_t) - (yi * sin_t) + rotctr_x")
@@ -179,13 +179,13 @@ def rotate_clip(data_np, theta_deg, rotctr_x=None, rotctr_y=None,
             ap = (xi * cos_t) - (yi * sin_t) + rotctr_x
             bp = (xi * sin_t) + (yi * cos_t) + rotctr_y
 
-        #ap = numpy.rint(ap).astype('int').clip(0, wd-1)
-        #bp = numpy.rint(bp).astype('int').clip(0, ht-1)
+        #ap = np.rint(ap).astype('int').clip(0, wd-1)
+        #bp = np.rint(bp).astype('int').clip(0, ht-1)
         # Optomizations to reuse existing intermediate arrays
-        numpy.rint(ap, out=ap)
+        np.rint(ap, out=ap)
         ap = ap.astype('int')
         ap.clip(0, wd-1, out=ap)
-        numpy.rint(bp, out=bp)
+        np.rint(bp, out=bp)
         bp = bp.astype('int')
         bp.clip(0, ht-1, out=bp)
 
@@ -238,7 +238,7 @@ def rotate(data_np, theta_deg, rotctr_x=None, rotctr_y=None, pad=20,
         bdy, tdy = min(ocy, ncy), min(ht - ocy, ncy)
 
         # TODO: fill with a different value?
-        newdata = numpy.zeros(dims, dtype=data_np.dtype)
+        newdata = np.zeros(dims, dtype=data_np.dtype)
         newdata[ncy-bdy:ncy+tdy, ncx-ldx:ncx+rdx] = \
                                  data_np[ocy-bdy:ocy+tdy, ocx-ldx:ocx+rdx]
 
@@ -265,8 +265,8 @@ def get_scaled_cutout_wdht_view(shp, x1, y1, x2, y2, new_wd, new_ht):
     if (new_wd != old_wd) or (new_ht != old_ht):
         # Make indexes and scale them
         # Is there a more efficient way to do this?
-        yi = numpy.mgrid[0:new_ht].reshape(-1, 1)
-        xi = numpy.mgrid[0:new_wd].reshape(1, -1)
+        yi = np.mgrid[0:new_ht].reshape(-1, 1)
+        xi = np.mgrid[0:new_wd].reshape(1, -1)
         iscale_x = float(old_wd) / float(new_wd)
         iscale_y = float(old_ht) / float(new_ht)
 
@@ -279,12 +279,12 @@ def get_scaled_cutout_wdht_view(shp, x1, y1, x2, y2, new_wd, new_ht):
         assert xi_max <= max_x, ValueError("X index (%d) exceeds shape bounds (%d)" % (xi_max, max_x))
         assert yi_max <= max_y, ValueError("Y index (%d) exceeds shape bounds (%d)" % (yi_max, max_y))
 
-        view = numpy.s_[yi, xi]
+        view = np.s_[yi, xi]
 
     else:
         # simple stepped view will do, because new view is same as old
         wd, ht = old_wd, old_ht
-        view = numpy.s_[y1:y2+1, x1:x2+1]
+        view = np.s_[y1:y2+1, x1:x2+1]
 
     # Calculate actual scale used (vs. desired)
     old_wd, old_ht = max(old_wd, 1), max(old_ht, 1)
@@ -315,9 +315,9 @@ def get_scaled_cutout_wdhtdp_view(shp, p1, p2, new_dims):
     if (new_wd != old_wd) or (new_ht != old_ht) or (new_dp != old_dp):
         # Make indexes and scale them
         # Is there a more efficient way to do this?
-        yi = numpy.mgrid[0:new_ht].reshape(-1, 1, 1)
-        xi = numpy.mgrid[0:new_wd].reshape(1, -1, 1)
-        zi = numpy.mgrid[0:new_dp].reshape(1, 1, -1)
+        yi = np.mgrid[0:new_ht].reshape(-1, 1, 1)
+        xi = np.mgrid[0:new_wd].reshape(1, -1, 1)
+        zi = np.mgrid[0:new_dp].reshape(1, 1, -1)
         iscale_x = float(old_wd) / float(new_wd)
         iscale_y = float(old_ht) / float(new_ht)
         iscale_z = float(old_dp) / float(new_dp)
@@ -333,12 +333,12 @@ def get_scaled_cutout_wdhtdp_view(shp, p1, p2, new_dims):
         assert yi_max <= max_y, ValueError("Y index (%d) exceeds shape bounds (%d)" % (yi_max, max_y))
         assert zi_max <= max_z, ValueError("Z index (%d) exceeds shape bounds (%d)" % (zi_max, max_z))
 
-        view = numpy.s_[yi, xi, zi]
+        view = np.s_[yi, xi, zi]
 
     else:
         # simple stepped view will do, because new view is same as old
         wd, ht, dp = old_wd, old_ht, old_dp
-        view = numpy.s_[y1:y2+1, x1:x2+1, z1:z2+1]
+        view = np.s_[y1:y2+1, x1:x2+1, z1:z2+1]
 
     # Calculate actual scale used (vs. desired)
     old_wd, old_ht, old_dp = max(old_wd, 1), max(old_ht, 1), max(old_dp, 1)
@@ -495,9 +495,9 @@ def transform(data_np, flip_x=False, flip_y=False, swap_xy=False):
 
     # Do transforms as necessary
     if flip_y:
-        data_np = numpy.flipud(data_np)
+        data_np = np.flipud(data_np)
     if flip_x:
-        data_np = numpy.fliplr(data_np)
+        data_np = np.fliplr(data_np)
     if swap_xy:
         data_np = data_np.swapaxes(0, 1)
 
@@ -577,7 +577,7 @@ def overlay_image_2d(dstarr, pos, srcarr, dst_order='RGBA',
     dst_x, dst_y = int(round(pos[0])), int(round(pos[1]))
 
     if flipy:
-        srcarr = numpy.flipud(srcarr)
+        srcarr = np.flipud(srcarr)
 
     # Trim off parts of srcarr that would be "hidden"
     # to the left and above the dstarr edge.
@@ -609,7 +609,7 @@ def overlay_image_2d(dstarr, pos, srcarr, dst_order='RGBA',
         src_wd -= ex
 
     if copy:
-        dstarr = numpy.copy(dstarr, order='C')
+        dstarr = np.copy(dstarr, order='C')
 
     da_idx = -1
     slc = slice(0, 3)
@@ -632,7 +632,7 @@ def overlay_image_2d(dstarr, pos, srcarr, dst_order='RGBA',
         # if overlay source contains an alpha channel, extract it
         # and use it, otherwise use scalar keyword parameter
         alpha = srcarr[0:src_ht, 0:src_wd, sa_idx] / 255.0
-        alpha = numpy.dstack((alpha, alpha, alpha))
+        alpha = np.dstack((alpha, alpha, alpha))
 
     # reorder srcarr if necessary to match dstarr for alpha merge
     get_order = dst_order
@@ -643,10 +643,10 @@ def overlay_image_2d(dstarr, pos, srcarr, dst_order='RGBA',
 
     # calculate alpha blending
     #   Co = CaAa + CbAb(1 - Aa)
-    a_arr = (alpha * srcarr[0:src_ht, 0:src_wd, slc]).astype(numpy.uint8)
+    a_arr = (alpha * srcarr[0:src_ht, 0:src_wd, slc]).astype(np.uint8)
     b_arr = ((1.0 - alpha) * dstarr[dst_y:dst_y+src_ht,
                                     dst_x:dst_x+src_wd,
-                                    slc]).astype(numpy.uint8)
+                                    slc]).astype(np.uint8)
 
     # Place our srcarr into this dstarr at dst offsets
     #dstarr[dst_y:dst_y+src_ht, dst_x:dst_x+src_wd, slc] += addarr[0:src_ht, 0:src_wd, slc]
@@ -663,7 +663,7 @@ def overlay_image_3d(dstarr, pos, srcarr, dst_order='RGBA', src_order='RGBA',
     src_ht, src_wd, src_dp, src_ch = srcarr.shape
 
     if flipy:
-        srcarr = numpy.flipud(srcarr)
+        srcarr = np.flipud(srcarr)
 
     # Trim off parts of srcarr that would be "hidden"
     # to the left and above the dstarr edge.
@@ -709,7 +709,7 @@ def overlay_image_3d(dstarr, pos, srcarr, dst_order='RGBA', src_order='RGBA',
         return dstarr
 
     if copy:
-        dstarr = numpy.copy(dstarr, order='C')
+        dstarr = np.copy(dstarr, order='C')
 
     da_idx = -1
     slc = slice(0, 3)
@@ -733,11 +733,11 @@ def overlay_image_3d(dstarr, pos, srcarr, dst_order='RGBA', src_order='RGBA',
         # if overlay source contains an alpha channel, extract it
         # and use it, otherwise use scalar keyword parameter
         alpha = srcarr[0:src_ht, 0:src_wd, 0:src_dp, sa_idx] / 255.0
-        #alpha = numpy.dstack((alpha, alpha, alpha))
-        alpha = numpy.concatenate([ alpha[..., numpy.newaxis],
-                                    alpha[..., numpy.newaxis],
-                                    alpha[..., numpy.newaxis] ],
-                                  axis=-1)
+        #alpha = np.dstack((alpha, alpha, alpha))
+        alpha = np.concatenate([ alpha[..., np.newaxis],
+                                 alpha[..., np.newaxis],
+                                 alpha[..., np.newaxis] ],
+                               axis=-1)
 
     # reorder srcarr if necessary to match dstarr for alpha merge
     get_order = dst_order
@@ -749,11 +749,11 @@ def overlay_image_3d(dstarr, pos, srcarr, dst_order='RGBA', src_order='RGBA',
     # calculate alpha blending
     #   Co = CaAa + CbAb(1 - Aa)
     a_arr = (alpha * srcarr[0:src_ht, 0:src_wd,
-                            0:src_dp, slc]).astype(numpy.uint8)
+                            0:src_dp, slc]).astype(np.uint8)
     b_arr = ((1.0 - alpha) * dstarr[dst_y:dst_y+src_ht,
                                     dst_x:dst_x+src_wd,
                                     dst_z:dst_z+src_dp,
-                                    slc]).astype(numpy.uint8)
+                                    slc]).astype(np.uint8)
 
     # Place our srcarr into this dstarr at dst offsets
     dstarr[dst_y:dst_y+src_ht, dst_x:dst_x+src_wd,
@@ -772,8 +772,8 @@ def overlay_image(dstarr, pos, srcarr, **kwargs):
 
 def reorder_image(dst_order, src_arr, src_order):
     indexes = [ src_order.index(c) for c in dst_order ]
-    #return numpy.dstack([ src_arr[..., idx] for idx in indexes ])
-    return numpy.concatenate([ src_arr[..., idx, numpy.newaxis]
+    #return np.dstack([ src_arr[..., idx] for idx in indexes ])
+    return np.concatenate([ src_arr[..., idx, np.newaxis]
                                for idx in indexes ], axis=-1)
 
 

--- a/ginga/trcalc.py
+++ b/ginga/trcalc.py
@@ -97,17 +97,16 @@ def rotate_pt(x_arr, y_arr, theta_deg, xoff=0, yoff=0):
     sin_t = np.sin(np.radians(theta_deg))
     ap = (a_arr * cos_t) - (b_arr * sin_t)
     bp = (a_arr * sin_t) + (b_arr * cos_t)
-    return (ap + xoff, bp + yoff)
+    return np.asarray((ap + xoff, bp + yoff))
 
 rotate_arr = rotate_pt
 
 def rotate_coord(coord, theta_deg, offsets):
     arr = np.asarray(coord)
     # TODO: handle dimensional rotation N>2
-    x_arr, y_arr = rotate_pt(arr.T[0], arr.T[1], theta_deg,
-                             xoff=offsets[0], yoff=offsets[1])
-    arr = np.asarray((x_arr, y_arr)).T
-    return arr
+    arr = rotate_pt(arr.T[0], arr.T[1], theta_deg,
+                    xoff=offsets[0], yoff=offsets[1])
+    return arr.T
 
 def rotate_clip(data_np, theta_deg, rotctr_x=None, rotctr_y=None,
                 out=None, use_opencl=True, logger=None):

--- a/ginga/util/bezier.py
+++ b/ginga/util/bezier.py
@@ -4,7 +4,6 @@
 # This is open-source software licensed under a BSD license.
 # Please see the file LICENSE.txt for details.
 #
-import math
 
 # "reasonable" number of steps to make a smooth bezier curve
 bezier_steps = 30
@@ -14,24 +13,24 @@ bezier_steps = 30
 #
 
 #   calculates points for a simple bezier curve with 4 control points
-#            
+#
 def get_4pt_bezier(steps, points):
     """Gets a series of bezier curve points with 1 set of 4
     control points."""
-    for i in range(steps): 
+    for i in range(steps):
         t = i / float(steps)
 
-        xloc = (math.pow(1-t, 3) * points[0][0] +
-                3 * t * math.pow(1-t, 2) * points[1][0] +
-                3 * (1-t) * math.pow(t, 2) * points[2][0] +
-                math.pow(t, 3) * points[3][0])
-        yloc = (math.pow(1-t, 3) * points[0][1] +
-                3 * t * math.pow(1-t, 2) * points[1][1] +
-                3 * (1-t) * math.pow(t, 2) * points[2][1] +
-                math.pow(t, 3) * points[3][1])
+        xloc = (1-t ** 3 * points[0][0] +
+                3 * t * 1-t ** 2 * points[1][0] +
+                3 * (1-t) * t ** 2 * points[2][0] +
+                t ** 3 * points[3][0])
+        yloc = (1-t ** 3 * points[0][1] +
+                3 * t * 1-t ** 2 * points[1][1] +
+                3 * (1-t) * t ** 2 * points[2][1] +
+                t ** 3 * points[3][1])
 
         yield (xloc, yloc)
-    
+
 def get_bezier(steps, points):
     """Gets a series of bezier curve points with any number of sets
     of 4 control points."""

--- a/ginga/util/toolbox.py
+++ b/ginga/util/toolbox.py
@@ -78,7 +78,7 @@ class ModeIndicator(object):
                 text = mode
 
             o1 = Text(0, 0, text,
-                      fontsize=self.fontsize, color='yellow', coord='canvas')
+                      fontsize=self.fontsize, color='yellow', coord='window')
 
             txt_wd, txt_ht = self.viewer.renderer.get_dimensions(o1)
 
@@ -92,7 +92,7 @@ class ModeIndicator(object):
             cx1, cy1, cx2, cy2 = x_base, y_base, x_base + box_wd, y_base + box_ht
             poly_pts = ((cx1, cy1), (cx2, cy1), (cx2, cy2), (cx1, cy2))
             o2 = Compound(Polygon(poly_pts,
-                               color='black', coord='canvas',
+                               color='black', coord='window',
                                fill=True, fillcolor='black'),
                                o1)
             self.mode_obj = o2


### PR DESCRIPTION
This is a major refactoring of transforms and coordinate mapping for Ginga canvases.  The main goal of the refactoring is to allow numpy vectorization of coordinate transformations all the way up and down the chain for any graphics type.  This PR removes almost all uses of `map` and substitutes numpy arrays and vectorized transforms in many places.  The result is clearer and faster code.

The changes are to  (mostly) internal APIs, and there should be very little effect to users and developers. However, since this affects the rendering pipeline for all back ends, it should be tested quite thoroughly before merging.  One backend (matplotlib) is slightly broken by this PR and it needs a fix also before this can be merged.

- transform.py is vectorized, which changes the internal API
- files using transform or coordmap internal API changed accordingly