### PR TITLE
Change use of optparse to argparse

### DIFF
--- a/ginga/examples/bokeh/example2.py
+++ b/ginga/examples/bokeh/example2.py
@@ -45,25 +45,23 @@ def main(options, args):
 if __name__ == "__main__":
 
     # Parse command line options
-    from optparse import OptionParser
+    from argparse import ArgumentParser
 
-    usage = "usage: %prog [options] cmd [args]"
-    optprs = OptionParser(usage=usage, version=('%%prog'))
+    usage = "usage: %prog [options] [args]"
+    argprs = ArgumentParser(usage=usage)
 
-    optprs.add_option("--debug", dest="debug", default=False, action="store_true",
-                      help="Enter the pdb debugger on main()")
-    optprs.add_option("-d", "--indir", dest="indir", metavar="DIR",
-                      default=os.environ['HOME'],
-                      help="Look in DIR for files")
-    optprs.add_option("--opencv", dest="use_opencv", default=False,
-                      action="store_true",
-                      help="Use OpenCv acceleration")
-    optprs.add_option("--profile", dest="profile", action="store_true",
-                      default=False,
-                      help="Run the profiler on main()")
-    log.addlogopts(optprs)
+    argprs.add_argument("--debug", dest="debug", default=False,
+                        action="store_true",
+                        help="Enter the pdb debugger on main()")
+    argprs.add_argument("-d", "--indir", dest="indir", metavar="DIR",
+                        default=os.environ['HOME'],
+                        help="Look in DIR for files")
+    argprs.add_argument("--profile", dest="profile", action="store_true",
+                        default=False,
+                        help="Run the profiler on main()")
+    log.addlogopts(argprs)
 
-    (options, args) = optprs.parse_args(sys.argv[1:])
+    (options, args) = argprs.parse_known_args(sys.argv[1:])
 
     # Are we debugging this?
     if options.debug:

--- a/ginga/examples/gl/example2_qt.py
+++ b/ginga/examples/gl/example2_qt.py
@@ -242,26 +242,27 @@ def main(options, args):
 
 if __name__ == "__main__":
 
-    # Parse command line options with nifty optparse module
-    from optparse import OptionParser
+    # Parse command line options
+    from argparse import ArgumentParser
 
-    usage = "usage: %prog [options] cmd [args]"
-    optprs = OptionParser(usage=usage, version=('%%prog'))
+    usage = "usage: %prog [options] [args]"
+    argprs = ArgumentParser(usage=usage)
 
-    optprs.add_option("--debug", dest="debug", default=False, action="store_true",
-                      help="Enter the pdb debugger on main()")
-    optprs.add_option("--opencv", dest="opencv", default=False,
-                      action="store_true",
-                      help="Use OpenCv acceleration")
-    optprs.add_option("--opencl", dest="opencl", default=False,
-                      action="store_true",
-                      help="Use OpenCL acceleration")
-    optprs.add_option("--profile", dest="profile", action="store_true",
-                      default=False,
-                      help="Run the profiler on main()")
-    log.addlogopts(optprs)
+    argprs.add_argument("--debug", dest="debug", default=False,
+                        action="store_true",
+                        help="Enter the pdb debugger on main()")
+    argprs.add_argument("--opencv", dest="opencv", default=False,
+                        action="store_true",
+                        help="Use OpenCv acceleration")
+    argprs.add_argument("--opencl", dest="opencl", default=False,
+                        action="store_true",
+                        help="Use OpenCL acceleration")
+    argprs.add_argument("--profile", dest="profile", action="store_true",
+                        default=False,
+                        help="Run the profiler on main()")
+    log.addlogopts(argprs)
 
-    (options, args) = optprs.parse_args(sys.argv[1:])
+    (options, args) = argprs.parse_known_args(sys.argv[1:])
 
     # Are we debugging this?
     if options.debug:

--- a/ginga/examples/gtk/example2_gtk.py
+++ b/ginga/examples/gtk/example2_gtk.py
@@ -241,27 +241,27 @@ def main(options, args):
 
 if __name__ == "__main__":
 
-    # Parse command line options with nifty optparse module
-    from optparse import OptionParser
+    # Parse command line options
+    from argparse import ArgumentParser
 
-    usage = "usage: %prog [options] cmd [args]"
-    optprs = OptionParser(usage=usage, version=('%%prog'))
+    usage = "usage: %prog [options] [args]"
+    argprs = ArgumentParser(usage=usage)
 
-    optprs.add_option("--debug", dest="debug", default=False,
-                      action="store_true",
-                      help="Enter the pdb debugger on main()")
-    optprs.add_option("--opencv", dest="opencv", default=False,
-                      action="store_true",
-                      help="Use OpenCv acceleration")
-    optprs.add_option("--opencl", dest="opencl", default=False,
-                      action="store_true",
-                      help="Use OpenCL acceleration")
-    optprs.add_option("--profile", dest="profile", action="store_true",
-                      default=False,
-                      help="Run the profiler on main()")
-    log.addlogopts(optprs)
+    argprs.add_argument("--debug", dest="debug", default=False,
+                        action="store_true",
+                        help="Enter the pdb debugger on main()")
+    argprs.add_argument("--opencv", dest="opencv", default=False,
+                        action="store_true",
+                        help="Use OpenCv acceleration")
+    argprs.add_argument("--opencl", dest="opencl", default=False,
+                        action="store_true",
+                        help="Use OpenCL acceleration")
+    argprs.add_argument("--profile", dest="profile", action="store_true",
+                        default=False,
+                        help="Run the profiler on main()")
+    log.addlogopts(argprs)
 
-    (options, args) = optprs.parse_args(sys.argv[1:])
+    (options, args) = argprs.parse_known_args(sys.argv[1:])
 
     # Are we debugging this?
     if options.debug:

--- a/ginga/examples/gtk3/example2.py
+++ b/ginga/examples/gtk3/example2.py
@@ -240,27 +240,27 @@ def main(options, args):
 
 if __name__ == "__main__":
 
-    # Parse command line options with nifty optparse module
-    from optparse import OptionParser
+    # Parse command line options
+    from argparse import ArgumentParser
 
-    usage = "usage: %prog [options] cmd [args]"
-    optprs = OptionParser(usage=usage, version=('%%prog'))
+    usage = "usage: %prog [options] [args]"
+    argprs = ArgumentParser(usage=usage)
 
-    optprs.add_option("--debug", dest="debug", default=False,
-                      action="store_true",
-                      help="Enter the pdb debugger on main()")
-    optprs.add_option("--opencv", dest="opencv", default=False,
-                      action="store_true",
-                      help="Use OpenCv acceleration")
-    optprs.add_option("--opencl", dest="opencl", default=False,
-                      action="store_true",
-                      help="Use OpenCL acceleration")
-    optprs.add_option("--profile", dest="profile", action="store_true",
-                      default=False,
-                      help="Run the profiler on main()")
-    log.addlogopts(optprs)
+    argprs.add_argument("--debug", dest="debug", default=False,
+                        action="store_true",
+                        help="Enter the pdb debugger on main()")
+    argprs.add_argument("--opencv", dest="opencv", default=False,
+                        action="store_true",
+                        help="Use OpenCv acceleration")
+    argprs.add_argument("--opencl", dest="opencl", default=False,
+                        action="store_true",
+                        help="Use OpenCL acceleration")
+    argprs.add_argument("--profile", dest="profile", action="store_true",
+                        default=False,
+                        help="Run the profiler on main()")
+    log.addlogopts(argprs)
 
-    (options, args) = optprs.parse_args(sys.argv[1:])
+    (options, args) = argprs.parse_known_args(sys.argv[1:])
 
     # Are we debugging this?
     if options.debug:

--- a/ginga/examples/gw/example1_video.py
+++ b/ginga/examples/gw/example1_video.py
@@ -273,30 +273,31 @@ def main(options, args):
 
 
 if __name__ == '__main__':
-    # Parse command line options with nifty optparse module
-    from optparse import OptionParser
 
-    usage = "usage: %prog [options] cmd [args]"
-    optprs = OptionParser(usage=usage, version=('%%prog'))
+    # Parse command line options
+    from argparse import ArgumentParser
 
-    optprs.add_option("--debug", dest="debug", default=False,
-                      action="store_true",
-                      help="Enter the pdb debugger on main()")
-    optprs.add_option("--fps", dest="fps", metavar="FPS",
-                      type='float', default=None,
-                      help="Force a FPS (frames/sec)")
-    optprs.add_option("--optimize", dest="optimize", default=False,
-                      action="store_true",
-                      help="Perform some optimizations to improve FPS")
-    optprs.add_option("-t", "--toolkit", dest="toolkit", metavar="NAME",
-                      default='qt',
-                      help="Choose GUI toolkit (gtk|qt)")
-    optprs.add_option("--profile", dest="profile", action="store_true",
-                      default=False,
-                      help="Run the profiler on main()")
-    log.addlogopts(optprs)
+    usage = "usage: %prog [options] [args]"
+    argprs = ArgumentParser(usage=usage)
 
-    (options, args) = optprs.parse_args(sys.argv[1:])
+    argprs.add_argument("--debug", dest="debug", default=False,
+                        action="store_true",
+                        help="Enter the pdb debugger on main()")
+    argprs.add_argument("--fps", dest="fps", metavar="FPS",
+                        type=float, default=None,
+                        help="Force a FPS (frames/sec)")
+    argprs.add_argument("--optimize", dest="optimize", default=False,
+                        action="store_true",
+                        help="Perform some optimizations to improve FPS")
+    argprs.add_argument("-t", "--toolkit", dest="toolkit", metavar="NAME",
+                        default='qt',
+                        help="Choose GUI toolkit (gtk|qt)")
+    argprs.add_argument("--profile", dest="profile", action="store_true",
+                        default=False,
+                        help="Run the profiler on main()")
+    log.addlogopts(argprs)
+
+    (options, args) = argprs.parse_known_args(sys.argv[1:])
 
     # Are we debugging this?
     if options.debug:

--- a/ginga/examples/gw/example2.py
+++ b/ginga/examples/gw/example2.py
@@ -315,33 +315,33 @@ def main(options, args):
 
 if __name__ == "__main__":
 
-    # Parse command line options with nifty optparse module
-    from optparse import OptionParser
+    # Parse command line options
+    from argparse import ArgumentParser
 
-    usage = "usage: %prog [options] cmd [args]"
-    optprs = OptionParser(usage=usage, version=('%%prog'))
+    usage = "usage: %prog [options] [args]"
+    argprs = ArgumentParser(usage=usage)
 
-    optprs.add_option("--debug", dest="debug", default=False,
-                      action="store_true",
-                      help="Enter the pdb debugger on main()")
-    optprs.add_option("-t", "--toolkit", dest="toolkit", metavar="NAME",
-                      default='qt',
-                      help="Choose GUI toolkit (gtk|qt)")
-    optprs.add_option("--opencv", dest="use_opencv", default=False,
-                      action="store_true",
-                      help="Use OpenCv acceleration")
-    optprs.add_option("--opencl", dest="use_opencl", default=False,
-                      action="store_true",
-                      help="Use OpenCL acceleration")
-    optprs.add_option("--profile", dest="profile", action="store_true",
-                      default=False,
-                      help="Run the profiler on main()")
-    optprs.add_option("-r", "--renderer", dest="renderer", metavar="NAME",
-                      default=None,
-                      help="Choose renderer (pil|agg|opencv|cairo|qt)")
-    log.addlogopts(optprs)
+    argprs.add_argument("--debug", dest="debug", default=False,
+                        action="store_true",
+                        help="Enter the pdb debugger on main()")
+    argprs.add_argument("-t", "--toolkit", dest="toolkit", metavar="NAME",
+                        default='qt',
+                        help="Choose GUI toolkit (gtk|qt)")
+    argprs.add_argument("--opencv", dest="use_opencv", default=False,
+                        action="store_true",
+                        help="Use OpenCv acceleration")
+    argprs.add_argument("--opencl", dest="use_opencl", default=False,
+                        action="store_true",
+                        help="Use OpenCL acceleration")
+    argprs.add_argument("--profile", dest="profile", action="store_true",
+                        default=False,
+                        help="Run the profiler on main()")
+    argprs.add_argument("-r", "--renderer", dest="renderer", metavar="NAME",
+                        default=None,
+                        help="Choose renderer (pil|agg|opencv|cairo|qt)")
+    log.addlogopts(argprs)
 
-    (options, args) = optprs.parse_args(sys.argv[1:])
+    (options, args) = argprs.parse_known_args(sys.argv[1:])
 
     # Are we debugging this?
     if options.debug:

--- a/ginga/examples/gw/shared_canvas.py
+++ b/ginga/examples/gw/shared_canvas.py
@@ -4,7 +4,6 @@
 # Please see the file LICENSE.txt for details.
 #
 import sys
-import logging
 
 from ginga import colors
 import ginga.toolkit as ginga_toolkit
@@ -320,18 +319,9 @@ if __name__ == "__main__":
     argprs.add_argument("-t", "--toolkit", dest="toolkit", metavar="NAME",
                         default='qt',
                         help="Choose GUI toolkit (gtk|qt)")
-    argprs.add_argument("--opencv", dest="use_opencv", default=False,
-                        action="store_true",
-                        help="Use OpenCv acceleration")
-    argprs.add_argument("--opencl", dest="use_opencl", default=False,
-                        action="store_true",
-                        help="Use OpenCL acceleration")
     argprs.add_argument("--profile", dest="profile", action="store_true",
                         default=False,
                         help="Run the profiler on main()")
-    argprs.add_argument("-r", "--renderer", dest="renderer", metavar="NAME",
-                        default=None,
-                        help="Choose renderer (pil|agg|opencv|cairo|qt)")
     log.addlogopts(argprs)
 
     (options, args) = argprs.parse_known_args(sys.argv[1:])

--- a/ginga/examples/gw/shared_canvas.py
+++ b/ginga/examples/gw/shared_canvas.py
@@ -308,31 +308,33 @@ def main(options, args):
 
 if __name__ == "__main__":
 
-    # Parse command line options with nifty optparse module
-    from optparse import OptionParser
+    # Parse command line options
+    from argparse import ArgumentParser
 
-    usage = "usage: %prog [options] cmd [args]"
-    optprs = OptionParser(usage=usage, version=('%%prog'))
+    usage = "usage: %prog [options] [args]"
+    argprs = ArgumentParser(usage=usage)
 
-    optprs.add_option("--debug", dest="debug", default=False,
-                      action="store_true",
-                      help="Enter the pdb debugger on main()")
-    optprs.add_option("--log", dest="logfile", metavar="FILE",
-                      help="Write logging output to FILE")
-    optprs.add_option("--loglevel", dest="loglevel", metavar="LEVEL",
-                      type='int', default=logging.INFO,
-                      help="Set logging level to LEVEL")
-    optprs.add_option("--stderr", dest="logstderr", default=False,
-                      action="store_true",
-                      help="Copy logging also to stderr")
-    optprs.add_option("-t", "--toolkit", dest="toolkit", metavar="NAME",
-                      default='qt',
-                      help="Choose GUI toolkit (gtk|qt)")
-    optprs.add_option("--profile", dest="profile", action="store_true",
-                      default=False,
-                      help="Run the profiler on main()")
+    argprs.add_argument("--debug", dest="debug", default=False,
+                        action="store_true",
+                        help="Enter the pdb debugger on main()")
+    argprs.add_argument("-t", "--toolkit", dest="toolkit", metavar="NAME",
+                        default='qt',
+                        help="Choose GUI toolkit (gtk|qt)")
+    argprs.add_argument("--opencv", dest="use_opencv", default=False,
+                        action="store_true",
+                        help="Use OpenCv acceleration")
+    argprs.add_argument("--opencl", dest="use_opencl", default=False,
+                        action="store_true",
+                        help="Use OpenCL acceleration")
+    argprs.add_argument("--profile", dest="profile", action="store_true",
+                        default=False,
+                        help="Run the profiler on main()")
+    argprs.add_argument("-r", "--renderer", dest="renderer", metavar="NAME",
+                        default=None,
+                        help="Choose renderer (pil|agg|opencv|cairo|qt)")
+    log.addlogopts(argprs)
 
-    (options, args) = optprs.parse_args(sys.argv[1:])
+    (options, args) = argprs.parse_known_args(sys.argv[1:])
 
     # Are we debugging this?
     if options.debug:

--- a/ginga/examples/matplotlib/example1_mpl.py
+++ b/ginga/examples/matplotlib/example1_mpl.py
@@ -151,28 +151,21 @@ def main(options, args):
 
 if __name__ == "__main__":
 
-    # Parse command line options with nifty optparse module
-    from optparse import OptionParser
+    # Parse command line options
+    from argparse import ArgumentParser
 
-    usage = "usage: %prog [options] cmd [args]"
-    optprs = OptionParser(usage=usage, version=('%%prog'))
+    usage = "usage: %prog [options] [args]"
+    argprs = ArgumentParser(usage=usage)
 
-    optprs.add_option("--debug", dest="debug", default=False,
-                      action="store_true",
-                      help="Enter the pdb debugger on main()")
-    optprs.add_option("--log", dest="logfile", metavar="FILE",
-                      help="Write logging output to FILE")
-    optprs.add_option("--loglevel", dest="loglevel", metavar="LEVEL",
-                      type='int', default=None,
-                      help="Set logging level to LEVEL")
-    optprs.add_option("--stderr", dest="logstderr", default=False,
-                      action="store_true",
-                      help="Copy logging also to stderr")
-    optprs.add_option("--profile", dest="profile", action="store_true",
-                      default=False,
-                      help="Run the profiler on main()")
+    argprs.add_argument("--debug", dest="debug", default=False,
+                        action="store_true",
+                        help="Enter the pdb debugger on main()")
+    argprs.add_argument("--profile", dest="profile", action="store_true",
+                        default=False,
+                        help="Run the profiler on main()")
+    log.addlogopts(argprs)
 
-    (options, args) = optprs.parse_args(sys.argv[1:])
+    (options, args) = argprs.parse_known_args(sys.argv[1:])
 
     # Are we debugging this?
     if options.debug:

--- a/ginga/examples/matplotlib/example2_mpl.py
+++ b/ginga/examples/matplotlib/example2_mpl.py
@@ -275,20 +275,21 @@ def main(options, args):
 
 if __name__ == "__main__":
 
-    # Parse command line options with nifty optparse module
-    from optparse import OptionParser
+    # Parse command line options
+    from argparse import ArgumentParser
 
-    usage = "usage: %prog [options] cmd [args]"
-    optprs = OptionParser(usage=usage, version=('%%prog'))
+    usage = "usage: %prog [options] [args]"
+    argprs = ArgumentParser(usage=usage)
 
-    optprs.add_option("--debug", dest="debug", default=False, action="store_true",
-                      help="Enter the pdb debugger on main()")
-    optprs.add_option("--profile", dest="profile", action="store_true",
-                      default=False,
-                      help="Run the profiler on main()")
-    log.addlogopts(optprs)
+    argprs.add_argument("--debug", dest="debug", default=False,
+                        action="store_true",
+                        help="Enter the pdb debugger on main()")
+    argprs.add_argument("--profile", dest="profile", action="store_true",
+                        default=False,
+                        help="Run the profiler on main()")
+    log.addlogopts(argprs)
 
-    (options, args) = optprs.parse_args(sys.argv[1:])
+    (options, args) = argprs.parse_known_args(sys.argv[1:])
 
     # Are we debugging this?
     if options.debug:

--- a/ginga/examples/matplotlib/example3_mpl.py
+++ b/ginga/examples/matplotlib/example3_mpl.py
@@ -393,28 +393,21 @@ def main(options, args):
 
 if __name__ == "__main__":
 
-    # Parse command line options with nifty optparse module
-    from optparse import OptionParser
+    # Parse command line options
+    from argparse import ArgumentParser
 
-    usage = "usage: %prog [options] cmd [args]"
-    optprs = OptionParser(usage=usage, version=('%%prog'))
+    usage = "usage: %prog [options] [args]"
+    argprs = ArgumentParser(usage=usage)
 
-    optprs.add_option("--debug", dest="debug", default=False,
-                      action="store_true",
-                      help="Enter the pdb debugger on main()")
-    optprs.add_option("--log", dest="logfile", metavar="FILE",
-                      help="Write logging output to FILE")
-    optprs.add_option("--loglevel", dest="loglevel", metavar="LEVEL",
-                      type='int', default=None,
-                      help="Set logging level to LEVEL")
-    optprs.add_option("--stderr", dest="logstderr", default=False,
-                      action="store_true",
-                      help="Copy logging also to stderr")
-    optprs.add_option("--profile", dest="profile", action="store_true",
-                      default=False,
-                      help="Run the profiler on main()")
+    argprs.add_argument("--debug", dest="debug", default=False,
+                        action="store_true",
+                        help="Enter the pdb debugger on main()")
+    argprs.add_argument("--profile", dest="profile", action="store_true",
+                        default=False,
+                        help="Run the profiler on main()")
+    log.addlogopts(argprs)
 
-    (options, args) = optprs.parse_args(sys.argv[1:])
+    (options, args) = argprs.parse_known_args(sys.argv[1:])
 
     # Are we debugging this?
     if options.debug:

--- a/ginga/examples/pg/example2_pg.py
+++ b/ginga/examples/pg/example2_pg.py
@@ -310,42 +310,42 @@ def main(options, args):
 
 if __name__ == "__main__":
 
-    # Parse command line options with nifty optparse module
-    from optparse import OptionParser
+    # Parse command line options
+    from argparse import ArgumentParser
 
-    usage = "usage: %prog [options] cmd [args]"
-    optprs = OptionParser(usage=usage, version=('%%prog'))
+    usage = "usage: %prog [options] [args]"
+    argprs = ArgumentParser(usage=usage)
 
-    optprs.add_option("--debug", dest="debug", default=False, action="store_true",
-                      help="Enter the pdb debugger on main()")
-    optprs.add_option("--host", dest="host", metavar="HOST",
-                      default='localhost',
-                      help="Listen on HOST for connections")
-    optprs.add_option("--log", dest="logfile", metavar="FILE",
-                      help="Write logging output to FILE")
-    optprs.add_option("--loglevel", dest="loglevel", metavar="LEVEL",
-                      type='int', default=logging.INFO,
-                      help="Set logging level to LEVEL")
-    optprs.add_option("--opencv", dest="use_opencv", default=False,
-                      action="store_true",
-                      help="Use OpenCv acceleration")
-    optprs.add_option("--opencl", dest="use_opencl", default=False,
-                      action="store_true",
-                      help="Use OpenCL acceleration")
-    optprs.add_option("--port", dest="port", metavar="PORT",
-                      type=int, default=9909,
-                      help="Listen on PORT for connections")
-    optprs.add_option("--profile", dest="profile", action="store_true",
-                      default=False,
-                      help="Run the profiler on main()")
-    optprs.add_option("--stderr", dest="logstderr", default=False,
-                      action="store_true",
-                      help="Copy logging also to stderr")
-    optprs.add_option("-t", "--toolkit", dest="toolkit", metavar="NAME",
-                      default='qt',
-                      help="Choose GUI toolkit (gtk|qt)")
+    argprs.add_argument("--debug", dest="debug", default=False, action="store_true",
+                        help="Enter the pdb debugger on main()")
+    argprs.add_argument("--host", dest="host", metavar="HOST",
+                        default='localhost',
+                        help="Listen on HOST for connections")
+    argprs.add_argument("--log", dest="logfile", metavar="FILE",
+                        help="Write logging output to FILE")
+    argprs.add_argument("--loglevel", dest="loglevel", metavar="LEVEL",
+                        type=int, default=logging.INFO,
+                        help="Set logging level to LEVEL")
+    argprs.add_argument("--opencv", dest="use_opencv", default=False,
+                        action="store_true",
+                        help="Use OpenCv acceleration")
+    argprs.add_argument("--opencl", dest="use_opencl", default=False,
+                        action="store_true",
+                        help="Use OpenCL acceleration")
+    argprs.add_argument("--port", dest="port", metavar="PORT",
+                        type=int, default=9909,
+                        help="Listen on PORT for connections")
+    argprs.add_argument("--profile", dest="profile", action="store_true",
+                        default=False,
+                        help="Run the profiler on main()")
+    argprs.add_argument("--stderr", dest="logstderr", default=False,
+                        action="store_true",
+                        help="Copy logging also to stderr")
+    argprs.add_argument("-t", "--toolkit", dest="toolkit", metavar="NAME",
+                        default='qt',
+                        help="Choose GUI toolkit (gtk|qt)")
 
-    (options, args) = optprs.parse_args(sys.argv[1:])
+    (options, args) = argprs.parse_known_args(sys.argv[1:])
 
     # Are we debugging this?
     if options.debug:

--- a/ginga/examples/qt/example2_qt.py
+++ b/ginga/examples/qt/example2_qt.py
@@ -303,27 +303,27 @@ def main(options, args):
 
 if __name__ == "__main__":
 
-    # Parse command line options with nifty optparse module
-    from optparse import OptionParser
+    # Parse command line options
+    from argparse import ArgumentParser
 
-    usage = "usage: %prog [options] cmd [args]"
-    optprs = OptionParser(usage=usage, version=('%%prog'))
+    usage = "usage: %prog [options] [args]"
+    argprs = ArgumentParser(usage=usage)
 
-    optprs.add_option("--debug", dest="debug", default=False,
-                      action="store_true",
-                      help="Enter the pdb debugger on main()")
-    optprs.add_option("--opencv", dest="opencv", default=False,
-                      action="store_true",
-                      help="Use OpenCv acceleration")
-    optprs.add_option("--opencl", dest="opencl", default=False,
-                      action="store_true",
-                      help="Use OpenCL acceleration")
-    optprs.add_option("--profile", dest="profile", action="store_true",
-                      default=False,
-                      help="Run the profiler on main()")
-    log.addlogopts(optprs)
+    argprs.add_argument("--debug", dest="debug", default=False,
+                        action="store_true",
+                        help="Enter the pdb debugger on main()")
+    argprs.add_argument("--opencv", dest="opencv", default=False,
+                        action="store_true",
+                        help="Use OpenCv acceleration")
+    argprs.add_argument("--opencl", dest="opencl", default=False,
+                        action="store_true",
+                        help="Use OpenCL acceleration")
+    argprs.add_argument("--profile", dest="profile", action="store_true",
+                        default=False,
+                        help="Run the profiler on main()")
+    log.addlogopts(argprs)
 
-    (options, args) = optprs.parse_args(sys.argv[1:])
+    (options, args) = argprs.parse_known_args(sys.argv[1:])
 
     # Are we debugging this?
     if options.debug:

--- a/ginga/examples/qt/example_asdf.py
+++ b/ginga/examples/qt/example_asdf.py
@@ -309,27 +309,27 @@ def main(options, args):
 
 if __name__ == "__main__":
 
-    # Parse command line options with nifty optparse module
-    from optparse import OptionParser
+    # Parse command line options
+    from argparse import ArgumentParser
 
-    usage = "usage: %prog [options] cmd [args]"
-    optprs = OptionParser(usage=usage, version=('%%prog'))
+    usage = "usage: %prog [options] [args]"
+    argprs = ArgumentParser(usage=usage)
 
-    optprs.add_option("--debug", dest="debug", default=False,
-                      action="store_true",
-                      help="Enter the pdb debugger on main()")
-    optprs.add_option("--opencv", dest="opencv", default=False,
-                      action="store_true",
-                      help="Use OpenCv acceleration")
-    optprs.add_option("--opencl", dest="opencl", default=False,
-                      action="store_true",
-                      help="Use OpenCL acceleration")
-    optprs.add_option("--profile", dest="profile", action="store_true",
-                      default=False,
-                      help="Run the profiler on main()")
-    log.addlogopts(optprs)
+    argprs.add_argument("--debug", dest="debug", default=False,
+                        action="store_true",
+                        help="Enter the pdb debugger on main()")
+    argprs.add_argument("--opencv", dest="opencv", default=False,
+                        action="store_true",
+                        help="Use OpenCv acceleration")
+    argprs.add_argument("--opencl", dest="opencl", default=False,
+                        action="store_true",
+                        help="Use OpenCL acceleration")
+    argprs.add_argument("--profile", dest="profile", action="store_true",
+                        default=False,
+                        help="Run the profiler on main()")
+    log.addlogopts(argprs)
 
-    (options, args) = optprs.parse_args(sys.argv[1:])
+    (options, args) = argprs.parse_known_args(sys.argv[1:])
 
     # Are we debugging this?
     if options.debug:

--- a/ginga/examples/tk/example2_tk.py
+++ b/ginga/examples/tk/example2_tk.py
@@ -202,21 +202,21 @@ def main(options, args):
 
 if __name__ == "__main__":
 
-    # Parse command line options with nifty optparse module
-    from optparse import OptionParser
+    # Parse command line options
+    from argparse import ArgumentParser
 
-    usage = "usage: %prog [options] cmd [args]"
-    optprs = OptionParser(usage=usage, version=('%%prog'))
+    usage = "usage: %prog [options] [args]"
+    argprs = ArgumentParser(usage=usage)
 
-    optprs.add_option("--debug", dest="debug", default=False,
-                      action="store_true",
-                      help="Enter the pdb debugger on main()")
-    optprs.add_option("--profile", dest="profile", action="store_true",
-                      default=False,
-                      help="Run the profiler on main()")
-    log.addlogopts(optprs)
+    argprs.add_argument("--debug", dest="debug", default=False,
+                        action="store_true",
+                        help="Enter the pdb debugger on main()")
+    argprs.add_argument("--profile", dest="profile", action="store_true",
+                        default=False,
+                        help="Run the profiler on main()")
+    log.addlogopts(argprs)
 
-    (options, args) = optprs.parse_args(sys.argv[1:])
+    (options, args) = argprs.parse_known_args(sys.argv[1:])
 
     # Are we debugging this?
     if options.debug:

--- a/ginga/misc/grc.py
+++ b/ginga/misc/grc.py
@@ -16,7 +16,7 @@ Show example usage (plugin must be started)::
 """
 
 import sys
-from optparse import OptionParser
+from argparse import ArgumentParser
 
 from ..util import grc as _grc
 
@@ -48,22 +48,22 @@ def main(options, args):
 
 def _main():
     """Run from command line."""
-    usage = "usage: %prog [options] cmd [arg] ..."
-    optprs = OptionParser(usage=usage, version=version)
+    usage = "usage: %prog [options] [args]"
+    argprs = ArgumentParser(usage=usage)
 
-    optprs.add_option("--debug", dest="debug", default=False,
-                      action="store_true",
-                      help="Enter the pdb debugger on main()")
-    optprs.add_option("--host", dest="host", metavar="HOST",
-                      default="localhost", help="Connect to server at HOST")
-    optprs.add_option("--port", dest="port", type="int",
-                      default=9000, metavar="PORT",
-                      help="Connect to server at PORT")
-    optprs.add_option("--profile", dest="profile", action="store_true",
-                      default=False,
-                      help="Run the profiler on main()")
+    argprs.add_argument("--debug", dest="debug", default=False,
+                        action="store_true",
+                        help="Enter the pdb debugger on main()")
+    argprs.add_argument("--host", dest="host", metavar="HOST",
+                        default="localhost", help="Connect to server at HOST")
+    argprs.add_argument("--port", dest="port", type=int,
+                        default=9000, metavar="PORT",
+                        help="Connect to server at PORT")
+    argprs.add_argument("--profile", dest="profile", action="store_true",
+                        default=False,
+                        help="Run the profiler on main()")
 
-    (options, args) = optprs.parse_args(sys.argv[1:])
+    (options, args) = argprs.parse_known_args(sys.argv[1:])
 
     # Are we debugging this?
     if options.debug:

--- a/ginga/rv/main.py
+++ b/ginga/rv/main.py
@@ -216,62 +216,69 @@ class ReferenceViewer(object):
                 print("Error trying to instantiate external plugin using %s: %s" % (
                     str(method), str(e)))
 
-    def add_default_options(self, optprs):
+    def add_default_options(self, argprs):
         """
         Adds the default reference viewer startup options to an
-        OptionParser instance `optprs`.
+        ArgumentParser instance `argprs`.
         """
-        optprs.add_option("--bufsize", dest="bufsize", metavar="NUM",
-                          type="int", default=10,
-                          help="Buffer length to NUM")
-        optprs.add_option('-c', "--channels", dest="channels",
-                          help="Specify list of channels to create")
-        optprs.add_option("--debug", dest="debug", default=False,
-                          action="store_true",
-                          help="Enter the pdb debugger on main()")
-        optprs.add_option("--disable-plugins", dest="disable_plugins",
-                          metavar="NAMES",
-                          help="Specify plugins that should be disabled")
-        optprs.add_option("--display", dest="display", metavar="HOST:N",
-                          help="Use X display on HOST:N")
-        optprs.add_option("--fitspkg", dest="fitspkg", metavar="NAME",
-                          default=None,
-                          help="Prefer FITS I/O module NAME")
-        optprs.add_option("-g", "--geometry", dest="geometry",
-                          default=None, metavar="GEOM",
-                          help="X geometry for initial size and placement")
-        optprs.add_option("--modules", dest="modules", metavar="NAMES",
-                          help="Specify additional modules to load")
-        optprs.add_option("--norestore", dest="norestore", default=False,
-                          action="store_true",
-                          help="Don't restore the GUI from a saved layout")
-        optprs.add_option("--nosplash", dest="nosplash", default=False,
-                          action="store_true",
-                          help="Don't display the splash screen")
-        optprs.add_option("--numthreads", dest="numthreads", type="int",
-                          default=30, metavar="NUM",
-                          help="Start NUM threads in thread pool")
-        optprs.add_option("--opencv", dest="opencv", default=False,
-                          action="store_true",
-                          help="Use OpenCv acceleration")
-        optprs.add_option("--opencl", dest="opencl", default=False,
-                          action="store_true",
-                          help="Use OpenCL acceleration")
-        optprs.add_option("--plugins", dest="plugins", metavar="NAMES",
-                          help="Specify additional plugins to load")
-        optprs.add_option("--profile", dest="profile", action="store_true",
-                          default=False,
-                          help="Run the profiler on main()")
-        optprs.add_option("--sep", dest="separate_channels", default=False,
-                          action="store_true",
-                          help="Load files in separate channels")
-        optprs.add_option("-t", "--toolkit", dest="toolkit", metavar="NAME",
-                          default=None,
-                          help="Prefer GUI toolkit (gtk|qt)")
-        optprs.add_option("--wcspkg", dest="wcspkg", metavar="NAME",
-                          default=None,
-                          help="Prefer WCS module NAME")
-        log.addlogopts(optprs)
+        if hasattr(argprs, 'add_option'):
+            # older OptParse
+            add_argument = argprs.add_option
+        else:
+            # newer ArgParse
+            add_argument = argprs.add_argument
+
+        add_argument("--bufsize", dest="bufsize", metavar="NUM",
+                     type=int, default=10,
+                     help="Buffer length to NUM")
+        add_argument('-c', "--channels", dest="channels",
+                     help="Specify list of channels to create")
+        add_argument("--debug", dest="debug", default=False,
+                     action="store_true",
+                     help="Enter the pdb debugger on main()")
+        add_argument("--disable-plugins", dest="disable_plugins",
+                     metavar="NAMES",
+                     help="Specify plugins that should be disabled")
+        add_argument("--display", dest="display", metavar="HOST:N",
+                     help="Use X display on HOST:N")
+        add_argument("--fitspkg", dest="fitspkg", metavar="NAME",
+                     default=None,
+                     help="Prefer FITS I/O module NAME")
+        add_argument("-g", "--geometry", dest="geometry",
+                     default=None, metavar="GEOM",
+                     help="X geometry for initial size and placement")
+        add_argument("--modules", dest="modules", metavar="NAMES",
+                     help="Specify additional modules to load")
+        add_argument("--norestore", dest="norestore", default=False,
+                     action="store_true",
+                     help="Don't restore the GUI from a saved layout")
+        add_argument("--nosplash", dest="nosplash", default=False,
+                     action="store_true",
+                     help="Don't display the splash screen")
+        add_argument("--numthreads", dest="numthreads", type=int,
+                     default=30, metavar="NUM",
+                     help="Start NUM threads in thread pool")
+        add_argument("--opencv", dest="opencv", default=False,
+                     action="store_true",
+                     help="Use OpenCv acceleration")
+        add_argument("--opencl", dest="opencl", default=False,
+                     action="store_true",
+                     help="Use OpenCL acceleration")
+        add_argument("--plugins", dest="plugins", metavar="NAMES",
+                     help="Specify additional plugins to load")
+        add_argument("--profile", dest="profile", action="store_true",
+                     default=False,
+                     help="Run the profiler on main()")
+        add_argument("--sep", dest="separate_channels", default=False,
+                     action="store_true",
+                     help="Load files in separate channels")
+        add_argument("-t", "--toolkit", dest="toolkit", metavar="NAME",
+                     default=None,
+                     help="Prefer GUI toolkit (gtk|qt)")
+        add_argument("--wcspkg", dest="wcspkg", metavar="NAME",
+                     default=None,
+                     help="Prefer WCS module NAME")
+        log.addlogopts(argprs)
 
     def main(self, options, args):
         """
@@ -695,15 +702,15 @@ def reference_viewer(sys_argv):
     viewer.add_default_plugins()
     viewer.add_separately_distributed_plugins()
 
-    # Parse command line options with optparse module
-    from optparse import OptionParser
+    # Parse command line options with argparse module
+    from argparse import ArgumentParser
 
     usage = "usage: %prog [options] cmd [args]"
-    optprs = OptionParser(usage=usage,
-                          version=('%%prog %s' % version.version))
-    viewer.add_default_options(optprs)
-
-    (options, args) = optprs.parse_args(sys_argv[1:])
+    argprs = ArgumentParser(usage=usage)
+    viewer.add_default_options(argprs)
+    argprs.add_argument('-V', '--version', action='version',
+                        version='%(prog)s {}'.format(version.version))
+    (options, args) = argprs.parse_known_args(sys_argv[1:])
 
     if options.display:
         os.environ['DISPLAY'] = options.display

--- a/ginga/util/mosaic.py
+++ b/ginga/util/mosaic.py
@@ -110,32 +110,33 @@ def main(options, args):
 
 if __name__ == "__main__":
 
-    # Parse command line options with nifty optparse module
-    from optparse import OptionParser
+    # Parse command line options
+    from argparse import ArgumentParser
 
-    usage = "usage: %prog [options] cmd [args]"
-    optprs = OptionParser(usage=usage, version=('%%prog'))
+    usage = "usage: %prog [options] [args]"
+    argprs = ArgumentParser(usage=usage)
 
-    optprs.add_option("--debug", dest="debug", default=False, action="store_true",
-                      help="Enter the pdb debugger on main()")
-    optprs.add_option("--fov", dest="fov", metavar="DEG",
-                      type='float',
-                      help="Set output field of view")
-    optprs.add_option("--log", dest="logfile", metavar="FILE",
-                      help="Write logging output to FILE")
-    optprs.add_option("--loglevel", dest="loglevel", metavar="LEVEL",
-                      type='int',
-                      help="Set logging level to LEVEL")
-    optprs.add_option("-o", "--outfile", dest="outfile", metavar="FILE",
-                      help="Write mosaic output to FILE")
-    optprs.add_option("--stderr", dest="logstderr", default=False,
-                      action="store_true",
-                      help="Copy logging also to stderr")
-    optprs.add_option("--profile", dest="profile", action="store_true",
-                      default=False,
-                      help="Run the profiler on main()")
+    argprs.add_argument("--debug", dest="debug", default=False,
+                        action="store_true",
+                        help="Enter the pdb debugger on main()")
+    argprs.add_argument("--fov", dest="fov", metavar="DEG",
+                        type=float,
+                        help="Set output field of view")
+    argprs.add_argument("--log", dest="logfile", metavar="FILE",
+                        help="Write logging output to FILE")
+    argprs.add_argument("--loglevel", dest="loglevel", metavar="LEVEL",
+                        type=int,
+                        help="Set logging level to LEVEL")
+    argprs.add_argument("-o", "--outfile", dest="outfile", metavar="FILE",
+                        help="Write mosaic output to FILE")
+    argprs.add_argument("--stderr", dest="logstderr", default=False,
+                        action="store_true",
+                        help="Copy logging also to stderr")
+    argprs.add_argument("--profile", dest="profile", action="store_true",
+                        default=False,
+                        help="Run the profiler on main()")
 
-    (options, args) = optprs.parse_args(sys.argv[1:])
+    (options, args) = argprs.parse_known_args(sys.argv[1:])
 
     # Are we debugging this?
     if options.debug:

--- a/ginga/web/pgw/ipg.py
+++ b/ginga/web/pgw/ipg.py
@@ -511,42 +511,42 @@ def main(options, args):
 
 if __name__ == "__main__":
 
-    # Parse command line options with nifty optparse module
-    from optparse import OptionParser
+    # Parse command line options
+    from argparse import ArgumentParser
 
-    usage = "usage: %prog [options] cmd [args]"
-    optprs = OptionParser(usage=usage, version=('%%prog'))
+    usage = "usage: %prog [options] [args]"
+    argprs = ArgumentParser(usage=usage)
 
-    optprs.add_option("-d", "--basedir", dest="basedir", metavar="DIR",
-                      default=".",
-                      help="Directory which is at the base of file open requests")
-    optprs.add_option("--debug", dest="debug", default=False, action="store_true",
-                      help="Enter the pdb debugger on main()")
-    optprs.add_option("--host", dest="host", metavar="HOST",
-                      default="localhost",
-                      help="HOST used to decide which interfaces to listen on")
-    optprs.add_option("--log", dest="logfile", metavar="FILE",
-                      help="Write logging output to FILE")
-    optprs.add_option("--loglevel", dest="loglevel", metavar="LEVEL",
-                      type='int', default=logging.INFO,
-                      help="Set logging level to LEVEL")
-    optprs.add_option("--numthreads", dest="numthreads", type="int",
-                      default=5, metavar="NUM",
-                      help="Start NUM threads in thread pool")
-    optprs.add_option("--stderr", dest="logstderr", default=False,
-                      action="store_true",
-                      help="Copy logging also to stderr")
-    optprs.add_option("--opencv", dest="use_opencv", default=False,
-                      action="store_true",
-                      help="Use OpenCv acceleration")
-    optprs.add_option("-p", "--port", dest="port",
-                      type='int', default=9909, metavar="PORT",
-                      help="Default PORT to use for the web socket")
-    optprs.add_option("--profile", dest="profile", action="store_true",
-                      default=False,
-                      help="Run the profiler on main()")
+    argprs.add_argument("-d", "--basedir", dest="basedir", metavar="DIR",
+                        default=".",
+                        help="Directory which is at the base of file open requests")
+    argprs.add_argument("--debug", dest="debug", default=False, action="store_true",
+                        help="Enter the pdb debugger on main()")
+    argprs.add_argument("--host", dest="host", metavar="HOST",
+                        default="localhost",
+                        help="HOST used to decide which interfaces to listen on")
+    argprs.add_argument("--log", dest="logfile", metavar="FILE",
+                        help="Write logging output to FILE")
+    argprs.add_argument("--loglevel", dest="loglevel", metavar="LEVEL",
+                        type=int, default=logging.INFO,
+                        help="Set logging level to LEVEL")
+    argprs.add_argument("--numthreads", dest="numthreads", type=int,
+                        default=5, metavar="NUM",
+                        help="Start NUM threads in thread pool")
+    argprs.add_argument("--stderr", dest="logstderr", default=False,
+                        action="store_true",
+                        help="Copy logging also to stderr")
+    argprs.add_argument("--opencv", dest="use_opencv", default=False,
+                        action="store_true",
+                        help="Use OpenCv acceleration")
+    argprs.add_argument("-p", "--port", dest="port",
+                        type=int, default=9909, metavar="PORT",
+                        help="Default PORT to use for the web socket")
+    argprs.add_argument("--profile", dest="profile", action="store_true",
+                        default=False,
+                        help="Run the profiler on main()")
 
-    (options, args) = optprs.parse_args(sys.argv[1:])
+    (options, args) = argprs.parse_known_args(sys.argv[1:])
 
     # Are we debugging this?
     if options.debug:


### PR DESCRIPTION
`optparse` will be deprecated in Python.  This changes uses to `argparse`, the heir apparent.
