### PR TITLE
Clean-up setup script based on Astropy's

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,6 @@ url = http://ejeschke.github.com/ginga
 edit_on_github = False
 github_project = ejeschke/ginga/
 version = 2.6.6.dev
-keywords = scientific image viewer numpy toolkit astronomy FITS
 test_suite = ginga.tests.ginga_test_suite
 
 [entry_points]

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ import sys
 import ah_bootstrap
 from setuptools import setup
 
-#A dirty hack to get around some early import/configurations ambiguities
+# A dirty hack to get around some early import/configurations ambiguities
 if sys.version_info[0] >= 3:
     import builtins
 else:
@@ -104,6 +104,8 @@ package_info['package_data'][PACKAGENAME].extend(c_files)
 # ``setup``, since these are now deprecated. See this link for more details:
 # https://groups.google.com/forum/#!topic/astropy-dev/urYO8ckB2uM
 
+setup_requires = ['numpy>=1.9']
+
 # pretty much needed
 install_requires = ['numpy>=1.9', 'qtpy>=1.1', 'setuptools>=1.0',
                     'astropy>=1.0']
@@ -118,7 +120,9 @@ setup(name=PACKAGENAME,
       version=VERSION,
       description=DESCRIPTION,
       requires=['numpy'],  # scipy not required, but strongly recommended
-      provides=['ginga'],
+      provides=[PACKAGENAME],
+      keywords=['scientific', 'image', 'viewer', 'numpy', 'toolkit',
+                'astronomy', 'FITS'],
       classifiers=[
           "Intended Audience :: Science/Research",
           "License :: OSI Approved :: BSD License",
@@ -133,8 +137,10 @@ setup(name=PACKAGENAME,
           "Topic :: Scientific/Engineering :: Physics",
           ],
       scripts=scripts,
+      setup_requires=setup_requires,
       install_requires=install_requires,
       extras_require=extras_require,
+      python_requires='>=2.7',
       author=AUTHOR,
       author_email=AUTHOR_EMAIL,
       license=LICENSE,


### PR DESCRIPTION
Fix #540 by comparing how `setup(...)` is defined in Ginga and Astropy. I did not remove all metadata from `setup.cfg` but only changed what seem different, as I don't want to break things that already work. Wouldn't know if this fixes the PyPi metadata until next release.

xref #539 