### PR TITLE
Update astropy-helpers to v3.1

### DIFF
--- a/ah_bootstrap.py
+++ b/ah_bootstrap.py
@@ -116,6 +116,7 @@ except:
 # End compatibility imports...
 
 
+# In case it didn't successfully import before the ez_setup checks
 import pkg_resources
 
 from setuptools import Distribution


### PR DESCRIPTION
This is an automated update of the astropy-helpers submodule to v3.1. This includes both the update of the astropy-helpers sub-module, and the ``ah_bootstrap.py`` file, if needed. 

A full list of changes can be found in the [changelog](https://github.com/astropy/astropy-helpers/blob/v3.1/CHANGES.rst). 

*This is intended to be helpful, but if you would prefer to manage these updates yourself, or if you notice any issues with this automated update, please let @bsipocz or @astrofrog know!* 

Similarly to the core package, the v3.0+ releases of astropy-helpers require Python 3.5+. We will open automated update PRs with astropy-helpers v3.1.x only for packages that specifically opt in for it when they start supporting Python 3.5+ only. Please let @bsipocz or @astrofrog know or add your package to the list in https://github.com/astropy/astropy-procedures/blob/master/update-packages/helpers_3.py