### PR TITLE
Fix wcspt_to_datapt bug for astropy_ape14

### DIFF
--- a/ginga/util/wcsmod/wcs_astropy_ape14.py
+++ b/ginga/util/wcsmod/wcs_astropy_ape14.py
@@ -191,7 +191,7 @@ class AstropyWCS(common.BaseWCS):
         try:
             args = [wcspt[:, i] for i in range(wcspt.shape[1])]
             # NOTE: Ignores system transformation.
-            datapt = np.asarray(self.wcs.world_to_pixel_values(*args))[:, :2].T
+            datapt = np.asarray(self.wcs.world_to_pixel_values(*args))[:2, :].T
         except Exception as e:
             self.logger.error(
                 "Error calculating wcspt_to_datapt: {}".format(str(e)))


### PR DESCRIPTION
Fix #729 . Turns out there was a bug in `wcspt_to_datapt` method in the `astropy_ape14` implementation from #719. 😅 

Also adds some logging to `WCSAxes` from the debugging process. No change log is needed as this is fixing something that is not released yet.