### PR TITLE
Consolidate pip dependencies between doc and setup

### DIFF
--- a/doc/WhatsNew.rst
+++ b/doc/WhatsNew.rst
@@ -17,6 +17,7 @@ Ver 3.0.0 (unreleased)
 - Improved smoothness and updates of Zoom plugin image
 - Improved smoothness and updates when rotating or shifting color map
 - Fixed broken banner
+- Improved ``pip`` installation commands for different backends.
 
 Ver 2.7.2 (2018-11-05)
 ======================

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -30,7 +30,7 @@ import os
 import sys
 
 try:
-    import astropy_helpers
+    import astropy_helpers  # noqa
 except ImportError:
     # Building from inside the docs/ directory?
     if os.path.basename(os.getcwd()) == 'doc':
@@ -39,13 +39,10 @@ except ImportError:
             sys.path.insert(1, a_h_path)
 
 # Load all of the global Astropy configuration
-from astropy_helpers.sphinx.conf import *
+from astropy_helpers.sphinx.conf import *  # noqa
 
 # Get configuration information from setup.cfg
-try:
-    from ConfigParser import ConfigParser
-except ImportError:
-    from configparser import ConfigParser
+from configparser import ConfigParser
 conf = ConfigParser()
 conf.read([os.path.join(os.path.dirname(__file__), '..', 'setup.cfg')])
 setup_cfg = dict(conf.items('metadata'))
@@ -61,7 +58,7 @@ setup_cfg = dict(conf.items('metadata'))
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns.append('_templates')
+exclude_patterns.append('_templates')  # noqa
 
 # This is added to the end of RST files - a good place to put substitutions to
 # be used globally.
@@ -74,17 +71,16 @@ modindex_common_prefix = ['ginga.']
 # -- Project information ------------------------------------------------------
 
 # This does not *have* to match the package name, but typically does
-project = setup_cfg['package_name']
+project = setup_cfg['name']
 author = setup_cfg['author']
-copyright = '{0}, {1}'.format(
-    datetime.datetime.now().year, setup_cfg['author'])
+copyright = '{0}, {1}'.format(datetime.datetime.now().year, author)
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 
-__import__(setup_cfg['package_name'])
-package = sys.modules[setup_cfg['package_name']]
+__import__(project)
+package = sys.modules[project]
 
 # The short X.Y version.
 version = package.__version__.split('-', 1)[0]
@@ -145,11 +141,11 @@ latex_documents = [('index', project + '.tex', project + u' Documentation',
 latex_elements = {
     # Additional stuff for the LaTeX preamble.
     'preamble': "".join((
-        '\DeclareUnicodeCharacter{9280}{N}',
-        '\DeclareUnicodeCharacter{6CB3}{N}',
-        '\DeclareUnicodeCharacter{304E}{N}',
-        '\DeclareUnicodeCharacter{3093}{N}',
-        '\DeclareUnicodeCharacter{304C}{N}',
+        r'\DeclareUnicodeCharacter{9280}{N}',
+        r'\DeclareUnicodeCharacter{6CB3}{N}',
+        r'\DeclareUnicodeCharacter{304E}{N}',
+        r'\DeclareUnicodeCharacter{3093}{N}',
+        r'\DeclareUnicodeCharacter{304C}{N}',
     )),
 }
 
@@ -163,15 +159,15 @@ man_pages = [('index', project.lower(), project + u' Documentation',
 
 ## -- Options for the edit_on_github extension ----------------------------------------
 
-if eval(setup_cfg.get('edit_on_github')):
-    extensions += ['astropy_helpers.sphinx.ext.edit_on_github']
-
-    versionmod = __import__(setup_cfg['package_name'] + '.version')
-    edit_on_github_project = setup_cfg['github_project']
-    if versionmod.version.release:
-        edit_on_github_branch = "v" + versionmod.version.version
-    else:
-        edit_on_github_branch = "master"
-
-    edit_on_github_source_root = ""
-    edit_on_github_doc_root = "docs"
+#if eval(setup_cfg.get('edit_on_github')):
+#    extensions += ['astropy_helpers.sphinx.ext.edit_on_github']  # noqa
+#
+#    versionmod = __import__(project + '.version')
+#    edit_on_github_project = setup_cfg['github_project']
+#    if versionmod.version.release:
+#        edit_on_github_branch = "v" + versionmod.version.version
+#    else:
+#        edit_on_github_branch = "master"
+#
+#    edit_on_github_source_root = ""
+#    edit_on_github_doc_root = "doc"

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -20,14 +20,18 @@ REQUIRED
 ========
 
 * python (v. 3.5 or higher)
-* numpy  (v. 1.7 or higher)
+* setuptools
+* numpy  (v. 1.13 or higher)
 * astropy
 
 Highly recommended, because some features will not be available without it:
 
 * scipy
-* pillow
-* opencv
+* Pillow
+* opencv-python (also distributed as opencv or python-opencv,
+  depending on where you get it from)
+* piexif
+* beautifulsoup4
 
 For opening `FITS <https://fits.gsfc.nasa.gov/>`_ files you will
 need one of the following packages:
@@ -50,39 +54,39 @@ Ginga can draw its output to a number of different back ends.
 Depending on which GUI toolkit you prefer (and what you want to
 do), you will need at least one of the following:
 
-* python-qt4
-* python-qt5
-* python-pyside (qt4/qt5 alternative)
-* python-gtk (gtk2) **AND** python-cairo
-* python gtk3 (gi) **AND** python-cairo
-* python-Tkinter
+.. TODO: This can be broken down in a clearer way.
+
+* QtPy (PyQt4 or PyQt5)
+* PySide (Qt4/Qt5 alternative)
+* PyGTK (gtk) **AND** `pycairo <https://github.com/pygobject/pycairo>`_ (GTK 2)
+* pygobject (gi) **AND** pycairo (GTK 3)
+* `tkinter <https://docs.python.org/3/library/tk.html>`_
 * matplotlib
 * tornado
-* aggdraw
-* PIL (pillow)
-* OpenCv
+* `aggdraw <https://github.com/pytroll/aggdraw>`_
+* Pillow (PIL fork)
 
 RECOMMENDED
 ===========
+
 Certain plugins in the reference viewer (or features of those plugins)
 will not work without the following packages:
 
 * matplotlib (required by: Pick, Cuts, Histogram, LineProfile)
-* webkit (required by: WBrowser (used for online help))
 * scipy (required by: Pick, some built-in
   :ref:`auto cuts algorithms <autoset_cut_levels>` used when you load an image)
 
 To save a movie:
 
-* mencoder (required by: Cuts)
+* mencoder (command line tool required by: Cuts)
 
 Helpful, but not necessary (may optimize or speed up certain operations):
 
-* python-opencv (speeds up rotation, mosaicing and some transformations)
-* python-pyopencl (speeds up rotation, mosaicing and some transformations)
-* python-numexpr (speeds up rotation a little)
-* python-filemagic (aids in identifying files when opening them)
-* python-PIL or pillow (useful for various RGB file manipulations)
+* opencv-python (speeds up rotation, mosaicing and some transformations)
+* pyopencl (speeds up rotation, mosaicing and some transformations)
+* numexpr (speeds up rotation a little)
+* filemagic (aids in identifying files when opening them)
+* Pillow (useful for various RGB file manipulations)
 
 ==============================
 Notes on Supported Widget Sets
@@ -94,7 +98,7 @@ full reference viewer, which includes many plugins (``ginga``).
 
 .. note:: For the full reference viewer, Mac and Windows users
 	  should probably install the Qt version, unless you are
-	  the tinkering sort.  Linux can use either Qt or Gtk fine.
+	  the tinkering sort.  Linux can use either Qt or GTK fine.
 
 Qt/PySide
 =========
@@ -107,14 +111,12 @@ There is support for both the basic widget and the full reference viewer.
 	  then set the environment variable QT_API to either "pyqt" or
 	  "pyside".  This is the same procedure as for Matplotlib.
 
-
-Gtk
+GTK
 ===
 
-Ginga can use either Gtk 2 (with pygtk) or Gtk 3 (with gi).  (If you have
-an older version of pycairo package, you may need to install a newer version
-from `pycairo repository <https://github.com/pygobject/pycairo>`_).
-
+Ginga can use either GTK 2 (with PyGTK) or GTK 3 (with ``gi``).  (If you have
+an older version of ``pycairo`` package, you may need to install a newer version
+from ``pycairo``).
 
 Tk
 ==
@@ -122,10 +124,9 @@ Tk
 Ginga's Tk support is limited to the viewing widget itself.  For
 overplotting (graphics) support, you will also need:
 
-* ``pillow``/PIL package
-* ``OpenCv`` module
-* ``aggdraw`` module (which you can find at
-  `aggdraw repository <https://github.com/pytroll/aggdraw>`_)
+* Pillow
+* opencv-python
+* aggdraw
 
 Matplotlib
 ==========
@@ -148,9 +149,16 @@ Tested browsers include Chromium (Chrome), Firefox, and Safari.
 Basic Installation
 ==================
 
-You can download and install via ``pip``::
+You can download and install via ``pip`` by choosing the command that best
+suits your needs (full selection is defined in
+`setup configuration file <https://github.com/ejeschke/ginga/blob/master/setup.cfg>`_
+)::
 
-   pip install ginga
+   pip install ginga  # The most basic installation
+
+   pip install ginga[recommended,qt5]  # Qt5
+
+   pip install ginga[recommended,gtk3]  # GTK 3
 
 Or via ``conda``::
 
@@ -179,8 +187,8 @@ Platform Specific Instructions
 
 .. _linux_install_instructions:
 
-Linux
-=====
+Linux (Debian/Ubuntu)
+=====================
 
 If you are on a relatively recent version of Debian or Ubuntu,
 something like the following will work::
@@ -190,17 +198,16 @@ something like the following will work::
 If you are using another distribution of Linux, we recommend to install
 via Anaconda or Miniconda as described below.
 
-Mac/Windows
-===========
+Mac/Windows/Linux (others)
+==========================
 
 Anaconda
 --------
 
-For Mac/Windows users, we recommend installing the
-`Anaconda distribution <http://continuum.io/downloads>` (or Miniconda).
+For Mac/Windows or other Linux users, we recommend installing the
+`Anaconda distribution <http://continuum.io/downloads>`_ (or Miniconda).
 This distribution already includes all of the necessary packages to run
 Ginga.
 
 After installing Anaconda, open the Anaconda Prompt and follow instructions
-under :ref:`install_generic`.
-
+under :ref:`install_generic` via ``conda``.

--- a/doc/rtd-pip-requirements
+++ b/doc/rtd-pip-requirements
@@ -1,7 +1,0 @@
-numpy>=1.13
-pillow
-matplotlib
-Cython
-scipy>=0.18
-astropy
-sphinx-astropy

--- a/ginga/__init__.py
+++ b/ginga/__init__.py
@@ -26,7 +26,7 @@ class UnsupportedPythonError(Exception):
     pass
 
 
-# This is the same check as the one at the top of setup.py
+# This is the same check as the one in setup.cfg
 if sys.version_info < tuple((int(val) for val in __minimum_python_version__.split('.'))):
     raise UnsupportedPythonError("Ginga does not support Python < {}".format(__minimum_python_version__))
 

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,12 @@
+build:
+    image: latest
+
+python:
+  version: 3.6
+  pip_install: true
+  extra_requirements: ['recommended', docs']
+
+# Build PDF & ePub
+formats:
+    - epub
+    - pdf

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ auto_use = True
 universal = 1
 
 [metadata]
-package_name = ginga
+name = ginga
 description = A scientific image viewer and toolkit
 author = Ginga Maintainers
 author_email = eric@naoj.org
@@ -28,7 +28,34 @@ url = http://ejeschke.github.com/ginga
 edit_on_github = False
 github_project = ejeschke/ginga/
 version = 3.0.dev
-test_suite = ginga.tests.ginga_test_suite
+keywords = scientific, image, viewer, numpy, toolkit, astronomy, FITS
+classifiers =
+    Intended Audience :: Science/Research
+    License :: OSI Approved :: BSD License
+    Operating System :: MacOS :: MacOS X
+    Operating System :: Microsoft :: Windows
+    Operating System :: POSIX
+    Programming Language :: C
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3
+    Topic :: Scientific/Engineering :: Astronomy
+    Topic :: Scientific/Engineering :: Physics
+
+[options]
+zip_safe = False
+packages = find:
+python_requires = >=3.5
+setup_requires = numpy>=1.13
+install_requires = numpy>=1.13; qtpy>=1.1; astropy>=3
+tests_require = pytest
+
+[options.extras_require]
+recommended = pillow>=3.2.0; scipy>=0.18.1; matplotlib>=1.5.1; opencv-python>=3.4.1; piexif>=1.0.13; beautifulsoup4>=4.3.2
+docs = sphinx-astropy
+gtk3 = pycairo; pygobject
+qt5 = PyQt5; QtPy>=1.1
+tk = aggdraw
+web = tornado; aggdraw
 
 [entry_points]
 ginga = ginga.rv.main:_main

--- a/setup.py
+++ b/setup.py
@@ -3,16 +3,6 @@
 
 import sys
 
-# NOTE: This is for older setuptools that does not understand
-#       python_requires
-# This is the same check as ginga/__init__.py but this one has to
-# happen before importing ah_bootstrap
-__minimum_python_version__ = '3.5'
-if sys.version_info < tuple((int(val) for val in __minimum_python_version__.split('.'))):
-    sys.stderr.write("ERROR: Ginga requires Python {} or later\n".format(
-        __minimum_python_version__))
-    sys.exit(1)
-
 import glob
 import os
 
@@ -35,12 +25,7 @@ conf = ConfigParser()
 conf.read(['setup.cfg'])
 metadata = dict(conf.items('metadata'))
 
-PACKAGENAME = metadata.get('package_name', 'packagename')
-DESCRIPTION = metadata.get('description', 'Astropy affiliated package')
-AUTHOR = metadata.get('author', '')
-AUTHOR_EMAIL = metadata.get('author_email', '')
-LICENSE = metadata.get('license', 'unknown')
-URL = metadata.get('url', 'http://astropy.org')
+PACKAGENAME = metadata.get('name', 'ginga')
 
 # Get the long description from the package's docstring
 __import__(PACKAGENAME)
@@ -106,53 +91,9 @@ for root, dirs, files in os.walk(PACKAGENAME):
                     os.path.relpath(root, PACKAGENAME), filename))
 package_info['package_data'][PACKAGENAME].extend(c_files)
 
-# Note that requires and provides should not be included in the call to
-# ``setup``, since these are now deprecated. See this link for more details:
-# https://groups.google.com/forum/#!topic/astropy-dev/urYO8ckB2uM
-
-setup_requires = ['numpy>=1.9']
-
-# pretty much needed
-install_requires = ['numpy>=1.13', 'qtpy>=1.1', 'setuptools>=1.0',
-                    'astropy>=3']
-
-# nice to have, but not required, depending on the application
-extras_require = {
-    'recommended': ['pillow>=3.2.0', 'scipy>=0.18.1', 'matplotlib>=1.5.1',
-                    'opencv-python>=3.4.1', 'piexif>=1.0.13',
-                    'beautifulsoup4>=4.3.2'],
-}
-
-setup(name=PACKAGENAME,
-      version=VERSION,
-      description=DESCRIPTION,
-      requires=['numpy'],  # scipy not required, but strongly recommended
-      provides=[PACKAGENAME],
-      keywords=['scientific', 'image', 'viewer', 'numpy', 'toolkit',
-                'astronomy', 'FITS'],
-      classifiers=[
-          "Intended Audience :: Science/Research",
-          "License :: OSI Approved :: BSD License",
-          "Operating System :: MacOS :: MacOS X",
-          "Operating System :: Microsoft :: Windows",
-          "Operating System :: POSIX",
-          "Programming Language :: C",
-          "Programming Language :: Python :: 3.7",
-          "Programming Language :: Python :: 3",
-          "Topic :: Scientific/Engineering :: Astronomy",
-          "Topic :: Scientific/Engineering :: Physics",
-      ],
+setup(version=VERSION,
       scripts=scripts,
-      setup_requires=setup_requires,
-      install_requires=install_requires,
-      extras_require=extras_require,
-      python_requires='>={}'.format(__minimum_python_version__),
-      author=AUTHOR,
-      author_email=AUTHOR_EMAIL,
-      license=LICENSE,
-      url=URL,
       long_description=LONG_DESCRIPTION,
       cmdclass=cmdclassd,
-      zip_safe=False,
       entry_points=entry_points,
       **package_info)


### PR DESCRIPTION
Fix #663.

This supersedes #709.

@astrofrog , can you please have a look to see if I wrote the setuptools syntax correctly? Thanks! 🙏 

So, I think, with this change
```
python setup.py install
```
becomes
```
pip install .[recommended,qt5]
```
with the latter also `pip install` the specified dependencies.

If you are used to `python setup.py develop`, then it becomes
```
pip install -e .[...]
```