### PR TITLE
Do not print out error when matplotlib colormap import fails

### DIFF
--- a/ginga/rv/main.py
+++ b/ginga/rv/main.py
@@ -382,7 +382,7 @@ class ReferenceViewer(object):
             # Add matplotlib color maps if matplotlib is installed
             try:
                 from ginga import cmap
-                cmap.add_matplotlib_cmaps()
+                cmap.add_matplotlib_cmaps(fail_on_import_error=False)
             except Exception as e:
                 logger.warning(
                     "failed to load matplotlib colormaps: %s" % (str(e)))


### PR DESCRIPTION
Follow up of #609. I find the printed messages too noisy and there is nothing we can do about them.