### PR TITLE
ENH: Load multiple files or multiple extensions from the same file

### DIFF
--- a/doc/WhatsNew.rst
+++ b/doc/WhatsNew.rst
@@ -12,6 +12,10 @@ Ver 3.0.0 (unreleased)
 - Added support for ASDF and GWCS.
 - Fixed drag-and-drop functionality in FBrowser plugin on Windows.
 - Enabled HDU sorting via config file in MultiDim.
+- Selecting item in FBrowser now populates its text box properly.
+- Support opening all extensions of given extension name from
+  a FITS file (e.g., ``filename.fits[SCI,*]``) from Ginga command
+  line or FBrowser.
 
 Ver 2.7.2 (2018-11-05)
 ======================

--- a/ginga/qtw/QtHelp.py
+++ b/ginga/qtw/QtHelp.py
@@ -184,8 +184,6 @@ class FileSelection(object):
             if '*' in filename or '[' in filename:
                 paths = []
                 res = iohelper.get_fileinfo(filename)
-                if not isinstance(res, list):
-                    res = [res]
                 for info in res:
                     ext = iohelper.get_hdu_suffix(info.numhdu)
                     files = glob.glob(info.filepath)  # Expand wildcard

--- a/ginga/qtw/QtHelp.py
+++ b/ginga/qtw/QtHelp.py
@@ -182,10 +182,14 @@ class FileSelection(object):
             # Special handling for wildcard or extension.
             # This is similar to open_files() in FBrowser plugin.
             if '*' in filename or '[' in filename:
-                info = iohelper.get_fileinfo(filename)
-                ext = iohelper.get_hdu_suffix(info.numhdu)
-                files = glob.glob(info.filepath)  # Expand wildcard
-                paths = ['{0}{1}'.format(f, ext) for f in files]
+                paths = []
+                res = iohelper.get_fileinfo(filename)
+                if not isinstance(res, list):
+                    res = [res]
+                for info in res:
+                    ext = iohelper.get_hdu_suffix(info.numhdu)
+                    files = glob.glob(info.filepath)  # Expand wildcard
+                    paths += ['{0}{1}'.format(f, ext) for f in files]
 
                 # NOTE: Using drag-drop callback here might give QPainter
                 # warnings.

--- a/ginga/rv/plugins/FBrowser.py
+++ b/ginga/rv/plugins/FBrowser.py
@@ -20,9 +20,10 @@ load it into any channel viewer.
 Multiple files can be selected by holding down ``Ctrl`` (``Command`` on Mac),
 or ``Shift``-clicking to select a contiguous range of files.
 
-You may also enter full path to the desired image(s) in the text box as
+You may also enter full path to the desired image(s) in the text box such as
 ``/my/path/to/image.fits``, ``/my/path/to/image.fits[ext]``,
-``/my/path/to/image*.fits``, or ``/my/path/to/image*.fits[ext]``.
+``/my/path/to/image*.fits``, ``/my/path/to/image*.fits[ext]``, or
+``/my/path/to/image.fits[extname,*]``.
 
 Because it is a local plugin, ``FBrowser`` will remember its last
 directory if closed and then restarted.

--- a/ginga/rv/plugins/FBrowser.py
+++ b/ginga/rv/plugins/FBrowser.py
@@ -262,10 +262,14 @@ class FBrowser(GingaPlugin.LocalPlugin):
             return False
 
         self.logger.debug('Opening files matched by {0}'.format(path))
-        info = iohelper.get_fileinfo(path)
-        ext = iohelper.get_hdu_suffix(info.numhdu)
-        files = glob.glob(info.filepath)  # Expand wildcard
-        paths = ['{0}{1}'.format(f, ext) for f in files]
+        res = iohelper.get_fileinfo(path)
+        if not isinstance(res, list):
+            res = [res]
+        paths = []
+        for info in res:
+            ext = iohelper.get_hdu_suffix(info.numhdu)
+            files = glob.glob(info.filepath)  # Expand wildcard
+            paths += ['{0}{1}'.format(f, ext) for f in files]
 
         self.load_paths(paths)
         return True

--- a/ginga/rv/plugins/FBrowser.py
+++ b/ginga/rv/plugins/FBrowser.py
@@ -232,9 +232,10 @@ class FBrowser(GingaPlugin.LocalPlugin):
 
     def item_selected_cb(self, widget, res_dict):
         paths = self.get_paths_from_item(res_dict)
-        if len(paths) <= 0:
+        n_paths = len(paths)
+        if n_paths <= 0:
             return
-        elif len(paths) == 1:
+        elif n_paths == 1:
             txt = paths[0]
         else:
             txt = ' '.join(['"{}"'.format(s) for s in paths])

--- a/ginga/rv/plugins/FBrowser.py
+++ b/ginga/rv/plugins/FBrowser.py
@@ -219,8 +219,11 @@ class FBrowser(GingaPlugin.LocalPlugin):
 
     def item_dblclicked_cb(self, widget, res_dict):
         paths = self.get_paths_from_item(res_dict)
-        if len(paths) > 0:
-            self.open_file(paths[0])
+        n_paths = len(paths)
+        if n_paths != 1:
+            self.logger.error('Double-click to open {} file(s) '
+                              'is not supported'.format(n_paths))
+        self.open_file(paths[0])
 
     def item_drag_cb(self, widget, drag_pkg, res_dict):
         urls = [Path(info.path).as_uri() for info in res_dict.values()]
@@ -283,8 +286,6 @@ class FBrowser(GingaPlugin.LocalPlugin):
 
             self.logger.debug('Opening files matched by {0}'.format(path))
             res = iohelper.get_fileinfo(path)
-            if not isinstance(res, list):
-                res = [res]
             for info in res:
                 ext = iohelper.get_hdu_suffix(info.numhdu)
                 files = glob.glob(info.filepath)  # Expand wildcard

--- a/ginga/rv/plugins/FBrowser.py
+++ b/ginga/rv/plugins/FBrowser.py
@@ -108,6 +108,7 @@ class FBrowser(GingaPlugin.LocalPlugin):
                                  dragable=True)
         table.add_callback('activated', self.item_dblclicked_cb)
         table.add_callback('drag-start', self.item_drag_cb)
+        table.add_callback('selected', self.item_selected_cb)
 
         # set header
         col = 0
@@ -211,18 +212,24 @@ class FBrowser(GingaPlugin.LocalPlugin):
             self.logger.debug("Resized columns for {0} row(s)".format(n_rows))
 
     def get_path_from_item(self, res_dict):
-        paths = [info.path for key, info in res_dict.items()]
-        path = paths[0]
-        return path
+        paths = [info.path for info in res_dict.values()]
+        if len(paths) == 0:
+            return
+        return paths[0]
 
     def item_dblclicked_cb(self, widget, res_dict):
         path = self.get_path_from_item(res_dict)
         self.open_file(path)
 
     def item_drag_cb(self, widget, drag_pkg, res_dict):
-        urls = [Path(info.path).as_uri() for key, info in res_dict.items()]
+        urls = [Path(info.path).as_uri() for info in res_dict.values()]
         self.logger.info("urls: %s" % (urls))
         drag_pkg.set_urls(urls)
+
+    def item_selected_cb(self, widget, res_dict):
+        path = self.get_path_from_item(res_dict)
+        if path is not None:
+            self.entry.set_text(path)
 
     def browse_cb(self, widget):
         path = str(widget.get_text()).strip()

--- a/ginga/tests/test_iohelper.py
+++ b/ginga/tests/test_iohelper.py
@@ -10,7 +10,7 @@ IS_WINDOWS = sys.platform.startswith('win')
 
 def test_get_fileinfo_real_file():
     """Test behavior on real file."""
-    bnch = iohelper.get_fileinfo(iohelper.__file__)
+    bnch = iohelper.get_fileinfo(iohelper.__file__)[0]
     assert bnch['ondisk']
     assert bnch['name'] == 'iohelper'
     assert bnch['numhdu'] is None
@@ -31,7 +31,7 @@ def test_get_fileinfo_dummy_file():
         filepath = '/mypath/dummyfile.fits'
         url = 'file:///mypath/dummyfile.fits'
 
-    bnch = iohelper.get_fileinfo(filename)
+    bnch = iohelper.get_fileinfo(filename)[0]
     assert not bnch['ondisk']
     assert bnch['name'] == 'dummyfile[1]'
     assert bnch['numhdu'] == 1

--- a/ginga/util/io_fits.py
+++ b/ginga/util/io_fits.py
@@ -188,9 +188,10 @@ class PyFitsFileHandler(BaseFitsFileHandler):
 
     def open_file(self, filespec, memmap=None, **kwargs):
 
-        info = iohelper.get_fileinfo(filespec)
-        if isinstance(info, list):
+        res = iohelper.get_fileinfo(filespec)
+        if len(res) != 1:
             raise NotImplementedError('Wildcard in extension not supported')
+        info = res[0]
         if not info.ondisk:
             raise FITSError("File does not appear to be on disk: %s" % (
                 info.url))
@@ -427,9 +428,10 @@ class FitsioFileHandler(BaseFitsFileHandler):
 
     def open_file(self, filespec, memmap=None, **kwargs):
 
-        info = iohelper.get_fileinfo(filespec)
-        if isinstance(info, list):
+        res = iohelper.get_fileinfo(filespec)
+        if len(res) != 1:
             raise NotImplementedError('Wildcard in extension not supported')
+        info = res[0]
         if not info.ondisk:
             raise FITSError("File does not appear to be on disk: %s" % (
                 info.url))

--- a/ginga/util/io_fits.py
+++ b/ginga/util/io_fits.py
@@ -189,6 +189,8 @@ class PyFitsFileHandler(BaseFitsFileHandler):
     def open_file(self, filespec, memmap=None, **kwargs):
 
         info = iohelper.get_fileinfo(filespec)
+        if isinstance(info, list):
+            raise NotImplementedError('Wildcard in extension not supported')
         if not info.ondisk:
             raise FITSError("File does not appear to be on disk: %s" % (
                 info.url))
@@ -426,6 +428,8 @@ class FitsioFileHandler(BaseFitsFileHandler):
     def open_file(self, filespec, memmap=None, **kwargs):
 
         info = iohelper.get_fileinfo(filespec)
+        if isinstance(info, list):
+            raise NotImplementedError('Wildcard in extension not supported')
         if not info.ondisk:
             raise FITSError("File does not appear to be on disk: %s" % (
                 info.url))

--- a/ginga/util/io_rgb.py
+++ b/ginga/util/io_rgb.py
@@ -59,9 +59,10 @@ class RGBFileHandler(object):
         self.clr_mgr = rgb_cms.ColorManager(self.logger)
 
     def load_file(self, filespec, dstobj=None, **kwargs):
-        info = iohelper.get_fileinfo(filespec)
-        if isinstance(info, list):
+        res = iohelper.get_fileinfo(filespec)
+        if len(res) != 1:
             raise NotImplementedError('Wildcard in extension not supported')
+        info = res[0]
         if not info.ondisk:
             raise ValueError("File does not appear to be on disk: %s" % (
                 info.url))

--- a/ginga/util/io_rgb.py
+++ b/ginga/util/io_rgb.py
@@ -60,6 +60,8 @@ class RGBFileHandler(object):
 
     def load_file(self, filespec, dstobj=None, **kwargs):
         info = iohelper.get_fileinfo(filespec)
+        if isinstance(info, list):
+            raise NotImplementedError('Wildcard in extension not supported')
         if not info.ondisk:
             raise ValueError("File does not appear to be on disk: %s" % (
                 info.url))

--- a/ginga/util/iohelper.py
+++ b/ginga/util/iohelper.py
@@ -74,6 +74,12 @@ def guess_filetype(filepath):
 def get_fileinfo(filespec, cache_dir='/tmp', download=False):
     """
     Parse a file specification and return information about it.
+
+    Returns
+    -------
+    res : list
+        A list of `~ginga.misc.Bunch.Bunch` objects.
+
     """
     # Loads first science extension by default.
     # This prevents [None] to be loaded instead.
@@ -157,10 +163,10 @@ def get_fileinfo(filespec, cache_dir='/tmp', download=False):
 
     dirname, fname = os.path.split(filepath)
     fname_pfx, fname_sfx = os.path.splitext(fname)
+    res = []
 
     # For [name, *] case
     if isinstance(name_ext, list):
-        res = []
         for cur_idx, cur_name_ext in zip(idx, name_ext):
             name = fname_pfx + cur_name_ext
             res.append(Bunch.Bunch(filepath=filepath, url=url, numhdu=cur_idx,
@@ -169,8 +175,8 @@ def get_fileinfo(filespec, cache_dir='/tmp', download=False):
     # Normal case
     else:
         name = fname_pfx + name_ext
-        res = Bunch.Bunch(filepath=filepath, url=url, numhdu=idx,
-                          name=name, ondisk=ondisk)
+        res.append(Bunch.Bunch(filepath=filepath, url=url, numhdu=idx,
+                               name=name, ondisk=ondisk))
 
     return res
 
@@ -215,9 +221,10 @@ def shorten_name(name, char_limit, side='right'):
     """
     # TODO: A more elegant way to do this?
     if char_limit is not None and len(name) > char_limit:
-        info = get_fileinfo(name)
-        if isinstance(info, list):
+        res = get_fileinfo(name)
+        if len(res) != 1:
             raise NotImplementedError('Wildcard in extension name not supported')
+        info = res[0]
         if info.numhdu is not None:
             i = name.rindex('[')
             s = (name[:i], name[i:])

--- a/ginga/util/loader.py
+++ b/ginga/util/loader.py
@@ -35,9 +35,10 @@ def load_data(filespec, idx=None, logger=None, **kwargs):
     """
     global viewer_registry
 
-    info = iohelper.get_fileinfo(filespec, cache_dir='/tmp')
-    if isinstance(info, list):
+    res = iohelper.get_fileinfo(filespec, cache_dir='/tmp')
+    if len(res) != 1:
         raise NotImplementedError('Wildcard in extension not supported')
+    info = res[0]
     filepath = info.filepath
 
     if idx is None:

--- a/ginga/util/loader.py
+++ b/ginga/util/loader.py
@@ -36,6 +36,8 @@ def load_data(filespec, idx=None, logger=None, **kwargs):
     global viewer_registry
 
     info = iohelper.get_fileinfo(filespec, cache_dir='/tmp')
+    if isinstance(info, list):
+        raise NotImplementedError('Wildcard in extension not supported')
     filepath = info.filepath
 
     if idx is None:


### PR DESCRIPTION
Fix #410 

* Update text entry when file is selected.
* Support opening multiple files from text entry box.

Fix #559 

* Enable `ginga filename[EXT,*]` command to open multiple named extensions for a given file.
* Enable opening `filename[EXT,*]` from `FBrowser` plugin.

Address part of #311 (enable opening multiple extensions at once but only if they are named the same). 

With this patch, crazy specifications like the following is now possible both from CLI and `FBrowser`:

```
file1.fits file2*.fits file3.fits[SCI,*] file4.fits[ERR]
```

However, `file.fits[*]` and `file*.fits[SCI,*]` are *not* supported (too crazy?). 

**Update:** The following error will go away if you use `gwcs` and `asdf` from latest `master`.

When testing this patch (Python 3.7.1, Numpy 1.15.4, Astropy 3.2.dev23734), the following combo gave me error (see spacetelescope/asdf#639) but I cannot reproduce it with a different combo nor from `FBrowser` 🤷‍♀️ 

```
$ ginga --loglevel=30 --stderr jb5g05ubq_flt.fits[SCI,*] imaging_wcs.asdf cropped_asdfinfits.fits[ASDF]
2019-01-14 16:07:08,833 | E | Control.py:577 (load_image) | Failed to load file'cropped_asdfinfits.fits': Can't handle 'tag:astropy.org:astropy/coordinates/frames/baseframe-1.0.0' as a file for mode 'r'
```

cc @jdavies-st and @AlexaVillaume