### PR TITLE
Do not load deprecated Matplotlib colormaps

### DIFF
--- a/ginga/cmap.py
+++ b/ginga/cmap.py
@@ -7,6 +7,8 @@
 from __future__ import absolute_import, print_function
 from .util import six
 
+import warnings
+
 import numpy as np
 
 __all__ = ['ColorMap', 'add_cmap', 'get_cmap', 'has_cmap', 'get_names',
@@ -13307,9 +13309,10 @@ def add_matplotlib_cmaps(fail_on_import_error=True):
     """Add all matplotlib colormaps."""
     try:
         from matplotlib import cm as _cm
-    except ImportError as e:
+        from matplotlib.cbook import mplDeprecation
+    except ImportError:
         if fail_on_import_error:
-            raise e
+            raise
         # silently fail
         return
 
@@ -13317,8 +13320,11 @@ def add_matplotlib_cmaps(fail_on_import_error=True):
         if not isinstance(name, six.string_types):
             continue
         try:
-            cm = _cm.get_cmap(name)
-            add_matplotlib_cmap(cm, name=name)
+            # Do not load deprecated colormaps
+            with warnings.catch_warnings():
+                warnings.simplefilter('error', mplDeprecation)
+                cm = _cm.get_cmap(name)
+                add_matplotlib_cmap(cm, name=name)
         except Exception as e:
             if fail_on_import_error:
                 print("Error adding colormap '%s': %s" % (name, str(e)))
@@ -13332,8 +13338,6 @@ for name, value in list(globals().items()):
         add_cmap(key, value)
 
 # by default add matplotlib colormaps, if available
-# NOTE: disable until we can figure out how to iterate over all the colormaps
-# without forcing warnings for maps to be deprecated
-#add_matplotlib_cmaps(fail_on_import_error=False)
+add_matplotlib_cmaps(fail_on_import_error=False)
 
-#END
+# END


### PR DESCRIPTION
Fix #553.

Re-enable auto-loading of `matplotlib` colormaps. However, do not load deprecated colormaps. This is because loading deprecated ones result in duplicate colormaps (you have the deprecated one *and* the new one that is replacing it). Instead, you will see these messages on the terminal when you start Ginga:

```Error adding colormap 'spectral': The spectral and spectral_r colormap was deprecated in version 2.0. Use nipy_spectral and nipy_spectral_r instead.
Error adding colormap 'Vega10': The Vega10 colormap was deprecated in version 2.0. Use tab10 instead.
Error adding colormap 'Vega20': The Vega20 colormap was deprecated in version 2.0. Use tab20 instead.
Error adding colormap 'Vega20b': The Vega20b colormap was deprecated in version 2.0. Use tab20b instead.
Error adding colormap 'Vega20c': The Vega20c colormap was deprecated in version 2.0. Use tab20c instead.
Error adding colormap 'spectral_r': The spectral and spectral_r colormap was deprecated in version 2.0. Use nipy_spectral and nipy_spectral_r instead.
Error adding colormap 'Vega10_r': The Vega10_r colormap was deprecated in version 2.0. Use tab10_r instead.
Error adding colormap 'Vega20_r': The Vega20_r colormap was deprecated in version 2.0. Use tab20_r instead.
Error adding colormap 'Vega20b_r': The Vega20b_r colormap was deprecated in version 2.0. Use tab20b_r instead.
Error adding colormap 'Vega20c_r': The Vega20c_r colormap was deprecated in version 2.0. Use tab20c_r instead.
```