### PR TITLE
Open file in binary mode for MultiDim save slice

### DIFF
--- a/ginga/rv/plugins/MultiDim.py
+++ b/ginga/rv/plugins/MultiDim.py
@@ -652,7 +652,7 @@ class MultiDim(GingaPlugin.LocalPlugin):
             # save canceled
             return
 
-        with open(target, 'w') as target_file:
+        with open(target, 'wb') as target_file:
             hival = self.fitsimage.get_cut_levels()[1]
             image = self.fitsimage.get_image()
             curr_slice_data = image.get_data()


### PR DESCRIPTION
Without this fix, I get the following error in Python 3 when I click the "Save Slice" button in `MultiDim`:
```
Error making callback 'activated': write() argument must be str, not bytes
Traceback:
  File ".../ginga/misc/Callback.py", line 128, in make_callback
    res = method(*cb_args, **cb_kwdargs)

  File ".../ginga/rv/plugins/MultiDim.py", line 169, in <lambda>
    b.save_slice.add_callback('activated', lambda w: self.save_slice_cb())

  File ".../ginga/rv/plugins/MultiDim.py", line 661, in save_slice_cb
    cmap=plt.get_cmap('gray'), origin='lower')

  File ".../matplotlib/pyplot.py", line 2319, in imsave
    return _imsave(*args, **kwargs)

  File ".../matplotlib/image.py", line 1347, in imsave
    image.write_png(fname)

  File ".../matplotlib/image.py", line 578, in write_png
    _png.write_png(im, fname)
```