### PR TITLE
Make AstroImage respect set_ioClass and set_wcsClass methods.

### DIFF
--- a/ginga/AstroImage.py
+++ b/ginga/AstroImage.py
@@ -42,7 +42,7 @@ class AstroImage(BaseImage):
         cls.ioClass = klass
 
     def __init__(self, data_np=None, metadata=None, logger=None,
-                 name=None, wcsclass=wcsClass, ioclass=ioClass,
+                 name=None, wcsclass=None, ioclass=None,
                  inherit_primary_header=False):
 
         BaseImage.__init__(self, data_np=data_np, metadata=metadata,
@@ -50,12 +50,19 @@ class AstroImage(BaseImage):
 
         # wcsclass specifies a pluggable WCS module
         if wcsclass is None:
-            wcsclass = wcsmod.WCS
+             if self.wcsClass is None:
+                 wcsclass = wcsmod.WCS
+             else:
+                 wcsclass = self.wcsClass
         self.wcs = wcsclass(self.logger)
 
         # ioclass specifies a pluggable IO module
         if ioclass is None:
-            ioclass = io_fits.fitsLoaderClass
+            if self.ioClass is None:
+                ioclass = io_fits.fitsLoaderClass
+            else:
+                ioclass = self.ioClass
+            
         self.io = ioclass(self.logger)
         self.io.register_type('image', self.__class__)
 


### PR DESCRIPTION
The `__init__` method uses the class attributes `ioClass` and `wcsClass` in the method definition for keyword defaults.  The class methods `set_ioClass` and `set_wcsClass` change their resepective class attributes, but the `__init__` method function call is not updated to reflect the change.  Solution: set the `__init__` keywords `ioclass` and `wcsclass` to `None`, test these for `None` first, then test `self.ioClass` and `self.wcsClass` before falling back on the defaults.