### PR TITLE
Add convenience functions for working with astropy NDData objects

### DIFF
--- a/doc/ref_api.rst
+++ b/doc/ref_api.rst
@@ -30,6 +30,7 @@ Reference/API
 .. automodapi:: ginga.util.wcsmod
    :skip: use
    :skip: get_wcs_wrappers
+   :skip: my_import
 
 .. automodapi:: ginga.util.wcs
    :no-inheritance-diagram:

--- a/ginga/AstroImage.py
+++ b/ginga/AstroImage.py
@@ -159,7 +159,7 @@ class AstroImage(BaseImage):
         if ndd.wcs is None:
             # no wcs in ndd obj--let's try to make one from the header
             self.wcs = wcsmod.WCS(logger=self.logger)
-            self.wcs.load_header(adhr)
+            self.wcs.load_header(ahdr)
         else:
             # already have a valid wcs in the ndd object
             # we assume it needs an astropy compatible wcs

--- a/ginga/tests/test_aimg.py
+++ b/ginga/tests/test_aimg.py
@@ -1,0 +1,89 @@
+
+import numpy as np
+
+from astropy import nddata
+from astropy.io import fits
+from astropy.wcs import WCS
+
+from ginga import AstroImage
+from ginga.misc import log
+from ginga.util import wcs, wcsmod
+wcsmod.use('astropy')
+
+
+class TestAstroImage(object):
+    def setup_class(self):
+        self.logger = log.get_logger("TestAstroImage", null=True)
+        self.image = AstroImage.AstroImage(logger=self.logger)
+
+    def _get_hdu(self):
+        data = np.random.randint(0, 10000, (10, 10))
+        ra_deg, dec_deg = 10.0, -10.0
+        px_scale_deg_px = 0.000026044
+        rot_deg = 90.0
+        ht, wd = data.shape
+        kwds = wcs.simple_wcs(wd / 2.0, ht / 2.0, ra_deg, dec_deg,
+                              px_scale_deg_px, rot_deg)
+        hdu = fits.PrimaryHDU(data)
+        hdu.header.update(kwds)
+        assert isinstance(hdu, fits.PrimaryHDU)
+        return hdu
+
+    def test_to_nddata(self):
+        """Test that we can convert an AstroImage to an NDData object.
+        """
+        hdu = self._get_hdu()
+
+        self.image.load_hdu(hdu)
+        # make sure we have a valid astropy wcs
+        assert isinstance(self.image.wcs.wcs, WCS)
+
+        # convert to NDData
+        ndd = self.image.as_nddata()
+        assert isinstance(ndd, nddata.NDData)
+
+        # this should also work
+        ndd = self.image.astype('nddata')
+        assert isinstance(ndd, nddata.NDData)
+
+    def test_from_nddata(self):
+        """Test that we can load a NDData object into an AstroImage object.
+        """
+        hdu = self._get_hdu()
+
+        ndd = nddata.NDData(hdu.data, wcs=WCS(hdu.header))
+        # make sure we have a valid NDData
+        assert isinstance(ndd, nddata.NDData)
+
+        self.image.load_nddata(ndd)
+        # make sure we have a valid astropy wcs and numpy data
+        assert isinstance(self.image.wcs.wcs, WCS)
+        assert isinstance(self.image.get_data(), np.ndarray)
+
+    def test_from_ccddata(self):
+        """Test that we can load a NDData object into an AstroImage object.
+        """
+        hdu = self._get_hdu()
+
+        ccdd = nddata.CCDData(hdu.data, unit='adu', wcs=WCS(hdu.header))
+        # make sure we have a valid CCDData
+        assert isinstance(ccdd, nddata.CCDData)
+
+        self.image.load_nddata(ccdd)
+        # make sure we have a valid astropy wcs and numpy data
+        assert isinstance(self.image.wcs.wcs, WCS)
+        assert isinstance(self.image.get_data(), np.ndarray)
+
+    def test_to_hdu(self):
+        """Test that we can convert an AstroImage to an astropy HDU.
+        """
+        hdu = self._get_hdu()
+
+        self.image.load_hdu(hdu)
+        # make sure we have a valid astropy wcs
+        assert isinstance(self.image.wcs.wcs, WCS)
+
+        hdu2 = self.image.as_hdu()
+        assert isinstance(hdu2, fits.PrimaryHDU)
+
+# END

--- a/ginga/util/wcsmod/__init__.py
+++ b/ginga/util/wcsmod/__init__.py
@@ -106,4 +106,10 @@ if not wcs_configured:
 def get_wcs_wrappers():
     return list(common.custom_wcs.keys())
 
+def get_wcs_class(name):
+    """Get a WCS class corresponding to the registered name.
+    Will raise a KeyError if a class of the given name does not exist.
+    """
+    return common.custom_wcs[name]
+
 # END

--- a/ginga/util/wcsmod/__init__.py
+++ b/ginga/util/wcsmod/__init__.py
@@ -106,6 +106,7 @@ if not wcs_configured:
 def get_wcs_wrappers():
     return list(common.custom_wcs.keys())
 
+
 def get_wcs_class(name):
     """Get a WCS class corresponding to the registered name.
     Will raise a KeyError if a class of the given name does not exist.

--- a/ginga/util/wcsmod/wcs_astropy.py
+++ b/ginga/util/wcsmod/wcs_astropy.py
@@ -63,12 +63,34 @@ class AstropyWCS(common.BaseWCS):
         try:
             # reconstruct a pyfits header, because otherwise we take an
             # incredible performance hit in astropy.wcs
-            self.logger.debug("Reconstructing PyFITS header")
+            self.logger.debug("Reconstructing astropy.io.fits header")
             self.header = pyfits.Header(header.items())
 
             self.logger.debug("Trying to make astropy-- wcs object")
             self.wcs = pywcs.WCS(self.header, fobj=fobj, relax=True)
             self.logger.debug("made astropy wcs object")
+
+            self.coordsys = common.get_coord_system_name(self.header)
+            self.logger.debug("Coordinate system is: %s" % (self.coordsys))
+
+        except Exception as e:
+            self.logger.error("Error making WCS object: %s" % (str(e)))
+            self.wcs = None
+
+    def load_nddata(self, ndd):
+        try:
+            # reconstruct a pyfits header, because otherwise we take an
+            # incredible performance hit in astropy.wcs
+            self.logger.debug("Reconstructing astropy.io.fits header")
+            self.header = pyfits.Header(ndd.meta)
+
+            if ndd.wcs is None:
+                self.logger.debug("Trying to make astropy-- wcs object")
+                self.wcs = pywcs.WCS(self.header, relax=True)
+                self.logger.debug("made astropy wcs object")
+            else:
+                self.logger.debug("reused nddata wcs object")
+                self.wcs = ndd.wcs
 
             self.coordsys = common.get_coord_system_name(self.header)
             self.logger.debug("Coordinate system is: %s" % (self.coordsys))


### PR DESCRIPTION
This PR adds convenience functions for working with astropy `NDData` objects.  Specifically, it adds support to the `AstroImage` class for loading `NDData` (or `NDData`-subclassed) objects and making an `NDData` object from an `AstroImage` object.  The conversions preserve data, header and wcs.

Examples:
```python
img = AstroImage()
img.load_nddata(ndd)

ndd2 = img.as_nddata()
ndd3 = img.astype('nddata')
```
this PR also adds support for converting to a `PrimaryHDU` object:
```python
hdu1 = img.as_hdu()
hdu2 = img.astype('hdu')
```