### PR TITLE
PEP8 fix for files under mockw and tkw sub-directories

### DIFF
--- a/ginga/mockw/CanvasRenderMock.py
+++ b/ginga/mockw/CanvasRenderMock.py
@@ -5,9 +5,10 @@
 # Please see the file LICENSE.txt for details.
 #
 # force registration of all canvas types
-import ginga.canvas.types.all
+import ginga.canvas.types.all  # noqa
 from ginga import trcalc
 from ginga.fonts import font_asst
+
 
 class RenderContext(object):
 
@@ -84,11 +85,12 @@ class RenderContext(object):
         cpoints = trcalc.strip_z(cpoints)
         for i in range(len(cpoints) - 1):
             cx1, cy1 = cpoints[i]
-            cx2, cy2 = cpoints[i+1]
+            cx2, cy2 = cpoints[i + 1]
             #self.cr.draw_line(cx1, cy1, cx2, cy2)
 
     def draw_bezier_curve(self, cp):
         pass
+
 
 class CanvasRenderer(object):
 

--- a/ginga/mockw/ImageViewCanvasMock.py
+++ b/ginga/mockw/ImageViewCanvasMock.py
@@ -15,6 +15,7 @@ from ginga.canvas.mixins import DrawingMixin, CanvasMixin, CompoundMixin
 class ImageViewCanvasError(ImageViewMock.ImageViewMockError):
     pass
 
+
 class ImageViewCanvas(ImageViewMock.ImageViewZoom,
                       DrawingMixin, CanvasMixin, CompoundMixin):
 

--- a/ginga/mockw/ImageViewCanvasTypesMock.py
+++ b/ginga/mockw/ImageViewCanvasTypesMock.py
@@ -1,5 +1,5 @@
 # TODO: this line is for backward compatibility with files importing
 # this module--to be removed
-from ginga.canvas.types.all import *
+from ginga.canvas.types.all import *  # noqa
 
-#END
+# END

--- a/ginga/mockw/ImageViewMock.py
+++ b/ginga/mockw/ImageViewMock.py
@@ -4,9 +4,7 @@
 # This is open-source software licensed under a BSD license.
 # Please see the file LICENSE.txt for details.
 #
-import sys, os
-import numpy
-from io import BytesIO
+import os
 
 from ginga import ImageView, Mixins, Bindings
 from ginga.util.io_rgb import RGBFileHandler
@@ -73,7 +71,6 @@ class ImageViewMock(ImageView.ImageViewBase):
         ##                   data,
         ##                   Rect(0, 0, width, height))
 
-
     def render_image(self, rgbobj, dst_x, dst_y):
         """Render the image represented by (rgbobj) at dst_x, dst_y
         in the offscreen pixmap.
@@ -133,7 +130,7 @@ class ImageViewMock(ImageView.ImageViewBase):
         img_w = self.get_rgb_image_as_widget()
         # assumes that the image widget has some method for saving to
         # a file
-        res = img_w.save(filepath, format=format, quality=quality)
+        img_w.save(filepath, format=format, quality=quality)
 
     def get_plain_image_as_widget(self):
         """Used for generating thumbnails.  Does not include overlaid
@@ -152,7 +149,7 @@ class ImageViewMock(ImageView.ImageViewBase):
         img_w = self.get_plain_image_as_widget()
         # assumes that the image widget has some method for saving to
         # a file
-        res = qimg.save(filepath, format=format, quality=quality)
+        img_w.save(filepath, format=format, quality=quality)
 
     def reschedule_redraw(self, time_sec):
         # stop any pending redraws, if possible
@@ -187,7 +184,8 @@ class ImageViewMock(ImageView.ImageViewBase):
         """Convert the numpy array (which is in our expected order)
         to a native image object in this widget set.
         """
-        return result
+        #return result
+        raise NotImplementedError
 
     def _get_color(self, r, g, b):
         """Convert red, green and blue values specified in floats with
@@ -237,7 +235,7 @@ class ImageViewEvent(ImageViewMock):
             "'": 'singlequote',
             '\\': 'backslash',
             ' ': 'space',
-            }
+        }
 
         for name in ('motion', 'button-press', 'button-release',
                      'key-press', 'key-release', 'drag-drop',
@@ -280,7 +278,7 @@ class ImageViewEvent(ImageViewMock):
         Called when the window is mapped to the screen.
         Adjust method signature as appropriate for callback.
         """
-        self.configure_window(width, height)
+        #self.configure_window(width, height)
         return self.make_callback('map')
 
     def focus_event(self, widget, event, hasFocus):
@@ -316,7 +314,7 @@ class ImageViewEvent(ImageViewMock):
         # get keyname or keycode and translate to ginga standard
         # keyname =
         # keycode =
-        keyname = self.transkey(keyname, keycode)
+        keyname = ''  # self.transkey(keyname, keycode)
         self.logger.debug("key press event, key=%s" % (keyname))
         return self.make_ui_callback('key-press', keyname)
 
@@ -328,7 +326,7 @@ class ImageViewEvent(ImageViewMock):
         # get keyname or keycode and translate to ginga standard
         # keyname =
         # keycode =
-        keyname = self.transkey(keyname, keycode)
+        keyname = ''  # self.transkey(keyname, keycode)
         self.logger.debug("key release event, key=%s" % (keyname))
         return self.make_ui_callback('key-release', keyname)
 
@@ -337,6 +335,8 @@ class ImageViewEvent(ImageViewMock):
         Called when a mouse button is pressed in the widget.
         Adjust method signature as appropriate for callback.
         """
+        x, y = event.x, event.y
+
         # x, y = coordinates where the button was pressed
         self.last_win_x, self.last_win_y = x, y
 
@@ -357,6 +357,8 @@ class ImageViewEvent(ImageViewMock):
         Called when a mouse button is released after being pressed.
         Adjust method signature as appropriate for callback.
         """
+        x, y = event.x, event.y
+
         # x, y = coordinates where the button was released
         self.last_win_x, self.last_win_y = x, y
 
@@ -372,6 +374,8 @@ class ImageViewEvent(ImageViewMock):
         Called when a mouse cursor is moving in the widget.
         Adjust method signature as appropriate for callback.
         """
+        x, y = event.x, event.y
+
         # x, y = coordinates of cursor
         self.last_win_x, self.last_win_y = x, y
 
@@ -388,6 +392,10 @@ class ImageViewEvent(ImageViewMock):
         finger scrolling in the trackpad).
         Adjust method signature as appropriate for callback.
         """
+        x, y = event.x, event.y
+        numDegrees = 0
+        direction = 0
+
         # x, y = coordinates of mouse
         self.last_win_x, self.last_win_y = x, y
 
@@ -401,7 +409,7 @@ class ImageViewEvent(ImageViewMock):
         data_x, data_y = self.check_cursor_location()
 
         return self.make_ui_callback('scroll', direction, numDegrees,
-                                  data_x, data_y)
+                                     data_x, data_y)
 
     def drop_event(self, widget, event):
         """
@@ -409,8 +417,9 @@ class ImageViewEvent(ImageViewMock):
         Adjust method signature as appropriate for callback.
         """
         # make a call back with a list of URLs that were dropped
-        self.logger.debug("dropped filename(s): %s" % (str(paths)))
-        self.make_ui_callback('drag-drop', paths)
+        #self.logger.debug("dropped filename(s): %s" % (str(paths)))
+        #self.make_ui_callback('drag-drop', paths)
+        raise NotImplementedError
 
 
 class ImageViewZoom(Mixins.UIMixin, ImageViewEvent):

--- a/ginga/tkw/ImageViewTk.py
+++ b/ginga/tkw/ImageViewTk.py
@@ -3,6 +3,7 @@
 #
 # This is open-source software licensed under a BSD license.
 # Please see the file LICENSE.txt for details.
+from __future__ import absolute_import
 
 from ginga.util import six
 

--- a/ginga/tkw/ImageViewTk.py
+++ b/ginga/tkw/ImageViewTk.py
@@ -4,7 +4,6 @@
 # This is open-source software licensed under a BSD license.
 # Please see the file LICENSE.txt for details.
 
-import numpy
 from ginga.util import six
 
 import PIL.Image as PILimage
@@ -20,36 +19,38 @@ except ImportError:
     else:
         from tkinter import PhotoImage
 
-from ginga import Mixins, Bindings, colors
-from ginga.canvas.mixins import DrawingMixin, CanvasMixin, CompoundMixin
-from ginga.util.toolbox import ModeIndicator
-from ginga.tkw import TkHelp
+from ginga import Mixins, Bindings  # noqa
+from ginga.canvas.mixins import DrawingMixin, CanvasMixin, CompoundMixin  # noqa
+from ginga.util.toolbox import ModeIndicator  # noqa
+
+from . import TkHelp  # noqa
 
 try:
     # See if we have aggdraw module--best choice
     from ginga.aggw.ImageViewAgg import ImageViewAgg as ImageView, \
-         ImageViewAggError as ImageViewError
+        ImageViewAggError as ImageViewError
 
 except ImportError:
     try:
         # No dice. How about the PIL module?
         from ginga.pilw.ImageViewPil import ImageViewPil as ImageView, \
-             ImageViewPilError as ImageViewError
+            ImageViewPilError as ImageViewError
 
     except ImportError:
         try:
             # No, hmm..ok, see if we have opencv module...
             from ginga.cvw.ImageViewCv import ImageViewCv as ImageView, \
-                 ImageViewCvError as ImageViewError
+                ImageViewCvError as ImageViewError
 
         except ImportError:
             # Fall back to mock--there will be no graphic overlays
             from ginga.mockw.ImageViewMock import ImageViewMock as ImageView, \
-                 ImageViewMockError as ImageViewError
+                ImageViewMockError as ImageViewError
 
 
 class ImageViewTkError(ImageViewError):
     pass
+
 
 class ImageViewTk(ImageView):
 
@@ -63,7 +64,6 @@ class ImageViewTk(ImageView):
 
         self._defer_task = None
         self.msgtask = None
-
 
     def set_widget(self, canvas):
         """Call this method with the Tkinter canvas that will be used
@@ -227,7 +227,7 @@ class ImageViewEvent(ImageViewTk):
             'end': 'end',
             'prior': 'page_up',
             'next': 'page_down',
-            }
+        }
 
         # Define cursors for pick and pan
         #hand = openHandCursor()
@@ -306,7 +306,8 @@ class ImageViewEvent(ImageViewTk):
         return self.make_ui_callback('key-release', keyname)
 
     def button_press_event(self, event):
-        x = event.x; y = event.y
+        x = event.x
+        y = event.y
         self.last_win_x, self.last_win_y = x, y
 
         button = 0
@@ -326,7 +327,7 @@ class ImageViewEvent(ImageViewTk):
                 data_x, data_y = self.check_cursor_location()
 
                 return self.make_ui_callback('scroll', direction, numDegrees,
-                                          data_x, data_y)
+                                             data_x, data_y)
 
             button |= 0x1 << (event.num - 1)
         self._button = button
@@ -338,7 +339,8 @@ class ImageViewEvent(ImageViewTk):
 
     def button_release_event(self, event):
         # event.button, event.x, event.y
-        x = event.x; y = event.y
+        x = event.x
+        y = event.y
         self.last_win_x, self.last_win_y = x, y
 
         button = 0
@@ -444,6 +446,7 @@ class CanvasView(ImageViewZoom):
 
 class ImageViewCanvasError(ImageViewTkError):
     pass
+
 
 class ImageViewCanvas(ImageViewZoom,
                       DrawingMixin, CanvasMixin, CompoundMixin):


### PR DESCRIPTION
Address #563 for files under `mockw` and `tkw` sub-directories. (I attached `tkw` here because it uses `mockw`)

I must admit that I don't understand what the "mock" stuff is for, but I found a lot of undefined variables, so I tried to either raise an exception or define them. Please review this one carefully and advise what to do for those cases.