### PR TITLE
Fix Cursor plugin not updating info on image/channel blinking

### DIFF
--- a/ginga/ImageView.py
+++ b/ginga/ImageView.py
@@ -1329,7 +1329,7 @@ class ImageViewBase(Callback.Callbacks):
         data_x, data_y = self.get_data_xy(self.last_win_x,
                                           self.last_win_y)
         if (data_x != self.last_data_x or
-                data_y != self.last_data_y):
+            data_y != self.last_data_y):
             self.last_data_x, self.last_data_y = data_x, data_y
             self.logger.debug("cursor location changed %.4f,%.4f => %.4f,%.4f" % (
                 self.last_data_x, self.last_data_y, data_x, data_y))

--- a/ginga/gtk3w/ImageViewGtk.py
+++ b/ginga/gtk3w/ImageViewGtk.py
@@ -362,6 +362,9 @@ class ImageViewEvent(ImageViewGtk):
         return self.make_callback('focus', hasFocus)
 
     def enter_notify_event(self, widget, event):
+        self.last_win_x, self.last_win_y = event.x, event.y
+        self.check_cursor_location()
+
         enter_focus = self.t_.get('enter_focus', False)
         if enter_focus:
             widget.grab_focus()
@@ -376,7 +379,6 @@ class ImageViewEvent(ImageViewGtk):
         # changes to another window
         #Gdk.keyboard_grab(widget.get_window(), False, event.time)
         #widget.grab_add()
-
         keyname = Gdk.keyval_name(event.keyval)
         keyname = self.transkey(keyname)
         self.logger.debug("key press event, key=%s" % (keyname))
@@ -385,7 +387,6 @@ class ImageViewEvent(ImageViewGtk):
     def key_release_event(self, widget, event):
         #Gdk.keyboard_ungrab(event.time)
         #widget.grab_remove()
-
         keyname = Gdk.keyval_name(event.keyval)
         keyname = self.transkey(keyname)
         self.logger.debug("key release event, key=%s" % (keyname))

--- a/ginga/gtkw/ImageViewGtk.py
+++ b/ginga/gtkw/ImageViewGtk.py
@@ -393,6 +393,9 @@ class ImageViewEvent(ImageViewGtk):
         return self.make_callback('focus', hasFocus)
 
     def enter_notify_event(self, widget, event):
+        self.last_win_x, self.last_win_y = event.x, event.y
+        self.check_cursor_location()
+
         enter_focus = self.t_.get('enter_focus', False)
         if enter_focus:
             widget.grab_focus()
@@ -406,7 +409,6 @@ class ImageViewEvent(ImageViewGtk):
         # without this we do not get key release events if the focus
         # changes to another window
         #gtk.gdk.keyboard_grab(widget.get_window(), False)
-
         keyname = gtk.gdk.keyval_name(event.keyval)
         keyname = self.transkey(keyname)
         self.logger.debug("key press event, key=%s" % (keyname))
@@ -414,7 +416,6 @@ class ImageViewEvent(ImageViewGtk):
 
     def key_release_event(self, widget, event):
         #gtk.gdk.keyboard_ungrab()
-
         keyname = gtk.gdk.keyval_name(event.keyval)
         keyname = self.transkey(keyname)
         self.logger.debug("key release event, key=%s" % (keyname))

--- a/ginga/qtw/ImageViewQt.py
+++ b/ginga/qtw/ImageViewQt.py
@@ -514,6 +514,9 @@ class QtEventMixin(object):
         return self.make_callback('focus', hasFocus)
 
     def enter_notify_event(self, widget, event):
+        self.last_win_x, self.last_win_y = event.x(), event.y()
+        self.check_cursor_location()
+
         enter_focus = self.t_.get('enter_focus', False)
         if enter_focus:
             widget.setFocus()

--- a/ginga/rv/plugins/Blink.py
+++ b/ginga/rv/plugins/Blink.py
@@ -151,7 +151,7 @@ class Blink(GingaPlugin.LocalPlugin):
     def stop(self):
         self.stop_blinking()
 
-    def redo(self):
+    def redo(self, *args):
         pass
 
     def _blink_timer_cb(self, timer):

--- a/ginga/rv/plugins/Cursor.py
+++ b/ginga/rv/plugins/Cursor.py
@@ -134,9 +134,18 @@ class Cursor(GingaPlugin.GlobalPlugin):
         readout.maxv = max(len(str(minval)), len(str(maxval)))
         return True
 
+    def force_update(self, channel):
+        viewer = channel.fitsimage
+        data_x, data_y = viewer.get_last_data_xy()
+        self.fv.showxy(viewer, data_x, data_y)
+
     def redo(self, channel, image):
         readout = channel.extdata.readout
         self.readout_config(channel.fitsimage, image, readout)
+
+        # force an update on an image change, because the WCS
+        # may be different, even if the data coords are the same
+        self.force_update(channel)
 
     def change_readout(self, channel, fitsimage):
         if (self.share_readout) and (self.readout is not None):
@@ -156,6 +165,10 @@ class Cursor(GingaPlugin.GlobalPlugin):
     def focus_cb(self, viewer, channel):
         if channel is not None:
             self.change_readout(channel, channel.fitsimage)
+
+            # force an update on a channel change, because the WCS
+            # may be different, even if the data coords are the same
+            self.force_update(channel)
 
     def field_info_cb(self, viewer, channel, info):
         readout = self.readout


### PR DESCRIPTION
Fixes an issue where the Cursor plugin doesn't update its info when images are blinked in a channel, or the channels are blinked.  Fixes #683.
