### PR TITLE
Avoid using masked array for iqcalc

### DIFF
--- a/ginga/tests/test_iqcalc.py
+++ b/ginga/tests/test_iqcalc.py
@@ -1,0 +1,20 @@
+import numpy as np
+import pytest
+
+from ginga.util import iqcalc
+
+
+@pytest.mark.parametrize(
+    ('arr', 'ans'),
+    [(np.arange(5), 2),
+     (np.array([1, np.inf, 3, np.nan, 5]), 3),
+     (np.arange(10).reshape(2, 5), 4.5)])
+def test_get_mean_median(arr, ans):
+    assert iqcalc.get_mean(arr) == ans
+    assert iqcalc.get_median(arr) == ans
+
+
+def test_get_mean_median_nan():
+    arr = np.array([np.nan, np.inf])
+    assert np.isnan(iqcalc.get_mean(arr))
+    assert np.isnan(iqcalc.get_median(arr))

--- a/ginga/util/iqcalc.py
+++ b/ginga/util/iqcalc.py
@@ -23,13 +23,32 @@ from ginga.misc import Bunch
 
 
 def get_mean(data_np):
-    mdata = np.ma.masked_array(data_np, np.isnan(data_np))
-    return np.mean(mdata)
+    """Calculate mean for valid values.
+
+    Parameters
+    ----------
+    data_np : ndarray
+        Input array.
+
+    Returns
+    -------
+    result : float
+        Mean of array values that are finite.
+        If array contains no finite values, returns NaN.
+
+    """
+    i = np.isfinite(data_np)
+    if not np.any(i):
+        return np.nan
+    return np.mean(data_np[i])
 
 
 def get_median(data_np):
-    mdata = np.ma.masked_array(data_np, np.isnan(data_np))
-    return np.median(mdata)
+    """Like :func:`get_mean` but for median."""
+    i = np.isfinite(data_np)
+    if not np.any(i):
+        return np.nan
+    return np.median(data_np[i])
 
 
 class IQCalcError(Exception):


### PR DESCRIPTION
When using `Mosaic` plugin, I noticed this warning:
```
2018-11-07 16:04:20,707 | W | warnings.py:99 (_showwarnmsg) |
    .../numpy/core/fromnumeric.py:688: UserWarning: Warning:
    'partition' will ignore the 'mask' of the MaskedArray.
  a.partition(kth, axis=axis, kind=kind, order=order)
```

Then, I found numpy/numpy#7330,  numpy/numpy#7345, and numpy/numpy#8669. To illustrate the problem using Numpy 1.15.4:
```python
>>> import numpy as np
>>> data_np = np.array([1, np.nan, 3, 4, 5])
>>> mdata = np.ma.masked_array(data_np, np.isnan(data_np))
>>> np.median(mdata)
.../numpy/core/fromnumeric.py:688: UserWarning: Warning: 'partition' will ignore the 'mask' of the MaskedArray.
  a.partition(kth, axis=axis, kind=kind, order=order)
.../numpy/lib/function_base.py:3250: RuntimeWarning: Invalid value encountered in median
  r = func(a, **kwargs)
nan
>>> np.ma.median(mdata)
3.5
```

However, behavior of `np.ma.median` is unstable (probably fixed since Numpy 1.12 but you seem to support Numpy as old as 1.9). Even if you use the latest Numpy, when the whole array is NaN, `np.ma.median` (or `np.ma.mean`) returns "masked", which you cannot operate on anyway.

This PR avoids masked array altogether. The tests should show you the expected behaviors. If these are not the behaviors you want, please let me know.