### PR TITLE
Add astropy_ape14 to config example

### DIFF
--- a/ginga/examples/configs/general.cfg
+++ b/ginga/examples/configs/general.cfg
@@ -70,12 +70,14 @@ widgetSet = 'choose'
 #use_opencv = True
 
 # Force of package for handling WCS
-# Possibilities are 'choose', 'kapteyn', 'astlib', 'starlink' and 'astropy'
+# Possibilities are 'choose', 'kapteyn', 'astlib', 'starlink', 'astropy',
+# and 'astropy_ape14'
 WCSpkg = 'choose'
 #WCSpkg = 'astlib'
 #WCSpkg = 'kapteyn'
 #WCSpkg = 'starlink'
 #WCSpkg = 'astropy'
+#WCSpkg = 'astropy_ape14'
 #WCSpkg = 'barebones'
 
 # Choice of package for handling FITS I/O


### PR DESCRIPTION
Follow up of #719. This adds `'astropy_ape14'` option to example of `general.cfg`. Thanks to @drdavella who brought this missing config to my attention.