### PR TITLE
Change LineProfile Y-axis label default

### DIFF
--- a/doc/WhatsNew.rst
+++ b/doc/WhatsNew.rst
@@ -21,6 +21,8 @@ Ver 3.0.0 (unreleased)
 - Fixed a bug where identically named HDUs could not be loaded by MultiDim
 - Fixed a bug where compressed HDUs could not be loaded by MultiDim
 - Plugins with splitter type panels now remember their sizes when closed
+- LineProfile plugin's default Y-axis label is now "Signal", to be more
+  scientifically accurate.
 
 Ver 2.7.2 (2018-11-05)
 ======================

--- a/ginga/rv/plugins/LineProfile.py
+++ b/ginga/rv/plugins/LineProfile.py
@@ -26,7 +26,7 @@ Displayed X-axis is constructed using ``CRVAL*``, ``CDELT*``, ``CRPIX*``,
 are unavailabled, the axis falls back to ``NAXIS*`` values instead.
 
 Displayed Y-axis is constructed using ``BTYPE`` and ``BUNIT``. If they are not
-available, it simply labels pixel values as "Flux".
+available, it simply labels pixel values as "Signal".
 
 To use this plugin:
 
@@ -431,7 +431,7 @@ class LineProfile(GingaPlugin.LocalPlugin):
                 self.x_lbl += (' ({})'.format(units))
 
             # Get pixel value info from header
-            self.y_lbl = self.image.get_keyword('BTYPE', 'Flux')
+            self.y_lbl = self.image.get_keyword('BTYPE', 'Signal')
             bunit = self.image.get_keyword('BUNIT', None)
             if bunit is not None:
                 self.y_lbl += (' ({})'.format(bunit))


### PR DESCRIPTION
This was based on a feedback from JWST/MIRI instrument scientists when I did a demo for them. Using "Flux" as a default could be misleading.