### PR TITLE
BUG: Fix FBrowser drag-and-drop on Windows

### DIFF
--- a/doc/WhatsNew.rst
+++ b/doc/WhatsNew.rst
@@ -10,6 +10,7 @@ Ver 3.0.0 (unreleased)
 - Pick plugin enhanced with option to center on found object; also
   default shape changed to a box rather than a rectangle
 - Added support for ASDF and GWCS.
+- Fixed drag-and-drop functionality in FBrowser plugin on Windows.
 
 Ver 2.7.2 (2018-11-05)
 ======================

--- a/ginga/rv/plugins/FBrowser.py
+++ b/ginga/rv/plugins/FBrowser.py
@@ -31,6 +31,7 @@ directory if closed and then restarted.
 import glob
 import os
 import time
+from pathlib import Path
 
 from ginga.misc import Bunch
 from ginga import GingaPlugin
@@ -219,7 +220,7 @@ class FBrowser(GingaPlugin.LocalPlugin):
         self.open_file(path)
 
     def item_drag_cb(self, widget, drag_pkg, res_dict):
-        urls = ["file://" + info.path for key, info in res_dict.items()]
+        urls = [Path(info.path).as_uri() for key, info in res_dict.items()]
         self.logger.info("urls: %s" % (urls))
         drag_pkg.set_urls(urls)
 
@@ -282,8 +283,7 @@ class FBrowser(GingaPlugin.LocalPlugin):
 
         elif os.path.exists(path):
             #self.fv.load_file(path)
-            uri = "file://%s" % (path)
-            self.load_paths([uri])
+            self.load_paths([Path(path).as_uri()])
 
         else:
             self.browse(path)

--- a/ginga/tests/test_iohelper.py
+++ b/ginga/tests/test_iohelper.py
@@ -1,0 +1,39 @@
+# This is open-source software licensed under a BSD license.
+# Please see the file LICENSE.txt for details.
+
+import sys
+
+from ginga.util import iohelper
+
+IS_WINDOWS = sys.platform.startswith('win')
+
+
+def test_get_fileinfo_real_file():
+    """Test behavior on real file."""
+    bnch = iohelper.get_fileinfo(iohelper.__file__)
+    assert bnch['ondisk']
+    assert bnch['name'] == 'iohelper'
+    assert bnch['numhdu'] is None
+    # filepath and url are OS-dependent, hence the lax check here
+    assert bnch['url'].startswith('file://')
+
+
+def test_get_fileinfo_dummy_file():
+    """Test behavior on dummy file."""
+
+    # pathlib behaves differently depending on OS.
+    if IS_WINDOWS:
+        filename = r'C:\mypath\dummyfile.fits[1]'
+        filepath = 'C:\\mypath\\dummyfile.fits'
+        url = 'file:///C:/mypath/dummyfile.fits'
+    else:
+        filename = '/mypath/dummyfile.fits[1]'
+        filepath = '/mypath/dummyfile.fits'
+        url = 'file:///mypath/dummyfile.fits'
+
+    bnch = iohelper.get_fileinfo(filename)
+    assert not bnch['ondisk']
+    assert bnch['name'] == 'dummyfile[1]'
+    assert bnch['numhdu'] == 1
+    assert bnch['filepath'] == filepath
+    assert bnch['url'] == url

--- a/ginga/util/iohelper.py
+++ b/ginga/util/iohelper.py
@@ -8,6 +8,7 @@ import os
 import re
 import hashlib
 import mimetypes
+import pathlib
 import urllib.parse
 
 from ginga.misc import Bunch
@@ -125,7 +126,7 @@ def get_fileinfo(filespec, cache_dir='/tmp', download=False):
     else:
         # Not a URL
         filepath = filespec
-        url = "file://" + filepath
+        url = pathlib.Path(os.path.abspath(filepath)).as_uri()
 
     ondisk = os.path.exists(filepath)
 


### PR DESCRIPTION
Fix #727

This uses `pathlib`, which is new in Python 3.4. For Ginga 3.0, this is not a problem because its minimum supported Python is 3.5.