### PR TITLE
Fix issue #677, for FutureWarning with numpy>=1.15.0

### DIFF
--- a/ginga/AstroImage.py
+++ b/ginga/AstroImage.py
@@ -179,7 +179,7 @@ class AstroImage(BaseImage):
         revnaxis.reverse()
 
         # construct slice view and extract it
-        view = revnaxis + [slice(None), slice(None)]
+        view = tuple(revnaxis + [slice(None), slice(None)])
         data = self.get_mddata()[view]
 
         if len(data.shape) != 2:

--- a/ginga/rv/plugins/Cuts.py
+++ b/ginga/rv/plugins/Cuts.py
@@ -679,7 +679,7 @@ class Cuts(GingaPlugin.LocalPlugin):
             axes_slice[sa] = coords[:, i]
         axes_slice[selected_axis] = slice(None, None, None)
 
-        self.slit_data = data[axes_slice]
+        self.slit_data = data[tuple(axes_slice)]
 
     def _plot_slit(self):
         if not self.selected_axis:

--- a/ginga/rv/plugins/LineProfile.py
+++ b/ginga/rv/plugins/LineProfile.py
@@ -341,7 +341,7 @@ class LineProfile(GingaPlugin.LocalPlugin):
                 axes_slice[i_y] = int(round(ycen))
                 axes_slice[i_sel] = slice(None, None, None)
                 try:
-                    plot_y_axis_data = mddata[axes_slice]
+                    plot_y_axis_data = mddata[tuple(axes_slice)]
                 except IndexError:
                     continue
 
@@ -352,7 +352,7 @@ class LineProfile(GingaPlugin.LocalPlugin):
                 if naxes > 3:
                     for j in (i_x, i_y, i_sel):
                         axes_slice[j] = slice(None, None, None)
-                    data = mddata[axes_slice]  # z, y, x
+                    data = mddata[tuple(axes_slice)]  # z, y, x
                 else:
                     data = mddata
                 # Mask is 2D only (True = enclosed)


### PR DESCRIPTION
This fixes an issue for the error message issued by numpy >= 1.15.0:

FutureWarning: Using a non-tuple sequence for multidimensional indexing is
deprecated; use `arr[tuple(seq)]` instead of `arr[seq]`. In the future this
will be interpreted as an array index, `arr[np.array(seq)]`, which will
result either in an error or a different result.

EDIT: Fix #677 