### PR TITLE
Fix typo in setup.cfg 

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[build_sphinx]
+[build_docs]
 source-dir = doc
 build-dir = doc/_build
 all_files = 1


### PR DESCRIPTION
Probably an oversight when helpers changed the command from `build_sphinx` to `build_docs`.