### PR TITLE
Enhance loader functionality

### DIFF
--- a/ginga/RGBImage.py
+++ b/ginga/RGBImage.py
@@ -9,7 +9,7 @@ import numpy as np
 from ginga import trcalc
 from ginga.util import io_rgb
 from ginga.misc import Bunch
-from ginga.BaseImage import BaseImage, Header, ImageError
+from ginga.BaseImage import BaseImage, ImageError
 
 
 class RGBImage(BaseImage):

--- a/ginga/RGBImage.py
+++ b/ginga/RGBImage.py
@@ -4,12 +4,12 @@
 # This is open-source software licensed under a BSD license.
 # Please see the file LICENSE.txt for details.
 #
+import numpy as np
+
 from ginga import trcalc
 from ginga.util import io_rgb
 from ginga.misc import Bunch
-from ginga.BaseImage import BaseImage, Header
-
-import numpy as np
+from ginga.BaseImage import BaseImage, Header, ImageError
 
 
 class RGBImage(BaseImage):
@@ -34,21 +34,17 @@ class RGBImage(BaseImage):
         blu = self.get_slice('B')
         blu[:] = int(ch_max * b)
 
-    def load_file(self, filepath):
-        kwds = Header()
-        metadata = {'header': kwds, 'path': filepath}
+    def load_file(self, filespec, **kwargs):
+        if self.io is None:
+            raise ImageError("No IO loader defined")
 
-        # TODO: ideally we would be informed by channel order
-        # in result by io_rgb
-        data_np = self.io.load_file(filepath, kwds)
-
-        self.load_data(data_np, metadata=metadata)
+        self.io.load_file(filespec, dstobj=self, **kwargs)
 
     def load_data(self, data_np, metadata=None):
         self.clear_metadata()
         self.set_data(data_np, metadata=metadata)
 
-        if not (self.name is None):
+        if self.name is not None:
             self.set(name=self.name)
 
     def save_as_file(self, filepath):

--- a/ginga/examples/bokeh/example1.py
+++ b/ginga/examples/bokeh/example1.py
@@ -23,7 +23,7 @@ from bokeh.models import TextInput, Slider
 
 from ginga.web.bokehw import ImageViewBokeh as ib
 from ginga.misc import log
-from ginga.AstroImage import AstroImage
+from ginga.util.loader import load_data
 
 
 def main(options, args):
@@ -54,8 +54,7 @@ def main(options, args):
     #curdoc().add_periodic_callback(update, 50)
 
     def load_file(path):
-        image = AstroImage(logger=logger)
-        image.load_file(path)
+        image = load_data(path, logger=logger)
         viewer.set_image(image)
 
     def load_file_cb(attr_name, old_val, new_val):

--- a/ginga/examples/bokeh/example2.py
+++ b/ginga/examples/bokeh/example2.py
@@ -8,7 +8,7 @@ from bokeh.models.widgets import TextInput
 
 from ginga.web.bokehw import ImageViewBokeh as ib
 from ginga.misc import log
-from ginga.AstroImage import AstroImage
+from ginga.util.loader import load_data
 
 
 def main(options, args):
@@ -23,8 +23,7 @@ def main(options, args):
     viewer.set_figure(fig)
 
     def load_file(path):
-        image = AstroImage(logger)
-        image.load_file(path)
+        image = load_data(path, logger=logger)
         viewer.set_image(image)
 
     def load_file_cb(attr_name, old_val, new_val):

--- a/ginga/examples/gl/example2_qt.py
+++ b/ginga/examples/gl/example2_qt.py
@@ -8,11 +8,12 @@
 
 import sys
 
-from ginga import AstroImage, colors
+from ginga import colors
 from ginga.opengl.ImageViewQtGL import CanvasView
 from ginga.canvas.CanvasObject import get_canvas_types
 from ginga.misc import log
 from ginga.qtw.QtHelp import QtGui, QtCore
+from ginga.util.loader import load_data
 
 STD_FORMAT = '%(asctime)s | %(levelname)1.1s | %(filename)s:%(lineno)d (%(funcName)s) | %(message)s'
 
@@ -145,9 +146,7 @@ class FitsViewer(QtGui.QMainWindow):
         self.canvas.delete_all_objects()
 
     def load_file(self, filepath):
-        image = AstroImage.AstroImage(logger=self.logger)
-        image.load_file(filepath)
-
+        image = load_data(filepath, logger=self.logger)
         self.fitsimage.set_image(image)
         self.setWindowTitle(filepath)
 

--- a/ginga/examples/gtk/example1_gtk.py
+++ b/ginga/examples/gtk/example1_gtk.py
@@ -11,7 +11,7 @@ import logging
 from ginga.gtkw.ImageViewCanvasGtk import ImageViewCanvas
 from ginga.gtkw.ImageViewGtk import ScrolledView
 from ginga.gtkw import GtkHelp
-from ginga import AstroImage
+from ginga.util.loader import load_data
 
 import gtk
 
@@ -74,8 +74,7 @@ class FitsViewer(object):
         return self.root
 
     def load_file(self, filepath):
-        image = AstroImage.AstroImage(logger=self.logger)
-        image.load_file(filepath)
+        image = load_data(filepath, logger=self.logger)
         self.fitsimage.set_image(image)
         self.root.set_title(filepath)
 

--- a/ginga/examples/gtk/example2_gtk.py
+++ b/ginga/examples/gtk/example2_gtk.py
@@ -8,12 +8,12 @@
 
 import sys
 
-from ginga import AstroImage
 from ginga.gtkw import GtkHelp
 from ginga.gtkw.ImageViewGtk import CanvasView
 from ginga.canvas.CanvasObject import get_canvas_types
 from ginga import colors
 from ginga.misc import log
+from ginga.util.loader import load_data
 
 import gtk
 
@@ -158,9 +158,7 @@ class FitsViewer(object):
         self.canvas.delete_all_objects()
 
     def load_file(self, filepath):
-        image = AstroImage.AstroImage(logger=self.logger)
-        image.load_file(filepath)
-
+        image = load_data(filepath, logger=self.logger)
         self.fitsimage.set_image(image)
         self.root.set_title(filepath)
 

--- a/ginga/examples/gtk/fits2pdf.py
+++ b/ginga/examples/gtk/fits2pdf.py
@@ -19,7 +19,7 @@ from optparse import OptionParser
 import cairo
 
 from ginga.cairow.ImageViewCairo import ImageViewCairo
-from ginga.AstroImage import AstroImage
+from ginga.util.loader import load_data
 
 try:
     from ginga.version import version
@@ -46,8 +46,7 @@ def convert(filepath, outfilepath):
     fi.configure(500, 1000)
 
     # Load fits file
-    image = AstroImage(logger=logger)
-    image.load_file(filepath)
+    image = load_data(filepath, logger=logger)
 
     # Make any adjustments to the image that we want
     fi.set_bg(1.0, 1.0, 1.0)

--- a/ginga/examples/gtk3/example1.py
+++ b/ginga/examples/gtk3/example1.py
@@ -10,7 +10,7 @@ import logging
 
 from ginga.gtk3w.ImageViewGtk import CanvasView, ScrolledView
 from ginga.gtk3w import GtkHelp
-from ginga import AstroImage
+from ginga.util.loader import load_data
 
 from gi.repository import Gtk
 
@@ -39,6 +39,7 @@ class FitsViewer(object):
         fi.set_callback('drag-drop', self.drop_file)
         fi.set_bg(0.2, 0.2, 0.2)
         fi.ui_set_active(True)
+        fi.enable_auto_orient(True)
         self.fitsimage = fi
 
         # enable some user interaction
@@ -72,8 +73,7 @@ class FitsViewer(object):
         return self.root
 
     def load_file(self, filepath):
-        image = AstroImage.AstroImage(logger=self.logger)
-        image.load_file(filepath)
+        image = load_data(filepath, logger=self.logger)
         self.fitsimage.set_image(image)
         self.root.set_title(filepath)
 

--- a/ginga/examples/gtk3/example2.py
+++ b/ginga/examples/gtk3/example2.py
@@ -8,12 +8,12 @@
 
 import sys
 
-from ginga import AstroImage
 from ginga.gtk3w import GtkHelp
 from ginga.gtk3w.ImageViewGtk import CanvasView
 from ginga.canvas.CanvasObject import get_canvas_types
 from ginga import colors
 from ginga.misc import log
+from ginga.util.loader import load_data
 
 from gi.repository import Gtk
 
@@ -157,9 +157,7 @@ class FitsViewer(object):
         self.canvas.deleteAllObjects()
 
     def load_file(self, filepath):
-        image = AstroImage.AstroImage(logger=self.logger)
-        image.load_file(filepath)
-
+        image = load_data(filepath, logger=self.logger)
         self.fitsimage.set_image(image)
         self.root.set_title(filepath)
 

--- a/ginga/examples/gw/example2.py
+++ b/ginga/examples/gw/example2.py
@@ -9,10 +9,11 @@
 import sys
 
 import ginga.toolkit as ginga_toolkit
-from ginga import AstroImage, colors
+from ginga import colors
 from ginga.canvas.CanvasObject import get_canvas_types
 from ginga.canvas import render
 from ginga.misc import log
+from ginga.util.loader import load_data
 
 
 class FitsViewer(object):
@@ -179,9 +180,7 @@ class FitsViewer(object):
         self.canvas.delete_all_objects()
 
     def load_file(self, filepath):
-        image = AstroImage.AstroImage(logger=self.logger)
-        image.load_file(filepath)
-
+        image = load_data(filepath, logger=self.logger)
         self.fitsimage.set_image(image)
         self.top.set_title(filepath)
 

--- a/ginga/examples/gw/shared_canvas.py
+++ b/ginga/examples/gw/shared_canvas.py
@@ -6,11 +6,12 @@
 import sys
 import logging
 
-from ginga import AstroImage, colors
+from ginga import colors
 import ginga.toolkit as ginga_toolkit
 from ginga.canvas.CanvasObject import get_canvas_types
 from ginga.util.toolbox import ModeIndicator
 from ginga.misc import log
+from ginga.util.loader import load_data
 
 
 class FitsViewer(object):
@@ -199,9 +200,7 @@ class FitsViewer(object):
         self.canvas.delete_all_objects()
 
     def load_file(self, viewer, filepath):
-        image = AstroImage.AstroImage(logger=self.logger)
-        image.load_file(filepath)
-
+        image = load_data(filepath, logger=self.logger)
         viewer.set_image(image)
         self.top.set_title(filepath)
 

--- a/ginga/examples/matplotlib/example1_mpl.py
+++ b/ginga/examples/matplotlib/example1_mpl.py
@@ -15,11 +15,11 @@ import sys
 
 from matplotlib.figure import Figure
 
-from ginga import AstroImage
 from ginga.qtw.QtHelp import QtGui, QtCore
 from ginga.mplw.ImageViewCanvasMpl import ImageViewCanvas
 from ginga.mplw.FigureCanvasQt import FigureCanvas
 from ginga.misc import log
+from ginga.util.loader import load_data
 
 
 class FitsViewer(QtGui.QMainWindow):
@@ -34,6 +34,7 @@ class FitsViewer(QtGui.QMainWindow):
         fi = ImageViewCanvas(logger=self.logger)
         fi.enable_autocuts('on')
         fi.set_autocut_params('zscale')
+        fi.enable_auto_orient(True)
         fi.enable_autozoom('on')
         #fi.set_callback('drag-drop', self.drop_file)
         fi.set_callback('none-move', self.motion)
@@ -80,9 +81,7 @@ class FitsViewer(QtGui.QMainWindow):
         return self.fitsimage
 
     def load_file(self, filepath):
-        image = AstroImage.AstroImage(logger=self.logger)
-        image.load_file(filepath)
-
+        image = load_data(filepath, logger=self.logger)
         self.fitsimage.set_image(image)
 
     def open_file(self):

--- a/ginga/examples/matplotlib/example2_mpl.py
+++ b/ginga/examples/matplotlib/example2_mpl.py
@@ -17,12 +17,12 @@ import sys
 from matplotlib.figure import Figure
 
 from ginga.qtw.QtHelp import QtGui, QtCore
-from ginga import AstroImage
 from ginga.mplw.ImageViewCanvasMpl import ImageViewCanvas
 from ginga.mplw.FigureCanvasQt import FigureCanvas
 from ginga.misc import log
 from ginga import colors
 from ginga.canvas.CanvasObject import get_canvas_types
+from ginga.util.loader import load_data
 
 
 class FitsViewer(QtGui.QMainWindow):
@@ -174,9 +174,7 @@ class FitsViewer(QtGui.QMainWindow):
         self.canvas.delete_all_objects()
 
     def load_file(self, filepath):
-        image = AstroImage.AstroImage(logger=self.logger)
-        image.load_file(filepath)
-
+        image = load_data(filepath, logger=self.logger)
         self.fitsimage.set_image(image)
         self.setWindowTitle(filepath)
 

--- a/ginga/examples/matplotlib/example3_mpl.py
+++ b/ginga/examples/matplotlib/example3_mpl.py
@@ -29,9 +29,9 @@ from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigureCanvas
 
 from ginga.qtw.ImageViewCanvasQt import ImageViewCanvas
 from ginga.qtw.QtHelp import QtGui, QtCore
-from ginga import AstroImage
 from ginga import cmap, imap
 from ginga.misc import log
+from ginga.util.loader import load_data
 
 STD_FORMAT = '%(asctime)s | %(levelname)1.1s | %(filename)s:%(lineno)d (%(funcName)s) | %(message)s'
 
@@ -194,9 +194,7 @@ class FitsViewer(QtGui.QMainWindow):
         self.fitsimage.delete_all_objects()
 
     def load_file(self, filepath):
-        image = AstroImage.AstroImage(logger=self.logger)
-        image.load_file(filepath)
-
+        image = load_data(filepath, logger=self.logger)
         self.fitsimage.set_image(image)
         self.setWindowTitle(filepath)
 

--- a/ginga/examples/matplotlib/example4_mpl.py
+++ b/ginga/examples/matplotlib/example4_mpl.py
@@ -49,8 +49,8 @@ import matplotlib.patches as patches
 
 from ginga.mplw.ImageViewCanvasMpl import ImageViewCanvas
 from ginga.misc import log
-from ginga.AstroImage import AstroImage
 from ginga import cmap
+from ginga.util.loader import load_data
 
 # add matplotlib colormaps to ginga's own set
 cmap.add_matplotlib_cmaps()
@@ -78,8 +78,7 @@ if len(sys.argv) < 2:
     print("Please provide a FITS file on the command line")
     sys.exit(1)
 
-image = AstroImage(logger=logger)
-image.load_file(sys.argv[1])
+image = load_data(sys.argv[1], logger=logger)
 fi.set_image(image)
 #fi.rotate(45)
 

--- a/ginga/examples/matplotlib/example5_mpl.py
+++ b/ginga/examples/matplotlib/example5_mpl.py
@@ -41,8 +41,8 @@ import matplotlib.pyplot as plt
 
 from ginga.mplw.ImageViewCanvasMpl import ImageViewCanvas
 from ginga.mplw.ImageViewCanvasTypesMpl import DrawingCanvas
-from ginga.AstroImage import AstroImage
 from ginga.misc import log
+from ginga.util.loader import load_data
 
 # Set to True to get diagnostic logging output
 use_logger = False
@@ -75,8 +75,7 @@ class MyGingaFigure(object):
 
     def load(self, fitspath):
         # load an image
-        image = AstroImage(logger=self.logger)
-        image.load_file(fitspath)
+        image = load_data(fitspath, logger=self.logger)
         self.fitsimage.set_image(image)
 
     def capture(self):

--- a/ginga/examples/pg/example2_pg.py
+++ b/ginga/examples/pg/example2_pg.py
@@ -9,10 +9,11 @@
 import sys
 import logging
 
-from ginga import AstroImage, colors
+from ginga import colors
 from ginga.canvas.CanvasObject import get_canvas_types
 from ginga.misc import log
 from ginga.web.pgw import Widgets, Viewers
+from ginga.util.loader import load_data
 
 
 class FitsViewer(object):
@@ -178,9 +179,7 @@ class FitsViewer(object):
         self.canvas.delete_all_objects()
 
     def load_file(self, filepath):
-        image = AstroImage.AstroImage(logger=self.logger)
-        image.load_file(filepath)
-
+        image = load_data(filepath, logger=self.logger)
         self.fitsimage.set_image(image)
         self.top.set_title(filepath)
 

--- a/ginga/examples/qt/example1_qt.py
+++ b/ginga/examples/qt/example1_qt.py
@@ -4,10 +4,10 @@
 #
 import sys
 
-from ginga import AstroImage
 from ginga.misc import log
 from ginga.qtw.QtHelp import QtGui, QtCore
 from ginga.qtw.ImageViewQt import CanvasView, ScrolledView
+from ginga.util.loader import load_data
 
 
 class FitsViewer(QtGui.QMainWindow):
@@ -24,6 +24,7 @@ class FitsViewer(QtGui.QMainWindow):
         fi.set_callback('drag-drop', self.drop_file)
         fi.set_bg(0.2, 0.2, 0.2)
         fi.ui_set_active(True)
+        fi.enable_auto_orient(True)
         self.fitsimage = fi
 
         # enable some user interaction
@@ -62,8 +63,7 @@ class FitsViewer(QtGui.QMainWindow):
         vw.setLayout(vbox)
 
     def load_file(self, filepath):
-        image = AstroImage.AstroImage(logger=self.logger)
-        image.load_file(filepath)
+        image = load_data(filepath, logger=self.logger)
         self.fitsimage.set_image(image)
         self.setWindowTitle(filepath)
 

--- a/ginga/examples/qt/example2_qt.py
+++ b/ginga/examples/qt/example2_qt.py
@@ -9,10 +9,11 @@
 import sys
 
 from ginga.qtw.QtHelp import QtGui, QtCore
-from ginga import AstroImage, colors
+from ginga import colors
 from ginga.qtw.ImageViewQt import CanvasView
 from ginga.canvas.CanvasObject import get_canvas_types
 from ginga.misc import log
+from ginga.util.loader import load_data
 
 STD_FORMAT = '%(asctime)s | %(levelname)1.1s | %(filename)s:%(lineno)d (%(funcName)s) | %(message)s'
 
@@ -178,8 +179,7 @@ class FitsViewer(QtGui.QMainWindow):
         self.canvas.delete_all_objects()
 
     def load_file(self, filepath):
-        image = AstroImage.AstroImage(logger=self.logger)
-        image.load_file(filepath)
+        image = load_data(filepath, logger=self.logger)
 
         self.fitsimage.set_image(image)
         self.setWindowTitle(filepath)

--- a/ginga/examples/tk/example1_tk.py
+++ b/ginga/examples/tk/example1_tk.py
@@ -9,7 +9,7 @@ import sys
 import logging
 
 from ginga.tkw.ImageViewTk import ImageViewCanvas
-from ginga import AstroImage
+from ginga.util.loader import load_data
 
 import tkinter as Tkinter
 from tkinter.filedialog import askopenfilename
@@ -37,6 +37,7 @@ class FitsViewer(object):
         fi.enable_autocuts('on')
         fi.set_autocut_params('zscale')
         fi.enable_autozoom('on')
+        fi.enable_auto_orient(True)
         fi.set_bg(0.2, 0.2, 0.2)
         fi.ui_set_active(True)
         # tk seems to not take focus with a click
@@ -68,8 +69,7 @@ class FitsViewer(object):
         return self.root
 
     def load_file(self, filepath):
-        image = AstroImage.AstroImage(logger=self.logger)
-        image.load_file(filepath)
+        image = load_data(filepath, logger=self.logger)
         self.fitsimage.set_image(image)
         self.root.title(filepath)
 

--- a/ginga/examples/tk/example2_tk.py
+++ b/ginga/examples/tk/example2_tk.py
@@ -7,9 +7,9 @@
 #
 import sys
 
-from ginga import AstroImage
 from ginga.tkw.ImageViewTk import ImageViewCanvas
 from ginga.misc import log
+from ginga.util.loader import load_data
 
 import tkinter as Tkinter
 from tkinter.filedialog import askopenfilename
@@ -138,9 +138,7 @@ class FitsViewer(object):
         self.canvas.deleteAllObjects()
 
     def load_file(self, filepath):
-        image = AstroImage.AstroImage(logger=self.logger)
-        image.load_file(filepath)
-
+        image = load_data(filepath, logger=self.logger)
         self.fitsimage.set_image(image)
         self.root.title(filepath)
 

--- a/ginga/rv/Channel.py
+++ b/ginga/rv/Channel.py
@@ -246,9 +246,9 @@ class Channel(Callback.Callbacks):
 
         info = self.history[self.cursor]
         if info.name in self.datasrc:
-            # image still in memory
-            image = self.datasrc[info.name]
-            self.switch_image(image)
+            # object still in memory
+            data_obj = self.datasrc[info.name]
+            self.switch_image(data_obj)
 
         else:
             self.switch_name(info.name)
@@ -355,6 +355,7 @@ class Channel(Callback.Callbacks):
         self.logger.debug("available viewers are: %s" % (str(vnames)))
 
         # for now, pick first available viewer that can view this type
+        # TODO: pop-up a dialog and ask the user?
         vname = vnames[0]
 
         # if we don't have this viewer type then install one in the channel

--- a/ginga/rv/Control.py
+++ b/ginga/rv/Control.py
@@ -26,7 +26,7 @@ from ginga import cmap, imap
 from ginga import AstroImage, RGBImage, BaseImage
 from ginga.table import AstroTable
 from ginga.misc import Bunch, Timer, Future
-from ginga.util import catalog, iohelper, io_fits, toolbox
+from ginga.util import catalog, iohelper, loader, io_fits, toolbox
 from ginga.canvas.CanvasObject import drawCatalog
 from ginga.canvas.types.layer import DrawingCanvas
 from ginga.canvas import render
@@ -163,6 +163,7 @@ class GingaShell(GwMain.GwMain, Widgets.Application):
         self.cursor_interval = self.settings.get('cursor_interval', 0.050)
 
         # for loading FITS files
+        # WARNING: TO BE DEPRECATED!! DON'T USE fits_opener IN PLUGINS!!
         fo = io_fits.fitsLoaderClass(self.logger)
         fo.register_type('image', AstroImage.AstroImage)
         fo.register_type('table', AstroTable.AstroTable)
@@ -559,45 +560,18 @@ class GingaShell(GwMain.GwMain, Widgets.Application):
     # BASIC IMAGE OPERATIONS
 
     def load_image(self, filepath, idx=None, show_error=True):
+        """
+        A wrapper around ginga.util.loader.load_data()
 
-        info = iohelper.get_fileinfo(filepath, cache_dir=self.tmpdir)
-        filepfx = info.filepath
+        This actually can load other data types, like
 
-        # Create an image.  Assume type to be an AstroImage unless
-        # the MIME association says it is something different.
+        """
+        inherit_prihdr = self.settings.get('inherit_primary_header',
+                                           False)
         try:
-            typ, subtyp = iohelper.guess_filetype(filepfx)
-
-        except Exception as e:
-            self.logger.warning("error determining file type: %s; "
-                                "assuming 'image/fits'" % (str(e)))
-            # Can't determine file type: assume and attempt FITS
-            typ, subtyp = 'image', 'fits'
-
-        kwargs = {}
-
-        self.logger.debug("assuming file type: %s/%s'" % (typ, subtyp))
-        try:
-            # RGB
-            if (typ == 'image') and (subtyp not in ('fits', 'x-fits')):
-                image = RGBImage.RGBImage(logger=self.logger)
-                filepath = filepfx
-                image.load_file(filepath, **kwargs)
-
-            # FITS
-            else:
-                if idx is None:
-                    idx = info.numhdu
-
-                inherit_prihdr = self.settings.get(
-                    'inherit_primary_header', False)
-                kwargs.update(
-                    dict(numhdu=idx, inherit_primary_header=inherit_prihdr))
-
-                self.logger.info("Loading object from %s kwargs=%s" % (
-                    filepath, str(kwargs)))
-                image = self.fits_opener.load_file(filepath, **kwargs)
-
+            image = loader.load_data(filepath, logger=self.logger,
+                                     idx=idx,
+                                     inherit_primary_header=inherit_prihdr)
         except Exception as e:
             errmsg = "Failed to load file '%s': %s" % (
                 filepath, str(e))

--- a/ginga/rv/Control.py
+++ b/ginga/rv/Control.py
@@ -23,7 +23,7 @@ import queue as Queue  # noqa
 
 # Local application imports
 from ginga import cmap, imap
-from ginga import AstroImage, RGBImage, BaseImage
+from ginga import AstroImage, BaseImage
 from ginga.table import AstroTable
 from ginga.misc import Bunch, Timer, Future
 from ginga.util import catalog, iohelper, loader, io_fits, toolbox

--- a/ginga/rv/plugins/Mosaic.py
+++ b/ginga/rv/plugins/Mosaic.py
@@ -36,7 +36,7 @@ import threading
 import numpy as np
 
 from ginga.AstroImage import AstroImage
-from ginga.util import wcs, iqcalc, dp
+from ginga.util import wcs, iqcalc, dp, io_fits
 from ginga import GingaPlugin
 from ginga.gw import Widgets
 
@@ -445,9 +445,8 @@ class Mosaic(GingaPlugin.LocalPlugin):
                 mosaic_hdus = self.settings.get('mosaic_hdus', False)
                 if mosaic_hdus:
                     self.logger.debug("loading hdus")
-                    opener = self.fv.fits_opener.get_factory()
+                    opener = io_fits.get_fitsloader(logger=self.logger)
                     # User wants us to mosaic HDUs
-                    # TODO: do this in a different thread?
                     opener.open_file(url, memmap=False)
                     try:
                         for i in range(len(opener)):

--- a/ginga/rv/plugins/MultiDim.py
+++ b/ginga/rv/plugins/MultiDim.py
@@ -1,5 +1,7 @@
+#
 # This is open-source software licensed under a BSD license.
 # Please see the file LICENSE.txt for details.
+#
 """
 A plugin to navigate HDUs in a FITS file or planes in a 3D cube or
 higher dimension dataset.
@@ -49,6 +51,7 @@ from ginga.misc import Future
 from ginga import GingaPlugin
 from ginga.util.iohelper import get_hdu_suffix
 from ginga.util.videosink import VideoSink
+from ginga.util import io_fits
 
 import numpy as np
 
@@ -595,7 +598,8 @@ class MultiDim(GingaPlugin.LocalPlugin):
                 except Exception:
                     pass
 
-            self.file_obj = self.fv.fits_opener.get_factory()
+            self.file_obj = io_fits.get_fitsloader(logger=self.logger)
+
             # TODO: specify 'readonly' somehow?
             self.file_obj.open_file(path)
 

--- a/ginga/util/io_fits.py
+++ b/ginga/util/io_fits.py
@@ -68,6 +68,14 @@ def use(fitspkg, raise_err=True):
 
 class BaseFitsFileHandler(object):
 
+    # holds datatype/class objects for instantiating objects
+    # loaded from FITS files
+    factory_dict = {}
+
+    @classmethod
+    def register_type(cls, name, klass):
+        cls.factory_dict[name.lower()] = klass
+
     def __init__(self, logger):
         super(BaseFitsFileHandler, self).__init__()
 
@@ -77,14 +85,9 @@ class BaseFitsFileHandler(object):
         self.hdu_info = []
         self.hdu_db = {}
         self.extver_db = {}
-        self.factory_dict = {}
-
-    def register_type(self, name, klass):
-        self.factory_dict[name.lower()] = klass
 
     def get_factory(self):
         hdlr = self.__class__(self.logger)
-        hdlr.factory_dict.update(self.factory_dict)
         return hdlr
 
 
@@ -568,5 +571,6 @@ if not fits_configured:
 
 def get_fitsloader(kind=None, logger=None):
     return fitsLoaderClass(logger)
+
 
 # END

--- a/ginga/util/loader.py
+++ b/ginga/util/loader.py
@@ -12,7 +12,7 @@ from ginga.util import iohelper, io_fits, io_rgb
 def load_data(filespec, idx=None, logger=None, **kwargs):
     """Load data from a file.
 
-    This call is used to determine the type
+    This call is used to load a data item from a filespec (path or URL)
 
     Parameters
     ----------

--- a/ginga/util/loader.py
+++ b/ginga/util/loader.py
@@ -1,0 +1,106 @@
+#
+# loader.py -- upper level routines used to load data
+#
+# This is open-source software licensed under a BSD license.
+# Please see the file LICENSE.txt for details.
+#
+
+from ginga.misc import Bunch
+from ginga.util import iohelper, io_fits, io_rgb
+
+
+def load_data(filespec, idx=None, logger=None, **kwargs):
+    """Load data from a file.
+
+    This call is used to determine the type
+
+    Parameters
+    ----------
+    filespec : str
+        The path of the file to load (can be a URL).
+
+    idx : int or string (optional)
+        The index or name of the data unit in the file (e.g. an HDU name)
+
+    logger : python logger (optional)
+        A logger to record progress opening the item
+
+    All other keyword parameters are passed to the opener chosen for
+    the file type.
+
+    Returns
+    -------
+    data_obj : a data object for a ginga viewer
+
+    """
+    global viewer_registry
+
+    info = iohelper.get_fileinfo(filespec, cache_dir='/tmp')
+    filepath = info.filepath
+
+    if idx is None:
+        idx = info.numhdu
+
+    # Create an image.  Assume type to be a FITS image unless
+    # the MIME association says it is something different.
+    try:
+        typ, subtyp = iohelper.guess_filetype(filepath)
+
+    except Exception as e:
+        if logger is not None:
+            logger.warning("error determining file type: %s; "
+                           "assuming 'image/fits'" % (str(e)))
+        # Can't determine file type: assume and attempt FITS
+        typ, subtyp = 'image', 'fits'
+
+    if logger is not None:
+        logger.debug("assuming file type: %s/%s'" % (typ, subtyp))
+    try:
+        loader_info = viewer_registry['%s/%s' % (typ, subtyp)]
+        data_loader = loader_info.loader
+
+    except KeyError:
+        # for now, assume that this is an unrecognized FITS file
+        data_loader = load_fits
+
+    data_obj = data_loader(filepath, idx=idx, logger=logger,
+                           **kwargs)
+    return data_obj
+
+def load_rgb(filepath, logger=None, **kwargs):
+    loader = io_rgb.get_rgbloader(logger=logger)
+    image = loader.load_file(filepath, **kwargs)
+    return image
+
+def load_fits(filepath, logger=None, **kwargs):
+    loader = io_fits.get_fitsloader(logger=logger)
+    numhdu = kwargs.pop('idx', None)
+    image = loader.load_file(filepath, numhdu=numhdu, **kwargs)
+    return image
+
+# This contains a registry of upper-level loaders with their secondary
+# loading functions
+#
+viewer_registry = {}
+
+def add_loader(mimetype, loader):
+    global viewer_registry
+    # TODO: can/should we store other preferences/customizations along
+    # with the loader?
+    viewer_registry[mimetype] = Bunch.Bunch(loader=loader,
+                                            mimetype=mimetype)
+
+# built ins
+# ### FITS ###
+lc = io_fits.fitsLoaderClass
+from ginga.AstroImage import AstroImage
+lc.register_type('image', AstroImage)
+from ginga.table.AstroTable import AstroTable
+lc.register_type('table', AstroTable)
+
+for mimetype in ['image/fits', 'image/x-fits']:
+    add_loader(mimetype, load_fits)
+
+# ### RGB ###
+for mimetype in ['image/jpeg', 'image/png', 'image/tiff', 'image/gif']:
+    add_loader(mimetype, load_rgb)

--- a/ginga/util/loader.py
+++ b/ginga/util/loader.py
@@ -86,6 +86,7 @@ def load_fits(filepath, logger=None, **kwargs):
 #
 viewer_registry = {}
 
+
 def add_loader(mimetype, loader):
     global viewer_registry
     # TODO: can/should we store other preferences/customizations along

--- a/ginga/util/loader.py
+++ b/ginga/util/loader.py
@@ -67,16 +67,19 @@ def load_data(filespec, idx=None, logger=None, **kwargs):
                            **kwargs)
     return data_obj
 
+
 def load_rgb(filepath, logger=None, **kwargs):
     loader = io_rgb.get_rgbloader(logger=logger)
     image = loader.load_file(filepath, **kwargs)
     return image
+
 
 def load_fits(filepath, logger=None, **kwargs):
     loader = io_fits.get_fitsloader(logger=logger)
     numhdu = kwargs.pop('idx', None)
     image = loader.load_file(filepath, numhdu=numhdu, **kwargs)
     return image
+
 
 # This contains a registry of upper-level loaders with their secondary
 # loading functions
@@ -89,6 +92,7 @@ def add_loader(mimetype, loader):
     # with the loader?
     viewer_registry[mimetype] = Bunch.Bunch(loader=loader,
                                             mimetype=mimetype)
+
 
 # built ins
 # ### FITS ###


### PR DESCRIPTION
This adds a "first-level" loader module to ginga.  This module allows opening a data item without knowing what it is first.  It works based off of the mime type of the file and also the magic function, if available.

This loader works with both the reference viewer as well as when using just the ginga widget.  This summarizes the difference:

Before:
```python
  from ginga.AstroImage import AstroImage
  image = AstroImage(logger)
  image.load_file(some_path)
```
After:
```python
  from ginga.util.loader import load_data
  image = load_data(path, logger=logger)
```
Although it is shorter, the main reason it is better is that in the first instance we commit to creating a `AstroImage`, but if the file references an RGB file this is not necessarily the right type.  In the second case an `AstroImage`, a `RGBImage` or some other kind of image might be returned.