### PR TITLE
EXP: Support JWST ASDF-in-FITS in reference viewer

### DIFF
--- a/ginga/util/io_asdf.py
+++ b/ginga/util/io_asdf.py
@@ -20,7 +20,7 @@ from ginga.util import iohelper
 __all__ = ['have_asdf', 'load_asdf', 'ASDFFileHandler']
 
 
-def load_asdf(asdf_obj, data_key='sci', wcs_key='wcs', header_key='meta'):
+def load_asdf(asdf_obj, data_key='data', wcs_key='wcs', header_key='meta'):
     """
     Load from an ASDF object.
 
@@ -49,6 +49,8 @@ def load_asdf(asdf_obj, data_key='sci', wcs_key='wcs', header_key='meta'):
 
     if wcs_key in asdf_keys:
         wcs = asdf_obj[wcs_key]
+    elif wcs_key in asdf_obj[header_key]:
+        wcs = asdf_obj[header_key][wcs_key]
     else:
         wcs = None
 
@@ -60,6 +62,11 @@ def load_asdf(asdf_obj, data_key='sci', wcs_key='wcs', header_key='meta'):
     # TODO: What about non-image ASDF data, such as table?
     if data_key in asdf_keys:
         data = np.asarray(asdf_obj[data_key])
+    # TODO: This hack is so earlier test files would still
+    # load, but we need to make customization easier so
+    # we can remove this hack.
+    elif 'sci' in asdf_keys:
+        data = np.asarray(asdf_obj['sci'])
     else:
         data = None
 

--- a/ginga/util/wcsmod/wcs_astropy_ape14.py
+++ b/ginga/util/wcsmod/wcs_astropy_ape14.py
@@ -226,6 +226,10 @@ class AstropyWCS(common.BaseWCS):
         """
         if self.coordsys == 'raw':
             raise common.WCSError("No usable WCS")
+        elif self.coordsys == 'world':
+            coordsys = 'icrs'
+        else:
+            coordsys = self.coordsys
 
         if system is None:
             system = 'icrs'
@@ -233,8 +237,7 @@ class AstropyWCS(common.BaseWCS):
         # Get a coordinates object based on ra/dec wcs transform
         wcspt = self.datapt_to_wcspt(datapt, coords=coords,
                                      naxispath=naxispath)
-        frame_class = coordinates.frame_transform_graph.lookup_name(
-            self.coordsys)
+        frame_class = coordinates.frame_transform_graph.lookup_name(coordsys)
         ra_deg = wcspt[:, 0]
         dec_deg = wcspt[:, 1]
         coord = frame_class(ra_deg * u.degree, dec_deg * u.degree)


### PR DESCRIPTION
~Need to discuss how to best generalize the ASDF loading in reference viewer. This might change depending on how #764 goes (currently does not depend on it).~ Will just roll with this and follow up in a separate PR after #764 is rebased on this and merged.

These are the changes necessary for Python in Astronomy 2019 demo using Ginga standalone GUI (reference viewer) to view ASDF-in-FITS data file generated by JWST. Follow up of #719. Also see spacetelescope/stginga#155

cc @jdavies-st (in case you are interested), @hcferguson , and @eteq 

~Figure out why compass in `Pan` appears weird for the ASDF extension, but not FITS. Maybe spacetelescope/gwcs#241 ?~

**Future work:**

- Ginga should not emit error when RA or Dec is `NaN`, but instead silently format the string to something equivalent (the default "BAD WCS" is probably a little misleading in this case). See #782 
- Figure out a better way to support ASDF loader customization.