### PR TITLE
Add experimental to MANIFEST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,6 +12,7 @@ recursive-include doc *
 recursive-include licenses *
 recursive-include cextern *
 recursive-include scripts *
+recursive-include experimental *
 
 prune build
 prune doc/_build


### PR DESCRIPTION
As part of #644 investigation, I found that "experimental" folder is not distributed via PyPI tarball, so I am adding it here. ~~I think this will be useful as people who do `pip install` will still be able to use experimental plugins if they so choose.~~ (see below)