### PR TITLE
Profile support

### DIFF
--- a/ginga/Bindings.py
+++ b/ginga/Bindings.py
@@ -933,7 +933,7 @@ class ImageViewBindings(object):
                 if idx < 0:
                     idx = len(cmapnames) - 1
             cmapname = cmapnames[idx]
-            rgbmap.set_cmap(cmap.get_cmap(cmapname))
+            viewer.set_color_map(cmapname)
             if msg:
                 viewer.onscreen_message("Color map: %s" % (cmapname),
                                         delay=1.0)
@@ -944,7 +944,7 @@ class ImageViewBindings(object):
             rgbmap = viewer.get_rgbmap()
             # default
             cmapname = 'gray'
-            rgbmap.set_cmap(cmap.get_cmap(cmapname))
+            viewer.set_color_map(cmapname)
             if msg:
                 viewer.onscreen_message("Color map: %s" % (cmapname),
                                         delay=1.0)
@@ -973,7 +973,7 @@ class ImageViewBindings(object):
                 if idx < 0:
                     idx = len(imapnames) - 1
             imapname = imapnames[idx]
-            rgbmap.set_imap(imap.get_imap(imapname))
+            viewer.set_intensity_map(imapname)
             if msg:
                 viewer.onscreen_message("Intensity map: %s" % (imapname),
                                         delay=1.0)
@@ -984,7 +984,7 @@ class ImageViewBindings(object):
             rgbmap = viewer.get_rgbmap()
             # default
             imapname = 'ramp'
-            rgbmap.set_imap(imap.get_imap(imapname))
+            viewer.set_intensity_map(imapname)
             if msg:
                 viewer.onscreen_message("Intensity map: %s" % (imapname),
                                         delay=1.0)

--- a/ginga/Bindings.py
+++ b/ginga/Bindings.py
@@ -941,7 +941,6 @@ class ImageViewBindings(object):
     def _reset_cmap(self, viewer, msg):
         if self.cancmap:
             msg = self.settings.get('msg_cmap', msg)
-            rgbmap = viewer.get_rgbmap()
             # default
             cmapname = 'gray'
             viewer.set_color_map(cmapname)
@@ -981,7 +980,6 @@ class ImageViewBindings(object):
     def _reset_imap(self, viewer, msg):
         if self.cancmap:
             msg = self.settings.get('msg_imap', msg)
-            rgbmap = viewer.get_rgbmap()
             # default
             imapname = 'ramp'
             viewer.set_intensity_map(imapname)

--- a/ginga/Bindings.py
+++ b/ginga/Bindings.py
@@ -147,6 +147,7 @@ class ImageViewBindings(object):
             kp_flip_y=[']', '}', 'rotate+]', 'rotate+}'],
             kp_swap_xy=['backslash', '|', 'rotate+backslash', 'rotate+|'],
             kp_rotate_reset=['R', 'rotate+R'],
+            kp_save_profile=['S'],
             kp_rotate_inc90=['.', 'rotate+.'],
             kp_rotate_dec90=[',', 'rotate+,'],
             kp_orient_lh=['o', 'rotate+o'],
@@ -1523,6 +1524,12 @@ class ImageViewBindings(object):
 
     def kp_softlock(self, viewer, event, data_x, data_y):
         self._toggle_lock(viewer, 'softlock')
+        return True
+
+    def kp_save_profile(self, viewer, event, data_x, data_y, msg=True):
+        viewer.checkpoint_profile()
+        if msg:
+            viewer.onscreen_message("Profile saved", delay=0.5)
         return True
 
     #####  MOUSE ACTION CALLBACKS #####

--- a/ginga/ImageView.py
+++ b/ginga/ImageView.py
@@ -20,7 +20,7 @@ import numpy as np
 from ginga.misc import Callback, Settings
 from ginga import BaseImage, AstroImage
 from ginga import RGBMap, AutoCuts, ColorDist
-from ginga import cmap, imap, colors, trcalc
+from ginga import colors, trcalc
 from ginga.canvas import coordmap, transform
 from ginga.canvas.types.layer import DrawingCanvas
 from ginga.util import rgb_cms, addons
@@ -923,7 +923,7 @@ class ImageViewBase(Callback.Callbacks):
         if self.use_image_profile:
             # ? and key in self.profile_keylist
             kwargs = {key: value}
-            profile = self.save_profile(**kwargs)
+            self.save_profile(**kwargs)
 
     def _image_modified_cb(self, image):
 

--- a/ginga/RGBMap.py
+++ b/ginga/RGBMap.py
@@ -236,7 +236,7 @@ class RGBMapper(Callback.Callbacks):
 
     def get_rgbval(self, index):
         """
-        Return a tuple of (R, G, B) values in the 0-maxv range associated
+        Return a tuple of (R, G, B) values in the 0-maxc range associated
         mapped by the value of `index`.
         """
         assert (index >= 0) and (index <= self.maxc), \
@@ -320,7 +320,7 @@ class RGBMapper(Callback.Callbacks):
         if carr is not None:
             carr = np.asarray(carr)
             maxlen = self.maxc + 1
-            self.carr = carr.astype(self.nptype, copy=False)
+            self.carr = carr.astype(self.dtype, copy=False)
             _len = carr.shape[1]
             if _len != maxlen:
                 raise RGBMapError("color map length %d != %d" % (_len, maxlen))
@@ -389,7 +389,7 @@ class RGBMapper(Callback.Callbacks):
         return [order.index(c) for c in cs]
 
     def _get_rgbarray(self, idx, rgbobj, image_order=''):
-        # NOTE: data is assumed to be in the range 0-maxv at this point
+        # NOTE: data is assumed to be in the range 0-maxc at this point
         # but clip as a precaution
         # See NOTE [A]: idx is always an array calculated in the caller and
         #    discarded afterwards
@@ -564,7 +564,7 @@ class NonColorMapper(RGBMapper):
         self.reset_sarr(callback=False)
 
     def _get_rgbarray(self, idx, rgbobj, image_order='RGB'):
-        # NOTE: data is assumed to be in the range 0-maxv at this point
+        # NOTE: data is assumed to be in the range 0-maxc at this point
         # but clip as a precaution
         # See NOTE [A]: idx is always an array calculated in the caller and
         #    discarded afterwards
@@ -600,12 +600,12 @@ class PassThruRGBMapper(RGBMapper):
         self.dist = ColorDist.LinearDist(maxlen)
 
     def get_hasharray(self, idx):
-        # data is already constrained to 0..maxv and we want to
+        # data is already constrained to 0..maxc and we want to
         # bypass color redistribution
         return idx
 
     def _get_rgbarray(self, idx, rgbobj, image_order='RGB'):
-        # NOTE: data is assumed to be in the range 0-maxv at this point
+        # NOTE: data is assumed to be in the range 0-maxc at this point
         # but clip as a precaution
         # See NOTE [A]: idx is always an array calculated in the caller and
         #    discarded afterwards

--- a/ginga/RGBMap.py
+++ b/ginga/RGBMap.py
@@ -221,16 +221,29 @@ class RGBMapper(Callback.Callbacks):
 
     def set_sarr(self, sarr, callback=True):
         maxlen = self.maxc + 1
-        assert len(sarr) == maxlen, \
-            RGBMapError("shift map length %d != %d" % (len(sarr), maxlen))
-        self.sarr = sarr.astype(np.uint, copy=False)
+        sarr = np.asarray(sarr, dtype=np.uint)
+        _len = len(sarr)
+        if _len != maxlen:
+            raise RGBMapError("shift map length %d != %d" % (_len, maxlen))
+        self.sarr = sarr
         self.scale_pct = 1.0
-
         if callback:
             self.make_callback('changed')
 
     def get_sarr(self):
         return self.sarr
+
+    def set_carr(self, carr, callback=True):
+        carr = np.asarray(carr)
+        maxlen = self.maxv + 1
+        self.carr = carr.astype(self.nptype)
+        _len = carr.shape[1]
+        if _len != maxlen:
+            raise RGBMapError("color map length %d != %d" % (_len, maxlen))
+        self.recalc(callback=callback)
+
+    def get_carr(self):
+        return self.carr
 
     def recalc(self, callback=True):
         self.arr = np.copy(self.carr)

--- a/ginga/RGBMap.py
+++ b/ginga/RGBMap.py
@@ -6,8 +6,10 @@
 #
 import numpy as np
 
-from ginga.misc import Callback
+from ginga.misc import Callback, Settings
 from ginga import ColorDist, trcalc
+from ginga import cmap as mod_cmap
+from ginga import imap as mod_imap
 
 
 class RGBMapError(Exception):
@@ -77,10 +79,38 @@ class RGBMapper(Callback.Callbacks):
     # result
     #
 
-    def __init__(self, logger, dist=None, bpp=None):
+    def __init__(self, logger, dist=None, settings=None, bpp=None):
         Callback.Callbacks.__init__(self)
 
         self.logger = logger
+
+        # Create settings and set defaults
+        if settings is None:
+            settings = Settings.SettingGroup(logger=self.logger)
+        self.settings = settings
+        self.t_ = settings
+        self.settings_keys = ['color_map','intensity_map',
+                              'color_array', 'shift_array',
+                              'color_algorithm', 'color_hashsize',
+                              ]
+
+        # add our defaults
+        self.t_.add_defaults(color_map='gray', intensity_map='ramp',
+                             color_algorithm='linear',
+                             color_hashsize=65535,
+                             color_array=None, shift_array=None)
+        self.t_.get_setting('color_map').add_callback('set',
+                                                      self.color_map_set_cb)
+        self.t_.get_setting('intensity_map').add_callback('set',
+                                                          self.intensity_map_set_cb)
+        self.t_.get_setting('color_array').add_callback('set',
+                                                        self.color_array_set_cb)
+        self.t_.get_setting('shift_array').add_callback('set',
+                                                        self.shift_array_set_cb)
+        self.t_.get_setting('color_hashsize').add_callback('set',
+                                                           self.color_hashsize_set_cb)
+        self.t_.get_setting('color_algorithm').add_callback('set',
+                                                            self.color_algorithm_set_cb)
 
         # For color and intensity maps
         self.cmap = None
@@ -90,8 +120,6 @@ class RGBMapper(Callback.Callbacks):
         self.carr = None
         self.sarr = None
         self.scale_pct = 1.0
-        # length of the color map
-        self.maxc = 255
 
         # targeted bit depth per-pixel band of the output RGB array
         # (can be less than the data size of the output array)
@@ -99,14 +127,16 @@ class RGBMapper(Callback.Callbacks):
             bpp = 8
         self.bpp = bpp
         # maximum value that we can generate in this range
-        self.maxv = 2 ** self.bpp - 1
+        self.maxc = 2 ** self.bpp - 1
         # data size per pixel band in the output RGB array
         self._set_dtype()
 
         # For scaling algorithms
-        hashsize = 65536
+        hashsize = self.t_.get('color_hashsize', 65536)
         if dist is None:
-            dist = ColorDist.LinearDist(hashsize)
+            color_alg_name = self.t_.get('color_algorithm', 'linear')
+            color_dist_class = ColorDist.get_dist(color_alg_name)
+            dist = color_dist_class(hashsize)
         self.dist = dist
 
         self.reset_sarr(callback=False)
@@ -114,6 +144,12 @@ class RGBMapper(Callback.Callbacks):
         # For callbacks
         for name in ('changed', ):
             self.enable_callback(name)
+
+        cm_name = self.t_.get('color_map', 'gray')
+        self.set_color_map(cm_name)
+
+        im_name = self.t_.get('intensity_map', 'ramp')
+        self.set_intensity_map(im_name)
 
     def _set_dtype(self):
         if self.bpp <= 8:
@@ -130,10 +166,20 @@ class RGBMapper(Callback.Callbacks):
         be 16, etc.
         """
         self.bpp = bpp
-        self.maxv = 2 ** self.bpp - 1
+        self.maxc = 2 ** self.bpp - 1
         self._set_dtype()
         self.calc_cmap()
         self.recalc(callback=False)
+
+    def get_settings(self):
+        return self.t_
+
+    def set_color_map(self, cmap_name):
+        self.t_.set(color_map=cmap_name)
+
+    def color_map_set_cb(self, setting, cmap_name):
+        cm = mod_cmap.get_cmap(cmap_name)
+        self.set_cmap(cm, callback=True)
 
     def set_cmap(self, cmap, callback=True):
         """
@@ -144,7 +190,10 @@ class RGBMapper(Callback.Callbacks):
         """
         self.cmap = cmap
         self.calc_cmap()
-        self.recalc(callback=callback)
+        # TEMP: ignore passed callback parameter
+        # callback=False in the following because we don't want to
+        # recursively invoke set_cmap()
+        self.t_.set(color_map=cmap.name, callback=False)
 
     def get_cmap(self):
         """
@@ -154,23 +203,29 @@ class RGBMapper(Callback.Callbacks):
 
     def calc_cmap(self):
         clst = self.cmap.clst
-        arr = np.array(clst).transpose() * float(self.maxv)
-        # does this really need to be the same type as rgbmap output type?
-        self.carr = np.round(arr).astype(self.dtype, copy=False)
         self.maxc = len(clst) - 1
+        arr = np.array(clst).transpose() * float(self.maxc)
+        # does this really need to be the same type as rgbmap output type?
+        carr = np.round(arr).astype(self.dtype, copy=False)
+        self.t_.set(color_array=carr)
 
     def invert_cmap(self, callback=True):
-        self.carr = np.fliplr(self.carr)
-        self.recalc(callback=callback)
+        carr = np.fliplr(self.carr)
+        # TEMP: ignore passed callback parameter
+        self.t_.set(color_array=carr)
 
     def rotate_cmap(self, num, callback=True):
-        self.carr = np.roll(self.carr, num, axis=1)
-        self.recalc(callback=callback)
+        carr = np.roll(self.carr, num, axis=1)
+        # TEMP: ignore passed callback parameter
+        self.t_.set(color_array=carr)
 
     def restore_cmap(self, callback=True):
         self.reset_sarr(callback=False)
+        # TEMP: ignore passed callback parameter
         self.calc_cmap()
-        self.recalc(callback=callback)
+
+    def reset_cmap(self):
+        self.recalc()
 
     def get_rgb(self, index):
         """
@@ -191,6 +246,13 @@ class RGBMapper(Callback.Callbacks):
                 self.arr[1][index],
                 self.arr[2][index])
 
+    def set_intensity_map(self, imap_name):
+        self.t_.set(intensity_map=imap_name)
+
+    def intensity_map_set_cb(self, setting, imap_name):
+        im = mod_imap.get_imap(imap_name)
+        self.set_imap(im, callback=True)
+
     def set_imap(self, imap, callback=True):
         """
         Set the intensity map used by this RGBMapper.
@@ -200,7 +262,11 @@ class RGBMapper(Callback.Callbacks):
         """
         self.imap = imap
         self.calc_imap()
-        self.recalc(callback=callback)
+        # TEMP: ignore passed callback parameter
+        self.recalc()
+        # callback=False in the following because we don't want to
+        # recursively invoke set_imap()
+        self.t_.set(intensity_map=imap.name, callback=False)
 
     def get_imap(self):
         """
@@ -214,36 +280,53 @@ class RGBMapper(Callback.Callbacks):
 
     def reset_sarr(self, callback=True):
         maxlen = self.maxc + 1
-        self.sarr = np.arange(maxlen)
         self.scale_pct = 1.0
-        if callback:
-            self.make_callback('changed')
-
-    def set_sarr(self, sarr, callback=True):
-        maxlen = self.maxc + 1
-        sarr = np.asarray(sarr, dtype=np.uint)
-        _len = len(sarr)
-        if _len != maxlen:
-            raise RGBMapError("shift map length %d != %d" % (_len, maxlen))
-        self.sarr = sarr
-        self.scale_pct = 1.0
-        if callback:
-            self.make_callback('changed')
+        sarr = np.arange(maxlen)
+        # TEMP: ignore passed callback parameter
+        self.t_.set(shift_array=sarr)
 
     def get_sarr(self):
         return self.sarr
 
-    def set_carr(self, carr, callback=True):
-        carr = np.asarray(carr)
-        maxlen = self.maxv + 1
-        self.carr = carr.astype(self.nptype)
-        _len = carr.shape[1]
-        if _len != maxlen:
-            raise RGBMapError("color map length %d != %d" % (_len, maxlen))
-        self.recalc(callback=callback)
+    def set_sarr(self, sarr, callback=True):
+        if sarr is not None:
+            sarr = np.asarray(sarr, dtype=np.uint)
+        # TEMP: ignore passed callback parameter
+        self.t_.set(shift_array=sarr)
+
+    def shift_array_set_cb(self, setting, sarr):
+        if sarr is not None:
+            sarr = np.asarray(sarr)
+            maxlen = self.maxc + 1
+            _len = len(sarr)
+            if _len != maxlen:
+                raise RGBMapError("shift map length %d != %d" % (_len, maxlen))
+            self.sarr = sarr.astype(np.uint, copy=False)
+            self.scale_pct = 1.0
+            self.make_callback('changed')
+        else:
+            self.reset_sarr(callback=True)
 
     def get_carr(self):
         return self.carr
+
+    def set_carr(self, carr, callback=True):
+        if carr is not None:
+            carr = np.asarray(carr)
+        # TEMP: ignore passed callback parameter
+        self.t_.set(color_array=carr, callback=True)
+
+    def color_array_set_cb(self, setting, carr):
+        if carr is not None:
+            carr = np.asarray(carr)
+            maxlen = self.maxc + 1
+            self.carr = carr.astype(self.nptype, copy=False)
+            _len = carr.shape[1]
+            if _len != maxlen:
+                raise RGBMapError("color map length %d != %d" % (_len, maxlen))
+        else:
+            self.calc_cmap()
+        self.recalc(callback=True)
 
     def recalc(self, callback=True):
         self.arr = np.copy(self.carr)
@@ -263,9 +346,12 @@ class RGBMapper(Callback.Callbacks):
         return self.dist.get_hash_size()
 
     def set_hash_size(self, size, callback=True):
+        # TEMP: ignore passed callback parameter
+        self.t_.set(color_hashsize=size)
+
+    def color_hashsize_set_cb(self, setting, size):
         self.dist.set_hash_size(size)
-        if callback:
-            self.make_callback('changed')
+        self.make_callback('changed')
 
     def get_hash_algorithms(self):
         return ColorDist.get_dist_names()
@@ -284,10 +370,14 @@ class RGBMapper(Callback.Callbacks):
         if callback:
             self.make_callback('changed')
 
-    def set_hash_algorithm(self, name, callback=True, **kwdargs):
-        hashsize = self.dist.get_hash_size()
-        dist = ColorDist.get_dist(name)(hashsize, **kwdargs)
-        self.set_dist(dist, callback=callback)
+    def set_hash_algorithm(self, name, callback=True, **kwargs):
+        # TODO: deal with algorithm parameters in kwargs
+        self.t_.set(color_algorithm=name)
+
+    def color_algorithm_set_cb(self, setting, name):
+        size = self.t_.get('color_hashsize', self.dist.get_hash_size())
+        dist = ColorDist.get_dist(name)(size)
+        self.set_dist(dist, callback=True)
 
     def get_order_indexes(self, order, cs):
         order = order.upper()
@@ -366,7 +456,7 @@ class RGBMapper(Callback.Callbacks):
         # set alpha channel
         if res.hasAlpha:
             aa = res.get_slice('A')
-            aa.fill(self.maxv)
+            aa.fill(self.maxc)
 
         idx = self.get_hasharray(idx)
 
@@ -396,7 +486,7 @@ class RGBMapper(Callback.Callbacks):
         xi = np.mgrid[0:new_wd]
         iscale_x = float(old_wd) / float(new_wd)
 
-        xi = (xi * iscale_x).astype('int', copy=False)
+        xi = (xi * iscale_x).astype(np.uint, copy=False)
         xi = xi.clip(0, old_wd - 1)
         newdata = sarr[xi]
         return newdata
@@ -406,9 +496,7 @@ class RGBMapper(Callback.Callbacks):
         maxlen = self.maxc + 1
         assert len(work) == maxlen, \
             RGBMapError("shifted shift map is != %d" % maxlen)
-        self.sarr = work
-        if callback:
-            self.make_callback('changed')
+        self.t_.set(shift_array=work)
 
     def scale_and_shift(self, scale_pct, shift_pct, callback=True):
         """Stretch and/or shrink the color map via altering the shift map.
@@ -444,9 +532,7 @@ class RGBMapper(Callback.Callbacks):
         assert len(work) == maxlen, \
             RGBMapError("shifted shift map is != %d" % maxlen)
 
-        self.sarr = work
-        if callback:
-            self.make_callback('changed')
+        self.t_.set(shift_array=work)
 
     def stretch(self, scale_factor, callback=True):
         """Stretch the color map via altering the shift map.
@@ -455,16 +541,12 @@ class RGBMapper(Callback.Callbacks):
         self.scale_and_shift(self.scale_pct, 0.0, callback=callback)
 
     def copy_attributes(self, dst_rgbmap):
-        dst_rgbmap.set_cmap(self.cmap, callback=False)
-        dst_rgbmap.set_imap(self.imap, callback=False)
-        dst_rgbmap.set_hash_algorithm(str(self.dist), callback=False)
-        # TODO: set hash size
-        dst_rgbmap.carr = np.copy(self.carr)
-        dst_rgbmap.sarr = np.copy(self.sarr)
-        dst_rgbmap.recalc()
+        self.t_.copy_settings(dst_rgbmap.get_settings(),
+                              keylist=self.settings_keys)
 
-    def reset_cmap(self):
-        self.recalc()
+    def share_attributes(self, dst_rgbmap):
+        self.t_.share_settings(dst_rgbmap.get_settings(),
+                               keylist=self.settings_keys)
 
 
 class NonColorMapper(RGBMapper):
@@ -477,7 +559,7 @@ class NonColorMapper(RGBMapper):
     def __init__(self, logger, dist=None, bpp=None):
         super(NonColorMapper, self).__init__(logger, dist=dist, bpp=bpp)
 
-        maxlen = self.maxv + 1
+        maxlen = self.maxc + 1
         self.dist.set_hash_size(maxlen)
         self.reset_sarr(callback=False)
 
@@ -514,7 +596,7 @@ class PassThruRGBMapper(RGBMapper):
         super(PassThruRGBMapper, self).__init__(logger, bpp=bpp)
 
         # ignore passed in distribution
-        maxlen = self.maxv + 1
+        maxlen = self.maxc + 1
         self.dist = ColorDist.LinearDist(maxlen)
 
     def get_hasharray(self, idx):

--- a/ginga/RGBMap.py
+++ b/ginga/RGBMap.py
@@ -139,8 +139,6 @@ class RGBMapper(Callback.Callbacks):
             dist = color_dist_class(hashsize)
         self.dist = dist
 
-        self.reset_sarr(callback=False)
-
         # For callbacks
         for name in ('changed', ):
             self.enable_callback(name)
@@ -150,6 +148,20 @@ class RGBMapper(Callback.Callbacks):
 
         im_name = self.t_.get('intensity_map', 'ramp')
         self.set_intensity_map(im_name)
+
+        # Initialize color array
+        carr = self.t_.get('color_array', None)
+        if carr is not None:
+            self.set_carr(carr)
+        else:
+            self.calc_cmap()
+
+        # Initialize shift array
+        sarr = self.t_.get('shift_array', None)
+        if sarr is not None:
+            self.set_sarr(sarr)
+        else:
+            self.reset_sarr(callback=False)
 
     def _set_dtype(self):
         if self.bpp <= 8:

--- a/ginga/RGBMap.py
+++ b/ginga/RGBMap.py
@@ -89,7 +89,7 @@ class RGBMapper(Callback.Callbacks):
             settings = Settings.SettingGroup(logger=self.logger)
         self.settings = settings
         self.t_ = settings
-        self.settings_keys = ['color_map','intensity_map',
+        self.settings_keys = ['color_map', 'intensity_map',
                               'color_array', 'shift_array',
                               'color_algorithm', 'color_hashsize',
                               ]

--- a/ginga/canvas/types/utils.py
+++ b/ginga/canvas/types/utils.py
@@ -99,9 +99,8 @@ class ColorBar(CanvasObjectBase):
 
         pxwd, pxht = width, max(self.height, scale_ht)
 
-        maxc = max(rgbmap.maxc, 256)
-        maxv = rgbmap.maxv
-        maxf = float(maxv)
+        maxc = max(rgbmap.maxc + 1, 256)
+        maxf = float(maxc)
 
         # calculate intervals for range numbers
         nums = max(int(pxwd // avg_pixels_per_range_num), 1)
@@ -295,8 +294,7 @@ class DrawableColorBar(Rectangle):
         pxwd, pxht = max(pxwd, 1), max(pxht, 1)
 
         maxc = max(rgbmap.maxc + 1, 256)
-        maxv = rgbmap.maxv
-        maxf = float(maxv)
+        maxf = float(maxc)
 
         # calculate intervals for range numbers
         nums = max(int(pxwd // avg_pixels_per_range_num), 1)

--- a/ginga/misc/Callback.py
+++ b/ginga/misc/Callback.py
@@ -91,6 +91,12 @@ class Callbacks(object):
             raise CallbackError("No callback category of '%s'" % (
                 name))
 
+    def merge_callbacks_to(self, other):
+        for name, cb_tups in self.cb.items():
+            for tup in cb_tups:
+                if tup not in other.cb[name]:
+                    other.cb[name].append(tup)
+
     # TODO: to be deprecated ?
     def set_callback(self, name, fn, *args, **kwdargs):
         if not self.has_callback(name):

--- a/ginga/misc/Settings.py
+++ b/ginga/misc/Settings.py
@@ -14,7 +14,7 @@ from . import Callback
 from . import Bunch
 
 unset_value = "^^UNSET^^"
-regex_array = re.compile(r'^array\((\[.*\]),\s*dtype=(.+)\)$',
+regex_array = re.compile(r'^\s*array\((\[.*\])\s*(,\s*dtype=(.+)\s*)?\)\s*$',
                          flags=re.DOTALL)
 
 
@@ -231,7 +231,7 @@ class SettingGroup(object):
                         val_s = line[i + 1:].strip()
                         match = regex_array.match(val_s)
                         if match:
-                            data, dtype = match.groups()
+                            data, _x, dtype = match.groups()
                             # special case for parsing numpy arrays
                             val = np.asarray(ast.literal_eval(data),
                                              dtype=dtype)

--- a/ginga/misc/Settings.py
+++ b/ginga/misc/Settings.py
@@ -85,11 +85,16 @@ class SettingGroup(object):
     def keys(self):
         return self.group.keys()
 
-    def share_settings(self, other, keylist=None):
+    def share_settings(self, other, keylist=None, callback=True):
         if keylist is None:
             keylist = self.group.keys()
         for key in keylist:
             other.group[key] = self.group[key]
+        if callback:
+            # make callbacks only after all items are set in the group
+            # TODO: only make callbacks for values that changed?
+            for key in keylist:
+                other.group[key].make_callback('set', other.group[key].value)
 
     def copy_settings(self, other, keylist=None, callback=True):
         if keylist is None:

--- a/ginga/misc/Settings.py
+++ b/ginga/misc/Settings.py
@@ -82,19 +82,20 @@ class SettingGroup(object):
     def get_setting(self, key):
         return self.group[key]
 
+    def keys(self):
+        return self.group.keys()
+
     def share_settings(self, other, keylist=None):
         if keylist is None:
             keylist = self.group.keys()
         for key in keylist:
             other.group[key] = self.group[key]
 
-    def copy_settings(self, other, keylist=None):
+    def copy_settings(self, other, keylist=None, callback=True):
         if keylist is None:
             keylist = self.group.keys()
-        d = {}
-        for key in keylist:
-            d[key] = self.get(key)
-        other.setDict(d)
+        d = {key: self.get(key) for key in keylist}
+        other.set_dict(d, callback=callback)
 
     def setdefault(self, key, value):
         if key in self.group:

--- a/ginga/rv/Control.py
+++ b/ginga/rv/Control.py
@@ -1725,6 +1725,7 @@ class GingaShell(GwMain.GwMain, Widgets.Application):
             focus_ind = self.settings.get('show_focus_indicator', False)
         fi.show_focus_indicator(focus_ind)
         fi.enable_auto_orient(True)
+        fi.use_image_profile = True
 
         fi.add_callback('cursor-changed', self.motion_cb)
         fi.add_callback('cursor-down', self.force_focus_cb)

--- a/ginga/rv/Control.py
+++ b/ginga/rv/Control.py
@@ -22,7 +22,7 @@ from collections import deque
 from ginga import cmap, imap
 from ginga import AstroImage, RGBImage, BaseImage
 from ginga.table import AstroTable
-from ginga.misc import Bunch, Timer, Future, Settings
+from ginga.misc import Bunch, Timer, Future
 from ginga.util import catalog, iohelper, io_fits, toolbox
 from ginga.canvas.CanvasObject import drawCatalog
 from ginga.canvas.types.layer import DrawingCanvas

--- a/ginga/rv/Control.py
+++ b/ginga/rv/Control.py
@@ -22,7 +22,7 @@ from collections import deque
 from ginga import cmap, imap
 from ginga import AstroImage, RGBImage, BaseImage
 from ginga.table import AstroTable
-from ginga.misc import Bunch, Timer, Future
+from ginga.misc import Bunch, Timer, Future, Settings
 from ginga.util import catalog, iohelper, io_fits, toolbox
 from ginga.canvas.CanvasObject import drawCatalog
 from ginga.canvas.types.layer import DrawingCanvas

--- a/ginga/rv/main.py
+++ b/ginga/rv/main.py
@@ -158,6 +158,8 @@ plugins = [
           menu="Header [G]", hidden=False, category='Utils', ptype='global'),
     Bunch(module='Zoom', tab='Zoom', workspace='left', start=False,
           menu="Zoom [G]", category='Utils', ptype='global'),
+    Bunch(module='Profiles', tab='Profiles', workspace='right', start=False,
+          menu="Profiles [G]", category='Utils', ptype='global'),
 ]
 
 

--- a/ginga/rv/main.py
+++ b/ginga/rv/main.py
@@ -158,8 +158,6 @@ plugins = [
           menu="Header [G]", hidden=False, category='Utils', ptype='global'),
     Bunch(module='Zoom', tab='Zoom', workspace='left', start=False,
           menu="Zoom [G]", category='Utils', ptype='global'),
-    Bunch(module='Profiles', tab='Profiles', workspace='right', start=False,
-          menu="Profiles [G]", category='Utils', ptype='global'),
 ]
 
 

--- a/ginga/rv/plugins/Pick.py
+++ b/ginga/rv/plugins/Pick.py
@@ -496,6 +496,7 @@ class Pick(GingaPlugin.LocalPlugin):
         di.set_bg(0.4, 0.4, 0.4)
         # for debugging
         di.set_name('pickimage')
+        di.show_mode_indicator(True)
         self.pickimage = di
 
         bd = di.get_bindings()
@@ -552,6 +553,7 @@ class Pick(GingaPlugin.LocalPlugin):
             bd.enable_cmap(True)
 
             ci.set_desired_size(width, height)
+            ci.show_mode_indicator(True)
 
             ciw = Viewers.GingaViewerWidget(viewer=ci)
             ciw.resize(width, height)

--- a/ginga/rv/plugins/Preferences.py
+++ b/ginga/rv/plugins/Preferences.py
@@ -304,7 +304,7 @@ class Preferences(GingaPlugin.LocalPlugin):
         self.pancoord_options = ('data', 'wcs')
         self.sort_options = ('loadtime', 'alpha')
 
-        for key in ['color_map','intensity_map',
+        for key in ['color_map', 'intensity_map',
                     'color_algorithm', 'color_hashsize']:
             self.t_.get_setting(key).add_callback(
                 'set', self.rgbmap_changed_ext_cb)
@@ -1123,7 +1123,7 @@ class Preferences(GingaPlugin.LocalPlugin):
         params = self.t_['autocut_params']
         # NOTE: use gui_do?
         # TODO: set the params from this tuple
-        params_d = dict(params)
+        params_d = dict(params)   # noqa
         #self.ac_params.params.update(params_d)
         #self.ac_params.params_to_widgets()
 

--- a/ginga/rv/plugins/Preferences.py
+++ b/ginga/rv/plugins/Preferences.py
@@ -274,12 +274,11 @@ The "Num Images" setting specifies how many images can be retained in
 buffers in this channel before being ejected.  A value of zero (0) means
 unlimited--images will never be ejected.  If an image was loaded from
 some accessible storage and it is ejected, it will automatically be
-reloaded if the image is revisited by navigating the channel.  A setting
-of 1 to 4 is typical.
+reloaded if the image is revisited by navigating the channel.
 
 The "Sort Order" setting determines whether images are sorted in the
 channel alphabetically by name or by the time when they were loaded.
-This principally effects the order in which images are cycled when using
+This principally affects the order in which images are cycled when using
 the up/down "arrow" keys or buttons, and not necessarily how they are
 displayed in plugins like "Contents" or "Thumbs" (which generally have
 their own setting preference for ordering).

--- a/ginga/rv/plugins/Preferences.py
+++ b/ginga/rv/plugins/Preferences.py
@@ -802,7 +802,8 @@ class Preferences(GingaPlugin.LocalPlugin):
                      'Save Pan', 'checkbutton'),
                     ('Save Transform', 'checkbutton',
                     'Save Rotation', 'checkbutton'),
-                    ('Save Cuts', 'checkbutton'),
+                    ('Save Cuts', 'checkbutton',
+                     'Save Color Map', 'checkbutton'),
                     )
         w, b = Widgets.build_info(captions, orientation=orientation)
         self.w.update(b)
@@ -824,6 +825,12 @@ class Preferences(GingaPlugin.LocalPlugin):
         self.w.save_cuts.set_state(self.t_.get('profile_use_cuts', False))
         self.w.save_cuts.add_callback('activated', self.set_profile_cb)
         self.w.save_cuts.set_tooltip("Remember cut levels with image")
+        # TEMP: until this feature is working
+        self.w.save_color_map.set_enabled(False)
+        self.w.save_color_map.set_state(False)
+            #self.t_.get('profile_use_color_map', False))
+        self.w.save_color_map.add_callback('activated', self.set_profile_cb)
+        self.w.save_color_map.set_tooltip("Remember color map with image")
 
         fr = Widgets.Frame()
         fr.set_widget(w)
@@ -1348,10 +1355,12 @@ class Preferences(GingaPlugin.LocalPlugin):
         save_cuts = (self.w.save_cuts.get_state() != 0)
         save_transform = (self.w.save_transform.get_state() != 0)
         save_rotation = (self.w.save_rotation.get_state() != 0)
+        save_color_map = (self.w.save_color_map.get_state() != 0)
         self.t_.set(profile_use_scale=save_scale, profile_use_pan=save_pan,
                     profile_use_cuts=save_cuts,
                     profile_use_transform=save_transform,
-                    profile_use_rotation=save_rotation)
+                    profile_use_rotation=save_rotation,
+                    profile_use_color_map=save_color_map)
 
     def set_buffer_cb(self, *args):
         num_images = int(self.w.num_images.get_text())
@@ -1493,6 +1502,8 @@ class Preferences(GingaPlugin.LocalPlugin):
         self.w.save_transform.set_state(prefs['profile_use_transform'])
         prefs.setdefault('profile_use_rotation', False)
         self.w.save_rotation.set_state(prefs['profile_use_rotation'])
+        prefs.setdefault('profile_use_color_map', False)
+        self.w.save_color_map.set_state(prefs['profile_use_color_map'])
 
     def save_preferences(self):
         self.t_.save()

--- a/ginga/rv/plugins/Preferences.py
+++ b/ginga/rv/plugins/Preferences.py
@@ -294,6 +294,7 @@ metadata in the channel.  These profiles are continuously updated with
 viewer state as the image is manipulated.  The "Remember" preferences
 control which parts of these profiles are restored to the viewer state
 when the image is navigated to in the channel:
+
 * "Restore Scale" will restore the zoom (scale) level
 * "Restore Pan" will restore the pan position
 * "Restore Transform" will restore any flip or swap axes transforms

--- a/ginga/rv/plugins/WCSMatch.py
+++ b/ginga/rv/plugins/WCSMatch.py
@@ -1,5 +1,7 @@
+#
 # This is open-source software licensed under a BSD license.
 # Please see the file LICENSE.txt for details.
+#
 """
 ``WCSMatch`` is a global plugin for the Ginga image viewer that allows
 you to roughly align images with different scales and orientations


### PR DESCRIPTION
This PR does two things: 1) refactors the way `RGBMap` objects manage their state, so that they can share the settings object of a ginga viewer widget; and 2) unifies the format of an "image profile" with a viewer `SettingGroup` object.  This simplifies the management of state between the viewer and the RGB mapper, but more importantly, opens up new possibilities for more advanced use cases for profiles.

Until now, profiles were only objects attached to the metadata of a `BaseImage`-subclassed object.  Using the Preferences (under the "Remember" category), certain state could be saved and restored to the viewer when moving between different images. Under this PR, basically almost all state from the viewer (meaning a channel image viewer in the context of a reference viewer) can be captured in a profile and saved and restored.  This opens up the interesting possibility of being able to manage profiles explicitly from the user's perspective (save from viewer, restore to viewer, attach to images).  Furthermore, using the sharing capabilities of the settings object, any parts of a profile could be shared with another profile, allowing fairly interesting setups in the reference viewer (think `WCSMatch`, but more powerful).  For example, using this it should be straightforward to implement the ds9 "lock" features, but with even more control by the user over what is "locked" (shared between channels).