### PR TITLE
Fix writing out to PNG with PIL

### DIFF
--- a/ginga/ImageView.py
+++ b/ginga/ImageView.py
@@ -3407,7 +3407,7 @@ class ImageViewBase(Callback.Callbacks):
             See :meth:`get_rgb_image_as_buffer`.
 
         """
-        with open(filepath, 'w') as out_f:
+        with open(filepath, 'wb') as out_f:
             self.get_rgb_image_as_buffer(output=out_f, format=format,
                                          quality=quality)
         self.logger.debug("wrote %s file '%s'" % (format, filepath))


### PR DESCRIPTION
I got an error writing using `viewer.save_rgb_image_as_file("screenshot.png")` for `EnhancedCanvasView` under `jupyterw`. This patch fixed the error for me. I am not sure if this is specific to PIL or  not.

xref eteq/astrowidgets#1