### PR TITLE
Fix table header error msg

### DIFF
--- a/ginga/table/AstroTable.py
+++ b/ginga/table/AstroTable.py
@@ -82,7 +82,7 @@ class AstroTable(ViewerObjectBase):
     def _get_data(self):
         return self._data
 
-    def get_header(self, create=True):
+    def get_header(self, create=True, **kwargs):
         try:
             # By convention, the fits header is stored in a dictionary
             # under the metadata keyword 'header'


### PR DESCRIPTION
This fixes the error message when displaying a table:

```
2018-08-27 12:16:50,628 | E | GwMain.py:76 (_execute_future) |
  gui event loop error: get_header() got an unexpected
  keyword argument 'include_primary_header'
2018-08-27 12:16:50,629 | E | GwMain.py:80 (_execute_future) | Traceback:
  File ".../ginga/gw/GwMain.py", line 73, in _execute_future
    future.thaw(suppress_exception=False)
  File ".../ginga/misc/Future.py", line 46, in thaw
    res = self.method(*self.args, **self.kwdargs)
  File ".../ginga/rv/plugins/Header.py", line 225, in redo
    self.set_header(info, image)
  File ".../ginga/rv/plugins/Header.py", line 131, in set_header
    header = image.get_header(include_primary_header=self.flg_prihdr)
```