### PR TITLE
Enable calling plugin methods from remote interface

### DIFF
--- a/ginga/rv/Control.py
+++ b/ginga/rv/Control.py
@@ -283,6 +283,28 @@ class GingaShell(GwMain.GwMain, Widgets.Application):
 
     def call_local_plugin_method(self, chname, plugin_name, method_name,
                                  args, kwargs):
+        """
+        Parameters
+        ----------
+        chname : str
+            The name of the channel containing the plugin.
+
+        plugin_name : str
+            The name of the local plugin containing the method to call.
+
+        method_name : str
+            The name of the method to call.
+
+        args : list or tuple
+            The positional arguments to the method
+
+        kwargs : dict
+            The keyword arguments to the method
+
+        Returns
+        -------
+        result : return value from calling the method
+        """
         channel = self.get_channel(chname)
         opmon = channel.opmon
         p_obj = opmon.get_plugin(plugin_name)
@@ -300,6 +322,25 @@ class GingaShell(GwMain.GwMain, Widgets.Application):
 
     def call_global_plugin_method(self, plugin_name, method_name,
                                   args, kwargs):
+        """
+        Parameters
+        ----------
+        plugin_name : str
+            The name of the global plugin containing the method to call.
+
+        method_name : str
+            The name of the method to call.
+
+        args : list or tuple
+            The positional arguments to the method
+
+        kwargs : dict
+            The keyword arguments to the method
+
+        Returns
+        -------
+        result : return value from calling the method
+        """
         p_obj = self.gpmon.get_plugin(plugin_name)
         method = getattr(p_obj, method_name)
         return self.gui_call(method, *args, **kwargs)

--- a/ginga/rv/Control.py
+++ b/ginga/rv/Control.py
@@ -281,6 +281,13 @@ class GingaShell(GwMain.GwMain, Widgets.Application):
         opmon = channel.opmon
         opmon.deactivate(opname)
 
+    def call_local_plugin_method(self, chname, plugin_name, args, kwargs):
+        channel = self.get_channel(chname)
+        opmon = channel.opmon
+        p_obj = opmon.get_plugin(plugin_name)
+        method = getattr(p_obj, plugin_name)
+        return self.gui_call(method, *args, **kwargs)
+
     def start_global_plugin(self, plugin_name, raise_tab=False):
         self.gpmon.start_plugin_future(None, plugin_name, None)
         if raise_tab:
@@ -289,6 +296,11 @@ class GingaShell(GwMain.GwMain, Widgets.Application):
 
     def stop_global_plugin(self, plugin_name):
         self.gpmon.deactivate(plugin_name)
+
+    def call_global_plugin_method(self, plugin_name, args, kwargs):
+        p_obj = self.gpmon.get_plugin(plugin_name)
+        method = getattr(p_obj, plugin_name)
+        return self.gui_call(method, *args, **kwargs)
 
     def start_plugin(self, plugin_name, spec):
         ptype = spec.get('ptype', 'local')

--- a/ginga/rv/Control.py
+++ b/ginga/rv/Control.py
@@ -281,11 +281,12 @@ class GingaShell(GwMain.GwMain, Widgets.Application):
         opmon = channel.opmon
         opmon.deactivate(opname)
 
-    def call_local_plugin_method(self, chname, plugin_name, args, kwargs):
+    def call_local_plugin_method(self, chname, plugin_name, method_name,
+                                 args, kwargs):
         channel = self.get_channel(chname)
         opmon = channel.opmon
         p_obj = opmon.get_plugin(plugin_name)
-        method = getattr(p_obj, plugin_name)
+        method = getattr(p_obj, method_name)
         return self.gui_call(method, *args, **kwargs)
 
     def start_global_plugin(self, plugin_name, raise_tab=False):
@@ -297,9 +298,10 @@ class GingaShell(GwMain.GwMain, Widgets.Application):
     def stop_global_plugin(self, plugin_name):
         self.gpmon.deactivate(plugin_name)
 
-    def call_global_plugin_method(self, plugin_name, args, kwargs):
+    def call_global_plugin_method(self, plugin_name, method_name,
+                                  args, kwargs):
         p_obj = self.gpmon.get_plugin(plugin_name)
-        method = getattr(p_obj, plugin_name)
+        method = getattr(p_obj, method_name)
         return self.gui_call(method, *args, **kwargs)
 
     def start_plugin(self, plugin_name, spec):

--- a/ginga/rv/plugins/RC.py
+++ b/ginga/rv/plugins/RC.py
@@ -209,6 +209,11 @@ class RC(GingaPlugin.GlobalPlugin):
         # If blank, listens on all interfaces
         self.host = 'localhost'
 
+        # this will hold the remote object
+        self.robj = None
+        # this will hold the remote object server
+        self.server = None
+
         self.ev_quit = fv.ev_quit
 
     def build_gui(self, container):
@@ -463,7 +468,9 @@ class GingaWrapper(object):
             newargs = args[1:]
             obj = klass(*newargs, **kwargs)
             return self.fv.gui_call(canvas.add, obj)
-        elif command == 'clear':  # Clear only drawn objects, not the image
+
+        elif command == 'clear':
+            # Clear only drawn objects, not the image
             nobj = len(canvas.objects)
             if nobj == 0:
                 return
@@ -471,8 +478,10 @@ class GingaWrapper(object):
                 return
             else:
                 canvas.objects = canvas.objects[0:1]
+
         elif command == 'nobj':
             return len(canvas.objects)
+
         else:
             print("Canvas RC command not recognized")
             return

--- a/ginga/rv/plugins/WCSMatch.py
+++ b/ginga/rv/plugins/WCSMatch.py
@@ -170,6 +170,11 @@ class WCSMatch(GingaPlugin.GlobalPlugin):
     def set_reference_channel_cb(self, w, idx):
         chname = self.chnames[idx]
         if chname == 'None':
+            chname = None
+        self.set_reference_channel(chname)
+
+    def set_reference_channel(self, chname):
+        if chname is None:
             self.ref_image = None
             self.ref_channel = None
             self.logger.info("turning off channel synchronization")

--- a/ginga/rv/plugins/WCSMatch.py
+++ b/ginga/rv/plugins/WCSMatch.py
@@ -76,7 +76,7 @@ class WCSMatch(GingaPlugin.GlobalPlugin):
         w, b = Widgets.build_info(captions, orientation=orientation)
         self.w = b
 
-        b.ref_channel.add_callback('activated', self.set_reference_channel_cb)
+        b.ref_channel.add_callback('activated', self._set_reference_channel_cb)
         self.w.match_pan.set_state(self._match['pan'])
         self.w.match_pan.set_tooltip("Match pan position of reference image")
         self.w.match_pan.add_callback('activated',
@@ -167,13 +167,9 @@ class WCSMatch(GingaPlugin.GlobalPlugin):
         self.xfmset(chviewer, chinfo)
         self.panset(chviewer, chinfo)
 
-    def set_reference_channel_cb(self, w, idx):
-        chname = self.chnames[idx]
+    def _set_reference_channel(self, chname):
         if chname == 'None':
             chname = None
-        self.set_reference_channel(chname)
-
-    def set_reference_channel(self, chname):
         if chname is None:
             self.ref_image = None
             self.ref_channel = None
@@ -192,6 +188,21 @@ class WCSMatch(GingaPlugin.GlobalPlugin):
         self._update_all()
 
         self.logger.info("set reference channel to '%s'" % (chname))
+
+    def _set_reference_channel_cb(self, w, idx):
+        """This is the GUI callback for the control that sets the reference
+        channel.
+        """
+        chname = self.chnames[idx]
+        self._set_reference_channel(chname)
+
+    def set_reference_channel(self, chname):
+        """This is the API call to set the reference channel.
+        """
+        # change the GUI control to match
+        idx = self.chnames.index(str(chname))
+        self.w.ref_channel.set_index(idx)
+        return self._set_reference_channel(chname)
 
     def set_match_cb(self, w, tf, key):
         # remember, in case we are closed and reopened


### PR DESCRIPTION
This adds two methods to the ginga shell that allow methods in a global or local plugin to be called.  This can be used e.g. from the RC interface, or internally.