### PR TITLE
Update mode change

### DIFF
--- a/doc/WhatsNew.rst
+++ b/doc/WhatsNew.rst
@@ -8,6 +8,11 @@ Ver 2.7.0.dev
 - Fix for broken polygon containment test
 - Addition of configurable zoom handlers for pan gestures
 - Fix for some broken tests under python 2.7
+- Update to mode handling via keyboard shortcuts
+  - addition of a new "meta" mode used primarily for mode switching
+  - most modes now initiated from meta mode, which frees up keys
+    for other uses
+  - see quick reference for details on how the new bindings work
 
 Ver 2.6.6 (2017-11-02)
 ======================

--- a/doc/manual/operation.rst
+++ b/doc/manual/operation.rst
@@ -90,16 +90,20 @@ For example:
 
 When zoomed in, panning is enabled. Panning takes two forms:
 
-1) *Proportional panning* or "drag panning" pans the image in direct proportion to the distance the mouse is moved. You can think of this as dragging the image canvas in the direction you want to move it under the window portal. To utilize a proportional pan, Ctrl-drag the canvas, or press
-"q" to go into pan mode, and then drag the canvas.
+1) *Proportional panning* or "drag panning" pans the image in direct
+   proportion to the distance the mouse is moved. You can think of this
+   as dragging the image canvas in the direction you want to move it
+   under the window portal. To utilize a proportional pan, Ctrl-drag the
+   canvas, or press Space followed by "q" to go into pan mode, and then
+   drag the canvas. 
 
-2) *Free panning* allows scrolling around the entire image by mapping
-the entire image boundaries to the window boundaries.  For example,
+2) *Free panning* allows scrolling around the entire image by mapping 
+the entire image boundaries to the window boundaries.  For example, 
 moving the mouse to the upper right-hand corner of the window will pan to
 the upper right hand corner of the image, etc.  You can think of this
 mode as moving the window portal around over the canvas.
-To initiate a free pan, press "w" to enter "freepan" mode and then
-Scroll-drag to move around the window.
+To initiate a free pan, press Space followed by "w" to enter "freepan"
+mode and then Scroll-drag to move around the window.
 
 ``[RV]`` The ``Pan`` plugin (usually embedded under the *Info* tab) shows the
 outline of the current pan position as a rectangle on a small version of
@@ -157,7 +161,7 @@ Manually setting cut levels
 
 There are several ways to manually set the cut levels:
 
-* Pressing and releasing the "s" key will put the viewer into
+* Pressing Space followed by "s" key will put the viewer into
   "cuts" mode.  Here you can invoke a dual (high and low) interactive cut levels. Click and drag the mouse horizontally in the window to interactively set the high level, and vertically to set the low
   level; and when you reach the desired levels, release the mouse
   button. Scrolling the mouse wheel in this mode will also change the
@@ -201,10 +205,9 @@ Ginga supports a number of color scale distribution algorithms, including:
 - "sinh", and
 - "histeq" (histogram equalization).
 
-These can be sampled with the
-current color and intensity maps by pressing the "d" key to go into
-"dist" mode, and then scrolling the mouse, pressing the up/down keys, or
-the "b" and "n" keys.
+These can be sampled with the current color and intensity maps by
+pressing Space followed by "d" key to go into "dist" mode, and then
+scrolling the mouse, pressing the up/down keys, or the "b" and "n" keys.
 
 Press Esc to exit the "dist" mode.
 
@@ -267,12 +270,13 @@ to cycle through the intensity maps.
 Color Maps
 ----------
 
-To change color maps from the keyboard shortcuts, press "Y" to go into
-"cmap" mode. While in "cmap" mode you can change color maps by
-scrolling the mouse, pressing the up/down keys, or the "b" and "n" keys.
+To change color maps from the keyboard shortcuts, press Space followed
+by "y" to go into "cmap" mode. While in "cmap" mode you can change color
+maps by scrolling the mouse, pressing the up/down keys, or the "b" and
+"n" keys. 
 
 While in "cmap" mode, pressing "I" (uppercase) will invert the current
-color map.
+color map.  Press Esc to exit cmap mode.
 
 .. note::
 
@@ -296,9 +300,10 @@ thereof. These operations can be done by keyboard shortcuts:
 
 The image can also be rotated in arbitrary amounts.
 
-An interactive rotate operation can be initiated by pressing "r" in the
-image and then dragging the mouse horizontally left or right to set the
-angle.  Press "R" (Shift+R) to restore the angle to 0 (unrotated).
+An interactive rotate operation can be initiated by pressing Space
+follwed by "r" in the image and then dragging the mouse horizontally
+left or right to set the angle.  Press "R" (Shift+R) to restore the
+angle to 0 (unrotated). 
 
 .. note::
 

--- a/doc/quickref.rst
+++ b/doc/quickref.rst
@@ -85,6 +85,14 @@ triggered from meta mode.
 | d                    | Enter dist (distribution) mode.                  |
 +----------------------+--------------------------------------------------+
 
+.. note:: For modes initiated from meta mode, the locked and softlock
+          mode types work the same way, which is slightly different
+          from that described above: you press the meta mode key to
+          switch back to meta mode, from which you can enter another
+          mode by pressing its key.  You can always press `Esc` in any
+          mode (including meta mode) to exit the mode.
+
+
 .. _panning_zooming_commands:
 
 Panning and zooming commands

--- a/doc/quickref.rst
+++ b/doc/quickref.rst
@@ -19,10 +19,10 @@ Mode control commands
 About modes
 -----------
 
-Certain keystrokes invoke a *mode*---modes are usually indicated by a
-small black rectangle with the mode name in one corner of the view.
-In a mode, there are usually some special key, cursor, and scroll bindings
-that override *some* of the default ones.
+Certain keystrokes invoke a *mode*---modes are usually indicated by the
+*mode indicator*: a small black rectangle with the mode name in one corner
+of the view.  In a mode, there are usually some special key, cursor, and
+scroll bindings that override *some* of the default ones.
 
 Modes additionally have a *mode type* which can be set to one of the following:
 
@@ -33,11 +33,16 @@ Modes additionally have a *mode type* which can be set to one of the following:
 * `softlock`: mode is locked until another mode key is pressed (or `Esc`)
 
 By default, most modes are activated in "oneshot" type, unless the mode
-lock is toggled.
+lock is toggled.  The mode type is indicated in the brackets after the
+mode name in the mode indicator.  The following keys are important for
+initiating a mode:
 
 +----------------------+--------------------------------------------------+
 | Commmand             | Description                                      |
 +======================+==================================================+
+| Space                | Enter "meta" mode. Next keystroke will trigger   |
+|                      | a particular mode.                               |
++----------------------+--------------------------------------------------+
 | Esc                  | Exit any mode. Does not toggle the lock.         |
 +----------------------+--------------------------------------------------+
 | l                    | Toggle the soft lock to the current mode or any  |
@@ -45,6 +50,39 @@ lock is toggled.
 +----------------------+--------------------------------------------------+
 | L                    | Toggle the normal lock to the current mode or    |
 |                      | any future modes.                                |
++----------------------+--------------------------------------------------+
+
+.. _meta_mode:
+
+"meta" mode
+-----------
+
+Most modes are defined so that they are invoked from a special intermediate
+mode called "meta".  In that case a two-key sequence is required to enter
+the mode: pressing the key that invokes "meta" and then pressing the key that
+invokes the desired mode.  The following table shows the modes that can be
+triggered from meta mode.
+
++----------------------+--------------------------------------------------+
+| Commmand             | Description                                      |
++======================+==================================================+
+| Space                | Exit/Enter "meta" mode.                          |
++----------------------+--------------------------------------------------+
+| b                    | Enter draw mode (canvas must be enabled to draw).|
++----------------------+--------------------------------------------------+
+| q                    | Enter pan mode.                                  |
++----------------------+--------------------------------------------------+
+| w                    | Enter freepan mode.                              |
++----------------------+--------------------------------------------------+
+| r                    | Enter rotate mode.                               |
++----------------------+--------------------------------------------------+
+| t                    | Enter contrast mode.                             |
++----------------------+--------------------------------------------------+
+| y                    | Enter cmap (color map) mode.                     |
++----------------------+--------------------------------------------------+
+| s                    | Enter cuts mode.                                 |
++----------------------+--------------------------------------------------+
+| d                    | Enter dist (distribution) mode.                  |
 +----------------------+--------------------------------------------------+
 
 .. _panning_zooming_commands:

--- a/ginga/Bindings.py
+++ b/ginga/Bindings.py
@@ -73,7 +73,7 @@ class ImageViewBindings(object):
             # Set up our standard modifiers
             mod_shift=['shift_l', 'shift_r'],
             mod_ctrl=['control_l', 'control_r'],
-            mod_meta=['meta_right'],
+            mod_win=['meta_right'],
 
             # Define our modes
             # Mode 'meta' is special: it is an intermediate mode that
@@ -201,7 +201,7 @@ class ImageViewBindings(object):
             ms_none=['nobtn'],
             ms_cursor=['left'],
             ms_wheel=[],
-            ms_draw=['draw+left', 'meta+left', 'right'],
+            ms_draw=['draw+left', 'win+left', 'right'],
 
             ms_rotate=['rotate+left'],
             ms_rotate_reset=['rotate+right'],
@@ -2481,7 +2481,7 @@ class BindingMapper(Callback.Callbacks):
             for keyname in ('control_l', 'control_r'):
                 self.add_modifier(keyname, 'ctrl')
             for keyname in ('meta_right',):
-                self.add_modifier(keyname, 'meta')
+                self.add_modifier(keyname, 'win')
         else:
             self.modifier_map = modifier_map
 

--- a/ginga/Bindings.py
+++ b/ginga/Bindings.py
@@ -1070,17 +1070,6 @@ class ImageViewBindings(object):
 
     #####  KEYBOARD ACTION CALLBACKS #####
 
-    def kp_mode_change(self, viewer, event, data_x, data_y, msg=True):
-        """Change the mode of the viewer."""
-        bd = viewer.get_bindmap()
-        if event.key not in bd.mode_tbl:
-            viewer.onscreen_message("? Key: '%s'" % event.key, delay=0.5)
-            return True
-
-        mode = bd.mode_tbl[event.key]
-        bd.set_mode(mode)
-        return True
-
     def kp_pan_set(self, viewer, event, data_x, data_y, msg=True):
         """Sets the pan position under the cursor."""
         if self.canpan:

--- a/ginga/Bindings.py
+++ b/ginga/Bindings.py
@@ -76,16 +76,22 @@ class ImageViewBindings(object):
             mod_meta=['meta_right'],
 
             # Define our modes
-            dmod_draw=['space', None, None],
-            dmod_cmap=['y', None, None],
-            dmod_cuts=['s', None, None],
-            dmod_dist=['d', None, None],
-            dmod_contrast=['t', None, None],
-            dmod_rotate=['r', None, None],
-            dmod_pan=['q', None, 'pan'],
-            dmod_freepan=['w', None, 'pan'],
-            dmod_camera=[None, None, 'pan'],
-            dmod_naxis=[None, None, None],
+            # Mode 'meta' is special: it is an intermediate mode that
+            # is used primarily to launch other modes
+            # If the mode initiation character is preceeded by a double
+            # underscore, then the mode must be initiated from the "meta"
+            # mode.
+            dmod_meta=['space', None, None],
+            dmod_draw=['__b', None, None],
+            dmod_cmap=['__y', None, None],
+            dmod_cuts=['__s', None, None],
+            dmod_dist=['__d', None, None],
+            dmod_contrast=['__t', None, None],
+            dmod_rotate=['__r', None, None],
+            dmod_pan=['__q', None, 'pan'],
+            dmod_freepan=['__w', None, 'pan'],
+            dmod_camera=['__c', None, 'pan'],
+            dmod_naxis=['__n', None, None],
 
             default_mode_type='oneshot',
             default_lock_mode_type='softlock',
@@ -149,8 +155,8 @@ class ImageViewBindings(object):
             kp_poly_del=['z', 'draw+z'],
             kp_edit_del=['draw+x'],
             kp_reset=['escape'],
-            kp_lock=['L'],
-            kp_softlock=['l'],
+            kp_lock=['L', 'meta+L'],
+            kp_softlock=['l', 'meta+l'],
             kp_camera_save=['camera+s'],
             kp_camera_reset=['camera+r'],
             kp_camera_toggle3d=['camera+3'],
@@ -1063,6 +1069,17 @@ class ImageViewBindings(object):
         return True
 
     #####  KEYBOARD ACTION CALLBACKS #####
+
+    def kp_mode_change(self, viewer, event, data_x, data_y, msg=True):
+        """Change the mode of the viewer."""
+        bd = viewer.get_bindmap()
+        if event.key not in bd.mode_tbl:
+            viewer.onscreen_message("? Key: '%s'" % event.key, delay=0.5)
+            return True
+
+        mode = bd.mode_tbl[event.key]
+        bd.set_mode(mode)
+        return True
 
     def kp_pan_set(self, viewer, event, data_x, data_y, msg=True):
         """Sets the pan position under the cursor."""
@@ -2466,7 +2483,7 @@ class BindingMapper(Callback.Callbacks):
             for keyname in ('meta_right',):
                 self.add_modifier(keyname, 'meta')
         else:
-            self.modifier_map = mode_map
+            self.modifier_map = modifier_map
 
         # Set up mode mapping
         if mode_map is None:
@@ -2475,6 +2492,7 @@ class BindingMapper(Callback.Callbacks):
             self.mode_map = mode_map
 
         self._empty_set = frozenset([])
+        self.mode_tbl = dict()
 
         # For callbacks
         for name in ('mode-set', ):
@@ -2520,8 +2538,12 @@ class BindingMapper(Callback.Callbacks):
 
         bnch = Bunch.Bunch(name=mode_name, type=mode_type, msg=msg)
         if keyname is not None:
-            # No key to launch this mode
-            self.mode_map[keyname] = bnch
+            # Key to launch this mode
+            if keyname[0:2] == '__':
+                keyname = keyname[2]
+                self.mode_tbl[keyname] = bnch
+            else:
+                self.mode_map[keyname] = bnch
         self.mode_map['mode_%s' % mode_name] = bnch
 
     def set_mode(self, name, mode_type=None):
@@ -2612,11 +2634,16 @@ class BindingMapper(Callback.Callbacks):
         keyname = event.key
         # Is this a mode key?
         if keyname not in self.mode_map:
-            # No
-            return False
+            if (keyname not in self.mode_tbl) or (self._kbdmode != 'meta'):
+                # No
+                return False
+            bnch = self.mode_tbl[keyname]
+        else:
+            bnch = self.mode_map[keyname]
 
-        bnch = self.mode_map[keyname]
         mode_name = bnch.name
+        self.logger.debug("cur mode='%s' mode pressed='%s'" % (
+            self._kbdmode, mode_name))
 
         if mode_name == self._kbdmode:
             # <== same key was pressed that started the mode we're in
@@ -2631,12 +2658,14 @@ class BindingMapper(Callback.Callbacks):
             self._delayed_reset = False
             return True
 
-        if (self._kbdmode is None) or (self._kbdmode_type != 'locked'):
+        if ((self._kbdmode in (None, 'meta'))
+            or (self._kbdmode_type != 'locked')
+            or (mode_name == 'meta')):
             if self._kbdmode is not None:
                 self.reset_mode(viewer)
 
             # activate this mode
-            if self._kbdmode is None:
+            if self._kbdmode in (None, 'meta'):
                 mode_type = bnch.type
                 if mode_type is None:
                     mode_type = self._kbdmode_type_default

--- a/ginga/canvas/types/utils.py
+++ b/ginga/canvas/types/utils.py
@@ -421,6 +421,7 @@ class ModeIndicator(CanvasObjectBase):
         self.kind = 'modeindicator'
         self.xpad = 8
         self.ypad = 4
+        self.modetbl = dict(locked='L', softlock='S', held='H', oneshot='O')
 
     def draw(self, viewer):
 
@@ -435,12 +436,11 @@ class ModeIndicator(CanvasObjectBase):
         cr = viewer.renderer.setup_cr(self)
         tr = viewer.tform['window_to_native']
 
-        if mode_type == 'locked':
-            text = '%s [L]' % (mode)
-        elif mode_type == 'softlock':
-            text = '%s [SL]' % (mode)
-        else:
-            text = mode
+        text = mode
+        if modetype in self.modetbl:
+            text += ' [%s]' % self.modetbl[modetype]
+
+        color = 'cyan' if mode == 'meta' else self.color
 
         cr.set_font(self.font, self.fontsize, color=self.color,
                     alpha=self.alpha)

--- a/ginga/examples/bindings/bindings.cfg.ds9
+++ b/ginga/examples/bindings/bindings.cfg.ds9
@@ -32,25 +32,31 @@ btn_right = 0x4
 mod_shift = ['shift_l', 'shift_r']
 # same setting ends up as "Ctrl" on a pc and "Command" on a mac:
 mod_ctrl = ['control_l', 'control_r']
-# "Control" key on a mac:
-mod_meta = ['meta_right']
+# "Control" key on a mac, "Windows" key on a pc keyboard:
+mod_win = ['meta_right']
 
 # Define up our custom modifiers.
 # These are typically "normal" keys.  The modifier is defined by a triplet:
 # [ keyname, modtype, msg ], where
 # keyname is a key whose press initiates the modifier,
-# modtype is either None or a type in {'held', 'oneshot', 'locked'}
+# modtype is either None or a type in {'held', 'oneshot', 'locked', 'softlock'}
 # msg is a string to be shown in the display or None for no indicator
-dmod_draw = ['space', None, None]
-dmod_edit = ['b', None, None]
-dmod_cmap = ['y', None, None]
-dmod_cuts = ['s', None, None]
-dmod_dist = ['d', None, None]
-dmod_contrast = ['t', None, None]
-dmod_rotate = ['r', None, None]
-dmod_pan = ['q', None, None]
-dmod_freepan = ['w', None, None]
-dmod_naxis = [None, None, None]
+# Mode 'meta' is special: it is an intermediate mode that
+# is used primarily to launch other modes
+# If the mode initiation character is preceeded by a double
+# underscore, then the mode must be initiated from the "meta"
+# mode.
+dmod_meta = ['space', None, None]
+dmod_draw = ['__b', None, None]
+dmod_cmap = ['__y', None, None]
+dmod_cuts = ['__s', None, None]
+dmod_dist = ['__d', None, None]
+dmod_contrast = ['__t', None, None]
+dmod_rotate = ['__r', None, None]
+dmod_pan = ['__q', None, 'pan']
+dmod_freepan = ['__w', None, 'pan']
+dmod_camera = ['__c', None, 'pan']
+dmod_naxis = ['__n', None, None]
 
 default_mode_type = 'oneshot'
 default_lock_mode_type = 'softlock'
@@ -112,8 +118,11 @@ kp_poly_add = ['v', 'draw+v']
 kp_poly_del = ['z', 'draw+z']
 kp_edit_del = ['draw+x']
 kp_reset = ['escape']
-kp_lock = ['L']
-kp_softlock = ['l']
+kp_lock = ['L', 'meta+L']
+kp_softlock = ['l', 'meta+l']
+kp_camera_save = ['camera+s']
+kp_camera_reset = ['camera+r']
+kp_camera_toggle3d = ['camera+3']
 
 # pct of a window of data to move with pan key commands
 key_pan_pct = 0.666667
@@ -134,6 +143,7 @@ sc_cuts_alg = []
 sc_dist = ['dist+scroll']
 sc_cmap = ['cmap+scroll']
 sc_imap = ['cmap+ctrl+scroll']
+sc_camera_track = ['camera+scroll']
 sc_naxis = ['naxis+scroll']
 
 # This controls how fast panning occurs with the sc_pan* functions.
@@ -153,7 +163,7 @@ scroll_zoom_direct_scale = False
 ms_none = ['nobtn']
 ms_cursor = ['left']
 ms_wheel = []
-ms_draw = ['draw+left', 'meta+left']
+ms_draw = ['draw+left', 'win+left']
 ms_edit = ['edit+left']
 
 # mouse commands initiated by a preceeding keystroke (see above)
@@ -173,6 +183,8 @@ ms_cut_auto = ['cuts+right']
 ms_panset = ['pan+middle', 'shift+left', 'middle']
 ms_cmap_rotate = ['cmap+left']
 ms_cmap_restore = ['cmap+right']
+ms_camera_orbit = ['camera+left']
+ms_camera_pan_delta = ['camera+right']
 ms_naxis = ['naxis+left']
 
 mouse_zoom_acceleration = 1.085

--- a/ginga/examples/bindings/bindings.cfg.standard
+++ b/ginga/examples/bindings/bindings.cfg.standard
@@ -32,25 +32,31 @@ btn_right = 0x4
 mod_shift = ['shift_l', 'shift_r']
 # same setting ends up as "Ctrl" on a pc and "Command" on a mac:
 mod_ctrl = ['control_l', 'control_r']
-# "Control" key on a mac:
-mod_meta = ['meta_right']
+# "Control" key on a mac, "Windows" key on a pc keyboard:
+mod_win = ['meta_right']
 
 # Define up our custom modifiers.
 # These are typically "normal" keys.  The modifier is defined by a triplet:
 # [ keyname, modtype, msg ], where
 # keyname is a key whose press initiates the modifier,
-# modtype is either None or a type in {'held', 'oneshot', 'locked'}
+# modtype is either None or a type in {'held', 'oneshot', 'locked', 'softlock'}
 # msg is a string to be shown in the display or None for no indicator
-dmod_draw = ['space', None, None]
-dmod_edit = ['b', None, None]
-dmod_cmap = ['y', None, None]
-dmod_cuts = ['s', None, None]
-dmod_dist = ['d', None, None]
-dmod_contrast = ['t', None, None]
-dmod_rotate = ['r', None, None]
-dmod_pan = ['q', None, None]
-dmod_freepan = ['w', None, None]
-dmod_naxis = [None, None, None]
+# Mode 'meta' is special: it is an intermediate mode that
+# is used primarily to launch other modes
+# If the mode initiation character is preceeded by a double
+# underscore, then the mode must be initiated from the "meta"
+# mode.
+dmod_meta = ['space', None, None]
+dmod_draw = ['__b', None, None]
+dmod_cmap = ['__y', None, None]
+dmod_cuts = ['__s', None, None]
+dmod_dist = ['__d', None, None]
+dmod_contrast = ['__t', None, None]
+dmod_rotate = ['__r', None, None]
+dmod_pan = ['__q', None, 'pan']
+dmod_freepan = ['__w', None, 'pan']
+dmod_camera = ['__c', None, 'pan']
+dmod_naxis = ['__n', None, None]
 
 default_mode_type = 'oneshot'
 default_lock_mode_type = 'softlock'
@@ -112,8 +118,11 @@ kp_poly_add = ['v', 'draw+v']
 kp_poly_del = ['z', 'draw+z']
 kp_edit_del = ['draw+x']
 kp_reset = ['escape']
-kp_lock = ['L']
-kp_softlock = ['l']
+kp_lock = ['L', 'meta+L']
+kp_softlock = ['l', 'meta+l']
+kp_camera_save = ['camera+s']
+kp_camera_reset = ['camera+r']
+kp_camera_toggle3d = ['camera+3']
 
 # pct of a window of data to move with pan key commands
 key_pan_pct = 0.666667
@@ -134,6 +143,7 @@ sc_cuts_alg = []
 sc_dist = ['dist+scroll']
 sc_cmap = ['cmap+scroll']
 sc_imap = ['cmap+ctrl+scroll']
+sc_camera_track = ['camera+scroll']
 sc_naxis = ['naxis+scroll']
 
 # This controls how fast panning occurs with the sc_pan* functions.
@@ -153,7 +163,7 @@ scroll_zoom_direct_scale = False
 ms_none = ['nobtn']
 ms_cursor = ['left']
 ms_wheel = []
-ms_draw = ['draw+left', 'meta+left', 'right']
+ms_draw = ['draw+left', 'win+left', 'right']
 ms_edit = ['edit+left']
 
 # mouse commands initiated by a preceeding keystroke (see above)
@@ -173,6 +183,8 @@ ms_cut_auto = ['cuts+right']
 ms_panset = ['pan+middle', 'shift+left', 'middle']
 ms_cmap_rotate = ['cmap+left']
 ms_cmap_restore = ['cmap+right']
+ms_camera_orbit = ['camera+left']
+ms_camera_pan_delta = ['camera+right']
 ms_naxis = ['naxis+left']
 
 mouse_zoom_acceleration = 1.085

--- a/ginga/examples/bindings/bindings.cfg.trackpad
+++ b/ginga/examples/bindings/bindings.cfg.trackpad
@@ -32,25 +32,31 @@ btn_right = 0x4
 mod_shift = ['shift_l', 'shift_r']
 # same setting ends up as "Ctrl" on a pc and "Command" on a mac:
 mod_ctrl = ['control_l', 'control_r']
-# "Control" key on a mac:
-mod_meta = ['meta_right']
+# "Control" key on a mac, "Windows" key on a pc keyboard:
+mod_win = ['meta_right']
 
 # Define up our custom modifiers.
 # These are typically "normal" keys.  The modifier is defined by a triplet:
 # [ keyname, modtype, msg ], where
 # keyname is a key whose press initiates the modifier,
-# modtype is either None or a type in {'held', 'oneshot', 'locked'}
+# modtype is either None or a type in {'held', 'oneshot', 'locked', 'softlock'}
 # msg is a string to be shown in the display or None for no indicator
-dmod_draw = ['space', None, None]
-dmod_edit = ['b', None, None]
-dmod_cmap = ['y', None, None]
-dmod_cuts = ['s', None, None]
-dmod_dist = ['d', None, None]
-dmod_contrast = ['t', None, None]
-dmod_rotate = ['r', None, None]
-dmod_pan = ['q', None, None]
-dmod_freepan = ['w', None, None]
-dmod_naxis = [None, None, None]
+# Mode 'meta' is special: it is an intermediate mode that
+# is used primarily to launch other modes
+# If the mode initiation character is preceeded by a double
+# underscore, then the mode must be initiated from the "meta"
+# mode.
+dmod_meta = ['space', None, None]
+dmod_draw = ['__b', None, None]
+dmod_cmap = ['__y', None, None]
+dmod_cuts = ['__s', None, None]
+dmod_dist = ['__d', None, None]
+dmod_contrast = ['__t', None, None]
+dmod_rotate = ['__r', None, None]
+dmod_pan = ['__q', None, 'pan']
+dmod_freepan = ['__w', None, 'pan']
+dmod_camera = ['__c', None, 'pan']
+dmod_naxis = ['__n', None, None]
 
 default_mode_type = 'oneshot'
 default_lock_mode_type = 'softlock'
@@ -112,8 +118,11 @@ kp_poly_add = ['v', 'draw+v']
 kp_poly_del = ['z', 'draw+z']
 kp_edit_del = ['draw+x']
 kp_reset = ['escape']
-kp_lock = ['L']
-kp_softlock = ['l']
+kp_lock = ['L', 'meta+L']
+kp_softlock = ['l', 'meta+l']
+kp_camera_save = ['camera+s']
+kp_camera_reset = ['camera+r']
+kp_camera_toggle3d = ['camera+3']
 
 # pct of a window of data to move with pan key commands
 key_pan_pct = 0.666667
@@ -134,6 +143,7 @@ sc_cuts_alg = []
 sc_dist = ['dist+scroll']
 sc_cmap = ['cmap+scroll']
 sc_imap = ['cmap+ctrl+scroll']
+sc_camera_track = ['camera+scroll']
 sc_naxis = ['naxis+scroll']
 
 # This controls how fast panning occurs with the sc_pan* functions.
@@ -153,7 +163,7 @@ scroll_zoom_direct_scale = False
 ms_none = ['nobtn']
 ms_cursor = ['left']
 ms_wheel = []
-ms_draw = ['draw+left', 'meta+left', 'right']
+ms_draw = ['draw+left', 'win+left', 'right']
 ms_edit = ['edit+left']
 
 # mouse commands initiated by a preceeding keystroke (see above)
@@ -173,6 +183,8 @@ ms_cut_auto = ['cuts+right']
 ms_panset = ['pan+middle', 'shift+left', 'middle']
 ms_cmap_rotate = ['cmap+left']
 ms_cmap_restore = ['cmap+right']
+ms_camera_orbit = ['camera+left']
+ms_camera_pan_delta = ['camera+right']
 ms_naxis = ['naxis+left']
 
 mouse_zoom_acceleration = 1.085

--- a/ginga/util/toolbox.py
+++ b/ginga/util/toolbox.py
@@ -42,6 +42,7 @@ class ModeIndicator(object):
         self.xpad = 8
         self.ypad = 4
         self.offset = 10
+        self.modetbl = dict(locked='L', softlock='S', held='H', oneshot='O')
 
         # for displaying modal keyboard state
         self.mode_obj = None
@@ -69,15 +70,14 @@ class ModeIndicator(object):
             Polygon = canvas.get_draw_class('polygon')
             Compound = canvas.get_draw_class('compoundobject')
 
-            if modetype == 'locked':
-                text = '%s [L]' % (mode)
-            elif modetype == 'softlock':
-                text = '%s [SL]' % (mode)
-            else:
-                text = mode
+            text = mode
+            if modetype in self.modetbl:
+                text += ' [%s]' % self.modetbl[modetype]
+
+            color = 'cyan' if mode == 'meta' else 'yellow'
 
             o1 = Text(0, 0, text,
-                      fontsize=self.fontsize, color='yellow', coord='window')
+                      fontsize=self.fontsize, color=color, coord='window')
 
             txt_wd, txt_ht = self.viewer.renderer.get_dimensions(o1)
 


### PR DESCRIPTION
This adds a special "meta" mode, which is an intermediate mode used to change modes.  In addition, the standard modes are all changed to be started from meta mode.  Under the new scheme, you press Space to invoke meta mode, then press the mode key that then invokes the mode you want.

The primary benefit of this modification is that it frees many key bindings that can be used for other things, and allows more keys to be bound within a mode.

The mode indicator has been updated to show a different color for the meta mode and also to show an indicator for all mode types, not just "locked" (L) and "softlock" (S), but also "held" (H) and "oneshot" (O).

This change affects the standard key bindings--documentation on quickref and manual has been updated.  The old behavior can be retained by simply installing the appropriate bindings.cfg file to $HOME/.ginga.
