### PR TITLE
Update Pick plugin to have a more interactive contour plot

### DIFF
--- a/ginga/AutoCuts.py
+++ b/ginga/AutoCuts.py
@@ -152,8 +152,8 @@ class Histogram(AutoCutsBase):
             if count < (self.crop_radius ** 2.0) * 0.50:
                 # if we have less than 50% finite pixels then fall back
                 # to using the whole array
-                self.logger.info("too many non-finite values in crop--"
-                                 "falling back to full image data")
+                self.logger.debug("too many non-finite values in crop--"
+                                  "falling back to full image data")
                 data = image.get_data()
         else:
             data = image.get_data()

--- a/ginga/trcalc.py
+++ b/ginga/trcalc.py
@@ -357,6 +357,9 @@ def get_scaled_cutout_wdhtdp_view(shp, p1, p2, new_dims):
 def get_scaled_cutout_wdht(data_np, x1, y1, x2, y2, new_wd, new_ht,
                            interpolation='basic', logger=None):
 
+    x1, y1, x2, y2 = int(x1), int(y1), int(x2), int(y2)
+    new_wd, new_ht = int(new_wd), int(new_ht)
+
     rdim = data_np.shape[2:]
     open_cl_ok = (len(rdim) == 0 or (len(rdim) == 1 and rdim[0] == 4))
 
@@ -438,6 +441,8 @@ def get_scaled_cutout_basic_view(shp, p1, p2, scales):
 def get_scaled_cutout_basic(data_np, x1, y1, x2, y2, scale_x, scale_y,
                             interpolation='basic', logger=None):
 
+    x1, y1, x2, y2 = int(x1), int(y1), int(x2), int(y2)
+
     rdim = data_np.shape[2:]
     open_cl_ok = (len(rdim) == 0 or (len(rdim) == 1 and rdim[0] == 4))
 
@@ -448,6 +453,7 @@ def get_scaled_cutout_basic(data_np, x1, y1, x2, y2, scale_x, scale_y,
         if interpolation == 'basic':
             interpolation = 'nearest'
         method = cv2_resize[interpolation]
+        x1, y1, x2, y2 = int(x1), int(y1), int(x2), int(y2)
         newdata = cv2.resize(data_np[y1:y2+1, x1:x2+1], None,
                              fx=scale_x, fy=scale_y,
                              interpolation=method)

--- a/ginga/util/contour.py
+++ b/ginga/util/contour.py
@@ -1,0 +1,69 @@
+#
+# contour.py -- Support for drawing contours on ginga canvases
+#
+# This is open-source software licensed under a BSD license.
+# Please see the file LICENSE.txt for details.
+#
+
+# THIRD-PARTY
+import numpy as np
+
+have_skimage = False
+try:
+    from skimage import measure
+    have_skimage = True
+except ImportError:
+    pass
+
+from ginga.util.six.moves import map, filter
+
+
+def get_contours(data, levels):
+    """Get sets of contour points for numpy array `data`.
+    `levels` is a sequence of values around which to calculate the
+    contours.  Returns a list of numpy arrays of points--each array
+    makes a polygon if plotted as such.
+    """
+    if not have_skimage:
+        raise Exception("Please install scikit-image > 0.13"
+                        "to use this function")
+    res = [ filter(lambda arr: len(arr) >= 3,
+                   measure.find_contours(data, level))
+            for level in levels ]
+    res = [ map(lambda arr: np.roll(arr, 1, axis=1),
+                 arrs) for arrs in res ]
+    return res
+
+
+def calc_contours(data, num_contours):
+    """Get sets of contour points for numpy array `data`.
+    `num_contours` specifies the number (int) of contours to make.
+    Returns a list of numpy arrays of points--each array makes a polygon
+    if plotted as such.
+    """
+    mn = np.nanmean(data)
+    top = np.nanmax(data)
+    levels = np.linspace(mn, top, num_contours)
+    return get_contours(data, levels)
+
+
+def create_contours_obj(canvas, contour_groups, colors=None, **kwargs):
+    """Create and return a compound object for ginga `canvas`, consisting
+    of a number of contour polygons.  `contour_groups` is a list of
+    numpy arrays of points representing polygons, such as returned by
+    calc_contours() or get_contours().
+    `colors` (if provided) is a list of colors for each polygon.
+    Any other keyword parameters are passed on to the Polygon class.
+    """
+    if colors is None:
+        colors = ['black']
+    Polygon = canvas.get_draw_class('polygon')
+    Compound = canvas.get_draw_class('compoundobject')
+    objs = [Polygon(contour, color=colors[i % len(colors)], **kwargs)
+            for i, contours in enumerate(contour_groups)
+            for n, contour in enumerate(contours)
+            ]
+    contours_obj = Compound(*objs)
+    return contours_obj
+
+# END


### PR DESCRIPTION
This introduces the capability to conveniently add contour plots on top of ginga canvases.  It requires a recent version of the `scikit-image` package.  If that is not available Pick falls back to using a matplotlib plot.