### PR TITLE
Correct WebKit package name for gtk3

### DIFF
--- a/ginga/gtk3w/Widgets.py
+++ b/ginga/gtk3w/Widgets.py
@@ -23,7 +23,6 @@ has_webkit = False
 
 try:
     # this is necessary to prevent a warning message on import
-    #import gi
     gi.require_version('WebKit2', '4.0')
 
     from gi.repository import WebKit2 as WebKit  # noqa
@@ -31,7 +30,6 @@ try:
 except Exception:
     gi.require_version('WebKit', '3.0')
     from gi.repository import WebKit  #noqa
-    #pass
 
 __all__ = ['WidgetError', 'WidgetBase', 'TextEntry', 'TextEntrySet',
            'TextArea', 'Label', 'Button', 'ComboBox',

--- a/ginga/gtk3w/Widgets.py
+++ b/ginga/gtk3w/Widgets.py
@@ -18,16 +18,20 @@ from gi.repository import Gdk
 from gi.repository import GObject
 from gi.repository import GdkPixbuf
 
+import gi
 has_webkit = False
+
 try:
     # this is necessary to prevent a warning message on import
-    import gi
+    #import gi
     gi.require_version('WebKit2', '4.0')
 
-    from gi.repository import WebKit  # noqa
+    from gi.repository import WebKit2 as WebKit  # noqa
     has_webkit = True
-except ImportError:
-    pass
+except Exception:
+    gi.require_version('WebKit', '3.0')
+    from gi.repository import WebKit  #noqa
+    #pass
 
 __all__ = ['WidgetError', 'WidgetBase', 'TextEntry', 'TextEntrySet',
            'TextArea', 'Label', 'Button', 'ComboBox',

--- a/ginga/gtk3w/Widgets.py
+++ b/ginga/gtk3w/Widgets.py
@@ -29,7 +29,7 @@ try:
     has_webkit = True
 except Exception:
     gi.require_version('WebKit', '3.0')
-    from gi.repository import WebKit  #noqa
+    from gi.repository import WebKit  # noqa
 
 __all__ = ['WidgetError', 'WidgetBase', 'TextEntry', 'TextEntrySet',
            'TextArea', 'Label', 'Button', 'ComboBox',

--- a/ginga/rv/plugins/IRAF.py
+++ b/ginga/rv/plugins/IRAF.py
@@ -613,7 +613,8 @@ class IRAF(GingaPlugin.GlobalPlugin):
                 keyname = chr(4)
 
         # Get cursor position
-        fitsimage = canvas.get_surface()
+        # TODO: not sure that this attribute will be permanent...
+        fitsimage = canvas.viewer
         last_x, last_y = fitsimage.get_last_data_xy()
 
         # Correct for surrounding framebuffer


### PR DESCRIPTION
The WebKit package is renamed as "WebKit2".  The correction fixes the gtk3 backend display.