### PR TITLE
Implement basic interface to ASDF and GWCS

### DIFF
--- a/doc/WhatsNew.rst
+++ b/doc/WhatsNew.rst
@@ -9,6 +9,7 @@ Ver 3.0.0 (unreleased)
 - Improved accuracy of Qt-based timers
 - Pick plugin enhanced with option to center on found object; also
   default shape changed to a box rather than a rectangle
+- Added support for ASDF and GWCS.
 
 Ver 2.7.2 (2018-11-05)
 ======================

--- a/doc/ref_api.rst
+++ b/doc/ref_api.rst
@@ -27,6 +27,8 @@ Reference/API
 .. automodapi:: ginga.rv.main
    :no-inheritance-diagram:
 
+.. automodapi:: ginga.util.io_asdf
+
 .. automodapi:: ginga.util.wcsmod
    :skip: use
    :skip: get_wcs_wrappers

--- a/ginga/AstroImage.py
+++ b/ginga/AstroImage.py
@@ -165,6 +165,31 @@ class AstroImage(BaseImage):
             self.wcs = wcsinfo.wrapper_class(logger=self.logger)
             self.wcs.load_nddata(ndd)
 
+    def load_asdf(self, asdf_obj, data_key='sci', wcs_key='wcs'):
+        """Load from an asdf object.
+        """
+        self.clear_metadata()
+
+        wcs = None
+        try:
+            wcs = asdf_obj[wcs_key]
+        except KeyError:
+            pass
+
+        ahdr = self.get_header()
+
+        data = None
+        try:
+            data = asdf_obj[data_key]
+        except KeyError:
+            pass
+
+        self.setup_data(data, naxispath=[])
+
+        wcsinfo = wcsmod.get_wcs_class('astropy_ape14')
+        self.wcs = wcsinfo.wrapper_class(logger=self.logger)
+        self.wcs.wcs = wcs
+
     def load_file(self, filespec, **kwargs):
 
         if self.io is None:

--- a/ginga/AstroImage.py
+++ b/ginga/AstroImage.py
@@ -11,7 +11,7 @@ from collections import OrderedDict
 
 import numpy as np
 
-from ginga.util import wcsmod, io_fits
+from ginga.util import wcsmod, io_fits, io_asdf
 from ginga.util import wcs, iqcalc
 from ginga.BaseImage import BaseImage, ImageError, Header
 from ginga.misc import Bunch
@@ -165,30 +165,23 @@ class AstroImage(BaseImage):
             self.wcs = wcsinfo.wrapper_class(logger=self.logger)
             self.wcs.load_nddata(ndd)
 
-    def load_asdf(self, asdf_obj, data_key='sci', wcs_key='wcs'):
-        """Load from an asdf object.
+    def load_asdf(self, asdf_obj, **kwargs):
+        """
+        Load from an ASDF object.
+        See :func:`ginga.util.io_asdf.load_asdf` for more info.
         """
         self.clear_metadata()
 
-        wcs = None
-        try:
-            wcs = asdf_obj[wcs_key]
-        except KeyError:
-            pass
-
-        ahdr = self.get_header()
-
-        data = None
-        try:
-            data = np.asarray(asdf_obj[data_key])
-        except KeyError:
-            pass
+        data, wcs, ahdr = io_asdf.load_asdf(asdf_obj, **kwargs)
 
         self.setup_data(data, naxispath=None)
 
         wcsinfo = wcsmod.get_wcs_class('astropy_ape14')
         self.wcs = wcsinfo.wrapper_class(logger=self.logger)
         self.wcs.wcs = wcs
+
+        if wcs is not None:
+            self.wcs.coordsys = wcs.output_frame.name
 
     def load_file(self, filespec, **kwargs):
 

--- a/ginga/AstroImage.py
+++ b/ginga/AstroImage.py
@@ -180,11 +180,11 @@ class AstroImage(BaseImage):
 
         data = None
         try:
-            data = asdf_obj[data_key]
+            data = np.asarray(asdf_obj[data_key])
         except KeyError:
             pass
 
-        self.setup_data(data, naxispath=[])
+        self.setup_data(data, naxispath=None)
 
         wcsinfo = wcsmod.get_wcs_class('astropy_ape14')
         self.wcs = wcsinfo.wrapper_class(logger=self.logger)

--- a/ginga/AutoCuts.py
+++ b/ginga/AutoCuts.py
@@ -400,6 +400,9 @@ class ZScale(AutoCutsBase):
 
         # calculate num_points parameter, if omitted
         total_points = wd * ht
+        if total_points == 0:
+            self.logger.debug('total_points is 0, setting cut levels to 0')
+            return 0, 0
         num_points = self.num_points
         if num_points is None:
             num_points = max(int(total_points * 0.0002), 1000)

--- a/ginga/canvas/types/astro.py
+++ b/ginga/canvas/types/astro.py
@@ -850,6 +850,9 @@ class WCSAxes(CompoundObject):
                 (pts[:, 1] >= 0) & (pts[:, 1] < image.height))
         pts = pts[mask]
 
+        if len(pts) == 0:
+            return []
+
         path_obj = Path(
             points=pts, coords='data', linewidth=self.linewidth,
             linestyle=self.linestyle, color=self.color,

--- a/ginga/examples/qt/example_asdf.py
+++ b/ginga/examples/qt/example_asdf.py
@@ -2,58 +2,157 @@
 #
 # example_asdf.py -- Simple ASDF viewer using the Ginga toolkit and Qt widgets.
 #
+# This is open-source software licensed under a BSD license.
+# Please see the file LICENSE.txt for details.
+#
+
 import sys
 
-from ginga import AstroImage
-from ginga.misc import log
 from ginga.qtw.QtHelp import QtGui, QtCore
-from ginga.qtw.ImageViewQt import CanvasView, ScrolledView
+from ginga import AstroImage, colors
+from ginga.qtw.ImageViewQt import CanvasView
+from ginga.canvas.CanvasObject import get_canvas_types
+from ginga.misc import log
 
+from ginga.util import wcsmod
+wcsmod.use('astropy_ape14')
 import asdf
+
+STD_FORMAT = '%(asctime)s | %(levelname)1.1s | %(filename)s:%(lineno)d (%(funcName)s) | %(message)s'
+
 
 class FitsViewer(QtGui.QMainWindow):
 
     def __init__(self, logger):
         super(FitsViewer, self).__init__()
         self.logger = logger
+        self.drawcolors = colors.get_colors()
+        self.dc = get_canvas_types()
 
-        # create the ginga viewer and configure it
-        fi = CanvasView(self.logger, render='widget')
+        fi = CanvasView(logger, render='widget')
         fi.enable_autocuts('on')
         fi.set_autocut_params('zscale')
         fi.enable_autozoom('on')
-        fi.set_callback('drag-drop', self.drop_file)
+        fi.set_zoom_algorithm('rate')
+        fi.set_zoomrate(1.4)
+        #fi.show_pan_mark(True)
+        #fi.enable_draw(False)
+        fi.add_callback('drag-drop', self.drop_file_cb)
+        fi.add_callback('cursor-changed', self.cursor_cb)
         fi.set_bg(0.2, 0.2, 0.2)
         fi.ui_set_active(True)
         self.fitsimage = fi
 
-        # enable some user interaction
         bd = fi.get_bindings()
         bd.enable_all(True)
+
+        # canvas that we will draw on
+        canvas = self.dc.DrawingCanvas()
+        canvas.enable_draw(True)
+        canvas.enable_edit(True)
+        canvas.set_drawtype('rectangle', color='lightblue')
+        canvas.set_surface(fi)
+        self.canvas = canvas
+        # add canvas to view
+        #fi.add(canvas)
+        private_canvas = fi.get_canvas()
+        private_canvas.add(canvas)
+        canvas.register_for_cursor_drawing(fi)
+        canvas.add_callback('draw-event', self.draw_cb)
+        canvas.set_draw_mode('draw')
+        canvas.ui_set_active(True)
+
+        self.drawtypes = canvas.get_drawtypes()
+        self.drawtypes.sort()
+
+        # add a color bar
+        #fi.show_color_bar(True)
+        fi.show_focus_indicator(True)
+
+        # add little mode indicator that shows keyboard modal states
+        fi.show_mode_indicator(True, corner='ur')
 
         w = fi.get_widget()
         w.resize(512, 512)
 
-        # add scrollbar interface around this viewer
-        si = ScrolledView(fi)
-
         vbox = QtGui.QVBoxLayout()
         vbox.setContentsMargins(QtCore.QMargins(2, 2, 2, 2))
         vbox.setSpacing(1)
-        vbox.addWidget(si, stretch=1)
+        vbox.addWidget(w, stretch=1)
+
+        self.readout = QtGui.QLabel("")
+        vbox.addWidget(self.readout, stretch=0,
+                       alignment=QtCore.Qt.AlignCenter)
 
         hbox = QtGui.QHBoxLayout()
         hbox.setContentsMargins(QtCore.QMargins(4, 2, 4, 2))
 
+        wdrawtype = QtGui.QComboBox()
+        for name in self.drawtypes:
+            wdrawtype.addItem(name)
+        index = self.drawtypes.index('rectangle')
+        wdrawtype.setCurrentIndex(index)
+        wdrawtype.activated.connect(self.set_drawparams)
+        self.wdrawtype = wdrawtype
+
+        wdrawcolor = QtGui.QComboBox()
+        for name in self.drawcolors:
+            wdrawcolor.addItem(name)
+        index = self.drawcolors.index('lightblue')
+        wdrawcolor.setCurrentIndex(index)
+        wdrawcolor.activated.connect(self.set_drawparams)
+        self.wdrawcolor = wdrawcolor
+
+        wfill = QtGui.QCheckBox("Fill")
+        wfill.stateChanged.connect(self.set_drawparams)
+        self.wfill = wfill
+
+        walpha = QtGui.QDoubleSpinBox()
+        walpha.setRange(0.0, 1.0)
+        walpha.setSingleStep(0.1)
+        walpha.setValue(1.0)
+        walpha.valueChanged.connect(self.set_drawparams)
+        self.walpha = walpha
+
+        wclear = QtGui.QPushButton("Clear Canvas")
+        wclear.clicked.connect(self.clear_canvas)
         wopen = QtGui.QPushButton("Open File")
         wopen.clicked.connect(self.open_file)
         wquit = QtGui.QPushButton("Quit")
         wquit.clicked.connect(self.quit)
 
         hbox.addStretch(1)
-        for w in (wopen, wquit):
+        for w in (wopen, wdrawtype, wdrawcolor, wfill,
+                  QtGui.QLabel('Alpha:'), walpha, wclear, wquit):
             hbox.addWidget(w, stretch=0)
 
+        hw = QtGui.QWidget()
+        hw.setLayout(hbox)
+        vbox.addWidget(hw, stretch=0)
+
+        mode = self.canvas.get_draw_mode()
+        hbox = QtGui.QHBoxLayout()
+        hbox.setContentsMargins(QtCore.QMargins(4, 2, 4, 2))
+
+        btn1 = QtGui.QRadioButton("Draw")
+        btn1.setChecked(mode == 'draw')
+        btn1.toggled.connect(lambda val: self.set_mode_cb('draw', val))
+        btn1.setToolTip("Choose this to draw on the canvas")
+        hbox.addWidget(btn1)
+
+        btn2 = QtGui.QRadioButton("Edit")
+        btn2.setChecked(mode == 'edit')
+        btn2.toggled.connect(lambda val: self.set_mode_cb('edit', val))
+        btn2.setToolTip("Choose this to edit things on the canvas")
+        hbox.addWidget(btn2)
+
+        btn3 = QtGui.QRadioButton("Pick")
+        btn3.setChecked(mode == 'pick')
+        btn3.toggled.connect(lambda val: self.set_mode_cb('pick', val))
+        btn3.setToolTip("Choose this to pick things on the canvas")
+        hbox.addWidget(btn3)
+
+        hbox.addWidget(QtGui.QLabel(''), stretch=1)
         hw = QtGui.QWidget()
         hw.setLayout(hbox)
         vbox.addWidget(hw, stretch=0)
@@ -62,10 +161,31 @@ class FitsViewer(QtGui.QMainWindow):
         self.setCentralWidget(vw)
         vw.setLayout(vbox)
 
+    def set_drawparams(self, kind):
+        index = self.wdrawtype.currentIndex()
+        kind = self.drawtypes[index]
+        index = self.wdrawcolor.currentIndex()
+        fill = (self.wfill.checkState() != 0)
+        alpha = self.walpha.value()
+
+        params = {'color': self.drawcolors[index],
+                  'alpha': alpha,
+                  }
+        if kind in ('circle', 'rectangle', 'polygon', 'triangle',
+                    'righttriangle', 'ellipse', 'square', 'box'):
+            params['fill'] = fill
+            params['fillalpha'] = alpha
+
+        self.canvas.set_drawtype(kind, **params)
+
+    def clear_canvas(self):
+        self.canvas.delete_all_objects()
+
     def load_file(self, filepath):
         image = AstroImage.AstroImage(logger=self.logger)
         with asdf.open(filepath) as asdf_f:
             image.load_asdf(asdf_f)
+
         self.fitsimage.set_image(image)
         self.setWindowTitle(filepath)
 
@@ -79,9 +199,71 @@ class FitsViewer(QtGui.QMainWindow):
         if len(fileName) != 0:
             self.load_file(fileName)
 
-    def drop_file(self, fitsimage, paths):
+    def drop_file_cb(self, fitsimage, paths):
         fileName = paths[0]
         self.load_file(fileName)
+
+    def cursor_cb(self, viewer, button, data_x, data_y):
+        """This gets called when the data position relative to the cursor
+        changes.
+        """
+        # Get the value under the data coordinates
+        try:
+            # We report the value across the pixel, even though the coords
+            # change halfway across the pixel
+            value = viewer.get_data(int(data_x + viewer.data_off),
+                                    int(data_y + viewer.data_off))
+
+        except Exception:
+            value = None
+
+        fits_x, fits_y = data_x + 1, data_y + 1
+
+        # Calculate WCS RA
+        try:
+            # NOTE: image function operates on DATA space coords
+            image = viewer.get_image()
+            if image is None:
+                # No image loaded
+                return
+            ra_txt, dec_txt = image.pixtoradec(fits_x, fits_y,
+                                               format='str', coords='fits')
+        except Exception as e:
+            self.logger.warning("Bad coordinate conversion: %s" % (
+                str(e)))
+            ra_txt = 'BAD WCS'
+            dec_txt = 'BAD WCS'
+
+        text = "RA: %s  DEC: %s  X: %.2f  Y: %.2f  Value: %s" % (
+            ra_txt, dec_txt, fits_x, fits_y, value)
+        self.readout.setText(text)
+
+    def set_mode_cb(self, mode, tf):
+        self.logger.info("canvas mode changed (%s) %s" % (mode, tf))
+        if not (tf is False):
+            self.canvas.set_draw_mode(mode)
+        return True
+
+    def draw_cb(self, canvas, tag):
+        obj = canvas.get_object_by_tag(tag)
+        obj.add_callback('pick-down', self.pick_cb, 'down')
+        obj.add_callback('pick-up', self.pick_cb, 'up')
+        obj.add_callback('pick-move', self.pick_cb, 'move')
+        obj.add_callback('pick-hover', self.pick_cb, 'hover')
+        obj.add_callback('pick-enter', self.pick_cb, 'enter')
+        obj.add_callback('pick-leave', self.pick_cb, 'leave')
+        obj.add_callback('pick-key', self.pick_cb, 'key')
+        obj.pickable = True
+        obj.add_callback('edited', self.edit_cb)
+
+    def pick_cb(self, obj, canvas, event, pt, ptype):
+        self.logger.info("pick event '%s' with obj %s at (%.2f, %.2f)" % (
+            ptype, obj.kind, pt[0], pt[1]))
+        return True
+
+    def edit_cb(self, obj):
+        self.logger.info("object %s has been edited" % (obj.kind))
+        return True
 
     def quit(self, *args):
         self.logger.info("Attempting to shut down the application...")
@@ -90,12 +272,26 @@ class FitsViewer(QtGui.QMainWindow):
 
 def main(options, args):
 
-    app = QtGui.QApplication(sys.argv)
+    #QtGui.QApplication.setGraphicsSystem('raster')
+    app = QtGui.QApplication(args)
 
-    # ginga needs a logger.
-    # If you don't want to log anything you can create a null logger by
-    # using null=True in this call instead of log_stderr=True
-    logger = log.get_logger("example1", log_stderr=True, level=40)
+    logger = log.get_logger("example2", options=options)
+
+    # Check whether user wants to use OpenCv
+    if options.opencv:
+        from ginga import trcalc
+        try:
+            trcalc.use('opencv')
+        except Exception as e:
+            logger.warning("failed to set OpenCv preference: %s" % (str(e)))
+
+    # Check whether user wants to use OpenCL
+    elif options.opencl:
+        from ginga import trcalc
+        try:
+            trcalc.use('opencl')
+        except Exception as e:
+            logger.warning("failed to set OpenCL preference: %s" % (str(e)))
 
     w = FitsViewer(logger)
     w.resize(524, 540)
@@ -110,7 +306,44 @@ def main(options, args):
     app.exec_()
 
 
-if __name__ == '__main__':
-    main(None, sys.argv[1:])
+if __name__ == "__main__":
+
+    # Parse command line options with nifty optparse module
+    from optparse import OptionParser
+
+    usage = "usage: %prog [options] cmd [args]"
+    optprs = OptionParser(usage=usage, version=('%%prog'))
+
+    optprs.add_option("--debug", dest="debug", default=False,
+                      action="store_true",
+                      help="Enter the pdb debugger on main()")
+    optprs.add_option("--opencv", dest="opencv", default=False,
+                      action="store_true",
+                      help="Use OpenCv acceleration")
+    optprs.add_option("--opencl", dest="opencl", default=False,
+                      action="store_true",
+                      help="Use OpenCL acceleration")
+    optprs.add_option("--profile", dest="profile", action="store_true",
+                      default=False,
+                      help="Run the profiler on main()")
+    log.addlogopts(optprs)
+
+    (options, args) = optprs.parse_args(sys.argv[1:])
+
+    # Are we debugging this?
+    if options.debug:
+        import pdb
+
+        pdb.run('main(options, args)')
+
+    # Are we profiling this?
+    elif options.profile:
+        import profile
+
+        print(("%s profile:" % sys.argv[0]))
+        profile.run('main(options, args)')
+
+    else:
+        main(options, args)
 
 # END

--- a/ginga/examples/qt/example_asdf.py
+++ b/ginga/examples/qt/example_asdf.py
@@ -190,8 +190,9 @@ class FitsViewer(QtGui.QMainWindow):
         self.setWindowTitle(filepath)
 
     def open_file(self):
-        res = QtGui.QFileDialog.getOpenFileName(self, "Open FITS file",
-                                                ".", "FITS files (*.fits)")
+        res = QtGui.QFileDialog.getOpenFileName(
+            self, "Open FITS or ASDF file",
+            ".", "FITS/ASDF files (*.fits *.asdf)")
         if isinstance(res, tuple):
             fileName = res[0]
         else:

--- a/ginga/examples/qt/example_asdf.py
+++ b/ginga/examples/qt/example_asdf.py
@@ -1,0 +1,116 @@
+#! /usr/bin/env python
+#
+# example_asdf.py -- Simple ASDF viewer using the Ginga toolkit and Qt widgets.
+#
+import sys
+
+from ginga import AstroImage
+from ginga.misc import log
+from ginga.qtw.QtHelp import QtGui, QtCore
+from ginga.qtw.ImageViewQt import CanvasView, ScrolledView
+
+import asdf
+
+class FitsViewer(QtGui.QMainWindow):
+
+    def __init__(self, logger):
+        super(FitsViewer, self).__init__()
+        self.logger = logger
+
+        # create the ginga viewer and configure it
+        fi = CanvasView(self.logger, render='widget')
+        fi.enable_autocuts('on')
+        fi.set_autocut_params('zscale')
+        fi.enable_autozoom('on')
+        fi.set_callback('drag-drop', self.drop_file)
+        fi.set_bg(0.2, 0.2, 0.2)
+        fi.ui_set_active(True)
+        self.fitsimage = fi
+
+        # enable some user interaction
+        bd = fi.get_bindings()
+        bd.enable_all(True)
+
+        w = fi.get_widget()
+        w.resize(512, 512)
+
+        # add scrollbar interface around this viewer
+        si = ScrolledView(fi)
+
+        vbox = QtGui.QVBoxLayout()
+        vbox.setContentsMargins(QtCore.QMargins(2, 2, 2, 2))
+        vbox.setSpacing(1)
+        vbox.addWidget(si, stretch=1)
+
+        hbox = QtGui.QHBoxLayout()
+        hbox.setContentsMargins(QtCore.QMargins(4, 2, 4, 2))
+
+        wopen = QtGui.QPushButton("Open File")
+        wopen.clicked.connect(self.open_file)
+        wquit = QtGui.QPushButton("Quit")
+        wquit.clicked.connect(self.quit)
+
+        hbox.addStretch(1)
+        for w in (wopen, wquit):
+            hbox.addWidget(w, stretch=0)
+
+        hw = QtGui.QWidget()
+        hw.setLayout(hbox)
+        vbox.addWidget(hw, stretch=0)
+
+        vw = QtGui.QWidget()
+        self.setCentralWidget(vw)
+        vw.setLayout(vbox)
+
+    def load_file(self, filepath):
+        image = AstroImage.AstroImage(logger=self.logger)
+        with asdf.open(filepath) as asdf_f:
+            image.load_asdf(asdf_f)
+        self.fitsimage.set_image(image)
+        self.setWindowTitle(filepath)
+
+    def open_file(self):
+        res = QtGui.QFileDialog.getOpenFileName(self, "Open FITS file",
+                                                ".", "FITS files (*.fits)")
+        if isinstance(res, tuple):
+            fileName = res[0]
+        else:
+            fileName = str(res)
+        if len(fileName) != 0:
+            self.load_file(fileName)
+
+    def drop_file(self, fitsimage, paths):
+        fileName = paths[0]
+        self.load_file(fileName)
+
+    def quit(self, *args):
+        self.logger.info("Attempting to shut down the application...")
+        self.deleteLater()
+
+
+def main(options, args):
+
+    app = QtGui.QApplication(sys.argv)
+
+    # ginga needs a logger.
+    # If you don't want to log anything you can create a null logger by
+    # using null=True in this call instead of log_stderr=True
+    logger = log.get_logger("example1", log_stderr=True, level=40)
+
+    w = FitsViewer(logger)
+    w.resize(524, 540)
+    w.show()
+    app.setActiveWindow(w)
+    w.raise_()
+    w.activateWindow()
+
+    if len(args) > 0:
+        w.load_file(args[0])
+
+    app.exec_()
+
+
+if __name__ == '__main__':
+    main(None, sys.argv[1:])
+
+# END

--- a/ginga/rv/Control.py
+++ b/ginga/rv/Control.py
@@ -564,7 +564,6 @@ class GingaShell(GwMain.GwMain, Widgets.Application):
         A wrapper around ginga.util.loader.load_data()
 
         This actually can load other data types, like
-
         """
         inherit_prihdr = self.settings.get('inherit_primary_header',
                                            False)

--- a/ginga/util/io_asdf.py
+++ b/ginga/util/io_asdf.py
@@ -1,0 +1,84 @@
+# This is open-source software licensed under a BSD license.
+# Please see the file LICENSE.txt for details.
+"""
+Module wrapper for loading ASDF files.
+
+.. note:: The API for this module is currently unstable
+          and may change in a future release.
+
+"""
+import numpy as np
+
+try:
+    import asdf  # noqa
+    have_asdf = True
+except ImportError:
+    have_asdf = False
+
+__all__ = ['have_asdf', 'load_asdf']
+
+
+def load_asdf(asdf_obj, data_key='sci', wcs_key='wcs', header_key='meta'):
+    """
+    Load from an ASDF object.
+
+    Parameters
+    ----------
+    asdf_obj : obj
+        ASDF or ASDF-in-FITS object.
+
+    data_key, wcs_key, header_key : str
+        Key values to specify where to find data, WCS, and header
+        in ASDF.
+
+    Returns
+    -------
+    data : ndarray or `None`
+        Image data, if found.
+
+    wcs : obj or `None`
+        GWCS object or models, if found.
+
+    ahdr : dict
+        Header containing metadata.
+
+    """
+    asdf_keys = asdf_obj.keys()
+
+    if wcs_key in asdf_keys:
+        wcs = asdf_obj[wcs_key]
+    else:
+        wcs = None
+
+    if header_key in asdf_keys:
+        ahdr = asdf_obj[header_key]
+    else:
+        ahdr = {}
+
+    # TODO: What about non-image ASDF data, such as table?
+    if data_key in asdf_keys:
+        data = np.asarray(asdf_obj[data_key])
+    else:
+        data = None
+
+    return data, wcs, ahdr
+
+
+def loader(filepath, logger=None, **kwargs):
+    """
+    Load an object from an ASDF file.
+    See :func:`ginga.util.loader` for more info.
+
+    TODO: kwargs may contain info about what part of the file to load
+    """
+    # see ginga.util.loader module
+    # TODO: return an AstroTable if loading a table, etc.
+    #   for now, assume always an image
+    from ginga import AstroImage
+    image = AstroImage.AstroImage(logger=logger)
+
+    with asdf.open(filepath) as asdf_f:
+        #image.load_asdf(asdf_f, **kwargs)
+        image.load_asdf(asdf_f)
+
+    return image

--- a/ginga/util/io_fits.py
+++ b/ginga/util/io_fits.py
@@ -140,6 +140,19 @@ class PyFitsFileHandler(BaseFitsFileHandler):
                               pyfits.BinTableHDU)):
             # <-- data is a table
 
+            # Handle ASDF embedded in FITS.
+            # TODO: Populate EXTNAME, EXTVER, NAXISn in ASDF meta from HDU?
+            # TODO: How to read from all the different ASDF layouts?
+            # TODO: Cache the ASDF object?
+            from ginga.util import io_asdf
+            if io_asdf.have_asdf and hdu.name == 'ASDF':
+                from asdf.fits_embed import AsdfInFits
+                from ginga import AstroImage
+                dstobj = AstroImage.AstroImage()
+                with AsdfInFits.open(self.fits_f) as asdf_f:
+                    dstobj.load_asdf(asdf_f)
+                return dstobj
+
             if dstobj is None:
                 # get model class for this type of object
                 obj_class = self.factory_dict.get('table', None)
@@ -219,12 +232,7 @@ class PyFitsFileHandler(BaseFitsFileHandler):
             # lookups by numerical index or (NAME, EXTVER)
             d = Bunch.Bunch(index=idx, name=name, extver=extver)
             if len(tup) > 5:
-                import astropy
-                from astropy.utils.introspection import minversion
-                if minversion(astropy, '2.0'):
-                    d.setvals(htype=tup[3], dtype=tup[6])
-                else:
-                    d.setvals(htype=tup[2], dtype=tup[5])
+                d.setvals(htype=tup[3], dtype=tup[6])
             self.hdu_info.append(d)
             # different ways of accessing this HDU:
             # by numerical index

--- a/ginga/util/io_fits.py
+++ b/ginga/util/io_fits.py
@@ -148,12 +148,15 @@ class PyFitsFileHandler(BaseFitsFileHandler):
             if io_asdf.have_asdf and hdu.name == 'ASDF':
                 from asdf.fits_embed import AsdfInFits
                 from ginga import AstroImage
+                self.logger.debug('Attempting to load {} extension from '
+                                  'FITS'.format(hdu.name))
                 dstobj = AstroImage.AstroImage()
                 with AsdfInFits.open(self.fits_f) as asdf_f:
                     dstobj.load_asdf(asdf_f)
                 return dstobj
 
             if dstobj is None:
+                self.logger.debug('Attempting to load table from FITS')
                 # get model class for this type of object
                 obj_class = self.factory_dict.get('table', None)
                 if obj_class is None:

--- a/ginga/util/iohelper.py
+++ b/ginga/util/iohelper.py
@@ -46,6 +46,14 @@ def guess_filetype(filepath):
         except Exception as e:
             pass
 
+    # Some specific checks for file suffixes
+    _fn = filepath.lower()
+    if _fn.endswith('.fits'):
+        typ = 'image/fits'
+
+    elif _fn.endswith('.asdf'):
+        typ = 'image/asdf'
+
     if typ is None:
         # if no magic, or magic fails, fall back to mimetypes
         try:

--- a/ginga/util/loader.py
+++ b/ginga/util/loader.py
@@ -68,6 +68,8 @@ def load_data(filespec, idx=None, logger=None, **kwargs):
     return data_obj
 
 
+# NOTE: for loader functions, kwargs can include 'idx', 'logger' and
+#    loader-specific parameters like
 def load_rgb(filepath, logger=None, **kwargs):
     loader = io_rgb.get_rgbloader(logger=logger)
     image = loader.load_file(filepath, **kwargs)
@@ -79,6 +81,12 @@ def load_fits(filepath, logger=None, **kwargs):
     numhdu = kwargs.pop('idx', None)
     image = loader.load_file(filepath, numhdu=numhdu, **kwargs)
     return image
+
+
+def load_asdf(filepath, logger=None, **kwargs):
+    from ginga.util import io_asdf
+    data_obj = io_asdf.loader(filepath, logger, **kwargs)
+    return data_obj
 
 
 # This contains a registry of upper-level loaders with their secondary
@@ -105,6 +113,9 @@ lc.register_type('table', AstroTable)
 
 for mimetype in ['image/fits', 'image/x-fits']:
     add_loader(mimetype, load_fits)
+
+for mimetype in ['image/asdf']:
+    add_loader(mimetype, load_asdf)
 
 # ### RGB ###
 for mimetype in ['image/jpeg', 'image/png', 'image/tiff', 'image/gif']:

--- a/ginga/util/wcsmod/__init__.py
+++ b/ginga/util/wcsmod/__init__.py
@@ -54,7 +54,7 @@ display_types = ['sexagesimal', 'degrees']
 
 # try to load them in this order until we find one that works.
 # If none can be loaded, we default to the BareBones dummy WCS
-wcs_try_order = ('astropy', 'kapteyn', 'starlink', 'astlib',
+wcs_try_order = ('astropy', 'astropy_ape14', 'kapteyn', 'starlink', 'astlib',
                  'barebones')
 
 wcs_home = os.path.split(sys.modules[__name__].__file__)[0]

--- a/ginga/util/wcsmod/wcs_astropy.py
+++ b/ginga/util/wcsmod/wcs_astropy.py
@@ -219,10 +219,13 @@ class AstropyWCS(common.BaseWCS):
             return (x, y)
 
         c = self.pixtocoords(idxs, system=system, coords=coords)
-
-        r = c.data
-        return tuple(map(self._deg, [getattr(r, component)
-                                     for component in r.components[:2]]))
+        if not self.new_coords:
+            # older astropy
+            return (self._deg(c.lonangle), self._deg(c.latangle))
+        else:
+            r = c.data
+            return tuple(map(self._deg, [getattr(r, component)
+                                         for component in r.components[:2]]))
 
     def datapt_to_wcspt(self, datapt, coords='data', naxispath=None):
 

--- a/ginga/util/wcsmod/wcs_astropy.py
+++ b/ginga/util/wcsmod/wcs_astropy.py
@@ -10,15 +10,12 @@ from astropy import coordinates, units
 
 from ginga.util.wcsmod import common
 
-if hasattr(coordinates, 'SkyCoord'):
-    try:
-        import sunpy.coordinates  # noqa
-    except ImportError:
-        pass
-    coord_types = [f.name for f in
-                   coordinates.frame_transform_graph.frame_set]
-else:
-    coord_types = ['icrs', 'fk5', 'fk4', 'galactic']
+try:
+    import sunpy.coordinates  # noqa
+except ImportError:
+    pass
+coord_types = [f.name for f in
+               coordinates.frame_transform_graph.frame_set]
 
 
 class AstropyWCS(common.BaseWCS):
@@ -31,30 +28,6 @@ class AstropyWCS(common.BaseWCS):
     """
     def __init__(self, logger):
         super(AstropyWCS, self).__init__(logger)
-
-        self.new_coords = False            # new astropy coordinate system
-
-        if hasattr(coordinates, 'SkyCoord'):
-            # v0.4 series astropy and later
-            self.new_coords = True
-
-        elif hasattr(coordinates, 'ICRS'):
-            # v0.3 series astropy
-            self.coord_table = {
-                'icrs': coordinates.ICRS,
-                'fk5': coordinates.FK5,
-                'fk4': coordinates.FK4,
-                'galactic': coordinates.Galactic,
-            }
-
-        else:
-            # v0.2 series astropy
-            self.coord_table = {
-                'icrs': coordinates.ICRSCoordinates,
-                'fk5': coordinates.FK5Coordinates,
-                'fk4': coordinates.FK4Coordinates,
-                'galactic': coordinates.GalacticCoordinates,
-            }
         self.kind = 'astropy/WCSLIB'
 
     def load_header(self, header, fobj=None):
@@ -83,7 +56,7 @@ class AstropyWCS(common.BaseWCS):
             self.header = pyfits.Header(ndd.meta)
 
             if ndd.wcs is None:
-                self.logger.debug("Trying to make astropy-- wcs object")
+                self.logger.debug("Trying to make astropy FITS WCS object")
                 self.wcs = pywcs.WCS(self.header, relax=True)
                 self.logger.debug("made astropy wcs object")
             else:
@@ -170,62 +143,24 @@ class AstropyWCS(common.BaseWCS):
         ra_deg, dec_deg = self.pixtoradec(idxs, coords=coords)
         self.logger.debug("ra, dec = %f, %f" % (ra_deg, dec_deg))
 
-        if not self.new_coords:
-            # convert to astropy coord
-            try:
-                fromclass = self.coord_table[self.coordsys]
-            except KeyError:
-                raise common.WCSError("No such coordinate system available: '%s'" % (
-                    self.coordsys))
-
-            coord = fromclass(ra_deg, dec_deg,
-                              unit=(units.degree, units.degree))
-
-            if (system is None) or (system == self.coordsys):
-                return coord
-
-            # Now give it back to the user in the system requested
-            try:
-                toclass = self.coord_table[system]
-            except KeyError:
-                raise common.WCSError("No such coordinate system available: '%s'" % (
-                    system))
-
-            coord = coord.transform_to(toclass)
-
-        else:
-            frameClass = coordinates.frame_transform_graph.lookup_name(
-                self.coordsys)
-            coord = frameClass(ra_deg * units.degree, dec_deg * units.degree)
-            toClass = coordinates.frame_transform_graph.lookup_name(system)
-            # Skip in input and output is the same (no realize_frame
-            # call in astropy)
-            if toClass != frameClass:
-                coord = coord.transform_to(toClass)
+        frame_class = coordinates.frame_transform_graph.lookup_name(
+            self.coordsys)
+        coord = frame_class(ra_deg * units.degree, dec_deg * units.degree)
+        to_class = coordinates.frame_transform_graph.lookup_name(system)
+        # Skip in input and output is the same (no realize_frame
+        # call in astropy)
+        if to_class != frame_class:
+            coord = coord.transform_to(to_class)
 
         return coord
 
-    def _deg(self, coord):
-        # AstroPy changed the API so now we have to support more
-        # than one--we don't know what version the user has installed!
-        if hasattr(coord, 'degrees'):
-            return coord.degrees
-        else:
-            return coord.degree
-
     def pixtosystem(self, idxs, system=None, coords='data'):
         if self.coordsys == 'pixel':
-            x, y = self.pixtoradec(idxs, coords=coords)
-            return (x, y)
+            return self.pixtoradec(idxs, coords=coords)
 
         c = self.pixtocoords(idxs, system=system, coords=coords)
-        if not self.new_coords:
-            # older astropy
-            return (self._deg(c.lonangle), self._deg(c.latangle))
-        else:
-            r = c.data
-            return tuple(map(self._deg, [getattr(r, component)
-                                         for component in r.components[:2]]))
+        r = c.data.represent_as(coordinates.UnitSphericalRepresentation)
+        return r.lon.deg, r.lat.deg
 
     def datapt_to_wcspt(self, datapt, coords='data', naxispath=None):
 
@@ -299,20 +234,16 @@ class AstropyWCS(common.BaseWCS):
         wcspt = self.datapt_to_wcspt(datapt, coords=coords,
                                      naxispath=naxispath)
 
-        if not self.new_coords:
-            raise NotImplementedError
-
-        else:
-            frameClass = coordinates.frame_transform_graph.lookup_name(
-                self.coordsys)
-            ra_deg = wcspt[:, 0]
-            dec_deg = wcspt[:, 1]
-            coord = frameClass(ra_deg * units.degree, dec_deg * units.degree)
-            toClass = coordinates.frame_transform_graph.lookup_name(system)
-            # Skip if input and output is the same (no realize_frame
-            # call in astropy)
-            if toClass != frameClass:
-                coord = coord.transform_to(toClass)
+        frame_class = coordinates.frame_transform_graph.lookup_name(
+            self.coordsys)
+        ra_deg = wcspt[:, 0]
+        dec_deg = wcspt[:, 1]
+        coord = frame_class(ra_deg * units.degree, dec_deg * units.degree)
+        to_class = coordinates.frame_transform_graph.lookup_name(system)
+        # Skip if input and output is the same (no realize_frame
+        # call in astropy)
+        if to_class != frame_class:
+            coord = coord.transform_to(to_class)
 
         return coord
 

--- a/ginga/util/wcsmod/wcs_astropy.py
+++ b/ginga/util/wcsmod/wcs_astropy.py
@@ -219,13 +219,10 @@ class AstropyWCS(common.BaseWCS):
             return (x, y)
 
         c = self.pixtocoords(idxs, system=system, coords=coords)
-        if not self.new_coords:
-            # older astropy
-            return (self._deg(c.lonangle), self._deg(c.latangle))
-        else:
-            r = c.data
-            return tuple(map(self._deg, [getattr(r, component)
-                                         for component in r.components[:2]]))
+
+        r = c.data
+        return tuple(map(self._deg, [getattr(r, component)
+                                     for component in r.components[:2]]))
 
     def datapt_to_wcspt(self, datapt, coords='data', naxispath=None):
 

--- a/ginga/util/wcsmod/wcs_astropy_ape14.py
+++ b/ginga/util/wcsmod/wcs_astropy_ape14.py
@@ -118,10 +118,9 @@ class AstropyWCS(common.BaseWCS):
         args = [ra_deg, dec_deg]
         if naxispath:
             args += [0] * len(naxispath)
-        skycrd = np.array([args], np.float_)
 
         try:
-            xy = np.squeeze(self.wcs.world_to_pixel_values(skycrd))[:2]
+            xy = self.wcs.world_to_pixel_values(*args)[:2]
         except Exception as e:
             self.logger.error(
                 "Error calculating radectopix: {}".format(str(e)))

--- a/ginga/util/wcsmod/wcs_astropy_ape14.py
+++ b/ginga/util/wcsmod/wcs_astropy_ape14.py
@@ -1,0 +1,115 @@
+#
+# This is open-source software licensed under a BSD license.
+# Please see the file LICENSE.txt for details.
+#
+import numpy as np
+from astropy import coordinates
+
+from ginga.util.wcsmod import common
+
+if hasattr(coordinates, 'SkyCoord'):
+    try:
+        import sunpy.coordinates  # noqa
+    except ImportError:
+        pass
+    coord_types = [f.name for f in
+                   coordinates.frame_transform_graph.frame_set]
+else:
+    coord_types = ['icrs', 'fk5', 'fk4', 'galactic']
+
+
+class AstropyWCS(common.BaseWCS):
+    """
+    A WCS interface for astropy.wcs as defined by Astropy APE 14.
+    You need to install python module 'astropy'
+    (http://pypi.python.org/pypi/astropy) v3.1 or later
+    if you want to use this version.
+
+    """
+    def __init__(self, logger):
+        super(AstropyWCS, self).__init__(logger)
+        self.kind = 'astropy/APE14'
+
+        # NOTE: self.wcs magically set in loader right now.
+        # TODO: Implement load_header
+
+    # TODO: Use coords?
+    def pixtoradec(self, idxs, coords='data'):
+        coord = self.wcs.pixel_to_world(*idxs)
+        return coord.ra.deg, coord.dec.deg
+
+    def radectopix(self, ra_deg, dec_deg, coords='data', naxispath=None):
+        coord = coordinates.SkyCoord(ra_deg, dec_deg, unit='deg')
+        return self.wcs.world_to_pixel(coord)
+
+    def pixtocoords(self, idxs, system=None, coords='data'):
+        if self.coordsys == 'raw':
+            raise common.WCSError("No usable WCS")
+
+        if system is None:
+            system = 'icrs'
+
+        # Get a coordinates object based on ra/dec wcs transform
+        ra_deg, dec_deg = self.pixtoradec(idxs, coords=coords)
+        self.logger.debug("ra, dec = {}, {}".format(ra_deg, dec_deg))
+
+        frame_class = coordinates.frame_transform_graph.lookup_name(
+            self.coordsys)
+        coord = frame_class(ra_deg, dec_deg, unit='deg')
+        to_class = coordinates.frame_transform_graph.lookup_name(system)
+        # Skip in input and output is the same (no realize_frame
+        # call in astropy)
+        if to_class != frame_class:
+            coord = coord.transform_to(to_class)
+
+        return coord
+
+    # TODO: Remove this
+    def _deg(self, coord):
+        # AstroPy changed the API so now we have to support more
+        # than one--we don't know what version the user has installed!
+        if hasattr(coord, 'degrees'):
+            return coord.degrees
+        else:
+            return coord.degree
+
+    def pixtosystem(self, idxs, system=None, coords='data'):
+        if self.coordsys == 'pixel':
+            return self.pixtoradec(idxs, coords=coords)
+
+        c = self.pixtocoords(idxs, system=system, coords=coords)
+        r = c.data
+        return tuple(map(self._deg, [getattr(r, component)
+                                     for component in r.components[:2]]))
+
+    def datapt_to_wcspt(self, datapt, coords='data', naxispath=None):
+        if naxispath is not None:
+            n = len(naxispath)
+            if n > 0:
+                datapt = np.hstack((datapt, np.zeros((len(datapt), n))))
+        try:
+            wcspt = self.wcs.pixel_to_world(datapt)
+        except Exception as e:
+            self.logger.error(
+                "Error calculating datapt_to_wcspt: {}".format(str(e)))
+            raise common.WCSError(e)
+
+        return wcspt
+
+    def wcspt_to_datapt(self, wcspt, coords='data', naxispath=None):
+        if naxispath is not None:
+            n = len(naxispath)
+            if n > 0:
+                wcspt = np.hstack((wcspt, np.zeros((len(wcspt), n))))
+        try:
+            datapt = self.wcs.world_to_pixel(wcspt)
+        except Exception as e:
+            self.logger.error(
+                "Error calculating wcspt_to_datapt: %s" % (str(e)))
+            raise common.WCSError(e)
+
+        return datapt[:, :2]
+
+
+# register our WCS with ginga
+common.register_wcs('astropy_ape14', AstropyWCS, coord_types)

--- a/ginga/util/wcsmod/wcs_astropy_ape14.py
+++ b/ginga/util/wcsmod/wcs_astropy_ape14.py
@@ -103,14 +103,20 @@ class AstropyWCS(common.BaseWCS):
         # NOTE: origin is always 0, coords unused.
         try:
             c = self.wcs.pixel_to_world(*idxs)
-            if isinstance(c, list):  # naxis > 2
+            if (isinstance(c, list) and
+                    isinstance(c[0], coordinates.SkyCoord)):  # naxis > 2
                 c = c[0]
         except Exception as e:
             self.logger.error(
                 "Error calculating pixtoradec: {}".format(str(e)))
             raise common.WCSError(e)
 
-        return c.ra.deg, c.dec.deg
+        if isinstance(c, coordinates.SkyCoord):
+            radec = (c.ra.deg, c.dec.deg)
+        else:  # list of Quantity (e.g., from primary header)
+            radec = (c[0].value, c[1].value)
+
+        return radec
 
     def radectopix(self, ra_deg, dec_deg, coords='data', naxispath=None):
         # NOTE: origin is always 0, coords unused.


### PR DESCRIPTION
This might still need unreleased ASDF and GWCS. It definitely requires Astropy 3.1 or later. But it does work, I propose that we merge this at its current state and improve it in future PRs, as needed. (Limited support is better than zero support?)

Fix #327

cc @hcferguson , @nden , and @drdavella

**TODO:**

- [x] Test with some files: FITS with FITS WCS, ADSF with GWCS, ASDF-in-FITS with GWCS
- [x] Write tests.

**Open Questions:**

* `AstroImage.load_asdf()` -- How to let user specify where data and WCS are in ASDF?
* No way to load JWST data in a meaningful way without JWST data models hidden within JWST pipeline.

**Known issues (future PRs):**

* ~~`Compass` does not work.~~ 
* `WCSAxes` does not work. But this could be an issue with the test image rather than the plugin; need a better dataset to be sure.
* ~~Data cube not fully supported. `LineProfile` does not fully work.~~
* Very limited testing done.
* Documentation deferred to future PR when this is more stable.