### PR TITLE
DOC: Jupyter slider demo

### DIFF
--- a/ginga/examples/jupyter-notebook/MEF_slider_demo.ipynb
+++ b/ginga/examples/jupyter-notebook/MEF_slider_demo.ipynb
@@ -1,0 +1,257 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Slider Widget for Multi-Extension FITS Image"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This demo shows you how to implement a simple Jupyter widget, which allows you to see a different extension in a given multi-extension FITS (MEF) image via a slider.\n",
+    "\n",
+    "Dependencies:\n",
+    "\n",
+    "* astropy\n",
+    "* ginga\n",
+    "* ipywidgets\n",
+    "* IPython\n",
+    "* jupyter\n",
+    "* notebook\n",
+    "\n",
+    "If widget does not show up, you also need to enable widget in your Jupyter notebooks::\n",
+    "\n",
+    "    jupyter nbextension enable --py widgetsnbextension"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "\n",
+    "# Create a Jupyter image that will be our display surface.\n",
+    "# Format can be 'jpeg' or 'png'; specify width and height to set viewer size.\n",
+    "# PNG will be a little clearer, especially with overlaid graphics, but\n",
+    "# JPEG is faster to update.\n",
+    "jup_img = widgets.Image(format='jpeg', width=500, height=500)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from ginga.misc.log import get_logger\n",
+    "\n",
+    "# Here, we just get a null logger.\n",
+    "# See other example(s) on how to log to a file.\n",
+    "logger = get_logger(\"my viewer\", null=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from ginga.web.jupyterw.ImageViewJpw import EnhancedCanvasView\n",
+    "\n",
+    "# Ginga viewer for Jupyter notebook.\n",
+    "v1 = EnhancedCanvasView(logger=logger)\n",
+    "\n",
+    "# Set our linkage between the Jupyter widget at Ginga viewer.\n",
+    "v1.set_widget(jup_img)\n",
+    "\n",
+    "# Enable all possible keyboard and pointer operations.\n",
+    "bd = v1.get_bindings()\n",
+    "bd.enable_all(True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/javascript": [
+       "/* some magic to keep the cell contents from scrolling\n",
+       "   (when we embed the viewer)\n",
+       " */\n",
+       "IPython.OutputArea.prototype._should_scroll = function(lines) {\n",
+       "    return false;\n",
+       "}"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%%javascript\n",
+    "/* some magic to keep the cell contents from scrolling\n",
+    "   (when we embed the viewer)\n",
+    " */\n",
+    "IPython.OutputArea.prototype._should_scroll = function(lines) {\n",
+    "    return false;\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Filename: jd2j07f12_flt.fits\n",
+      "No.    Name      Ver    Type      Cards   Dimensions   Format\n",
+      "  0  PRIMARY       1 PrimaryHDU     244   ()      \n",
+      "  1  SCI           1 ImageHDU        95   (2048, 2048)   float32   \n",
+      "  2  ERR           1 ImageHDU        48   (2048, 2048)   float32   \n",
+      "  3  DQ            1 ImageHDU        40   (2048, 2048)   int16   \n"
+     ]
+    }
+   ],
+   "source": [
+    "from astropy.io import fits\n",
+    "\n",
+    "# Replace this file with a real MEF image you can access.\n",
+    "filename = 'jd2j07f12_flt.fits'\n",
+    "\n",
+    "pf = fits.open(filename)\n",
+    "\n",
+    "# Display extensions info for sanity check.\n",
+    "pf.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Define a function for the slider.\n",
+    "def change_ext(ext):\n",
+    "    \"\"\"\n",
+    "    Change displayed extension when it slides.\n",
+    "    \n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    ext : int\n",
+    "        Integer value of the extension.\n",
+    "        \n",
+    "    \"\"\"\n",
+    "    v1.load_hdu(pf[ext])\n",
+    "    v1.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "54241560d1ec4d10a4d30b301490c712",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "A Jupyter Widget"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5294cb2ad62242a8a02cd199ad984e42",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "A Jupyter Widget"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from IPython.display import display\n",
+    "from ipywidgets import interact\n",
+    "\n",
+    "# Embed the viewer here.\n",
+    "display(jup_img)\n",
+    "\n",
+    "# Initialize and display the slider right below the viewer.\n",
+    "interact(change_ext, ext=widgets.IntSlider(min=0,max=len(pf)-1,step=1,value=1));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, you should see an image displayed in the viewer. When you move the slider, viewer should update to display the selected extension. If you select a primary header (`ext=0`), viewer will give a warning, which you can ignore.\n",
+    "\n",
+    "See other example(s) on how you can further interact with and customize your Ginga viewer in Jupyter notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Close the FITS file handler when you are done.\n",
+    "pf.close()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Add a new demo notebook on how to implement a simple slider for multi-extension FITS image.

A semi-rendered notebook can be viewed at https://gist.github.com/pllim/f0d465eaf4eb45f9bcd2cccd1779dea3 (except the widgets, which will only show properly when you run it locally).