### PR TITLE
Support astropy regions

### DIFF
--- a/doc/WhatsNew.rst
+++ b/doc/WhatsNew.rst
@@ -39,8 +39,8 @@ Ver 3.0.0 (unreleased)
 - New file opener framework
 - Text objects can be resized and rotated in edit mode on the canvas
 - Added ellipse and box annulus types as Annulus2R canvas object
-- Supports plotting ds9 regions via 2-way conversion between Ginga canvas
-  types and AstroPy regions
+- Supports plotting DS9 regions via 2-way conversion between Ginga canvas
+  types and Astropy regions
 
 Ver 2.7.2 (2018-11-05)
 ======================

--- a/doc/WhatsNew.rst
+++ b/doc/WhatsNew.rst
@@ -38,6 +38,9 @@ Ver 3.0.0 (unreleased)
   hexagon, uptriangle, downtriangle
 - New file opener framework
 - Text objects can be resized and rotated in edit mode on the canvas
+- Added ellipse and box annulus types as Annulus2R canvas object
+- Supports plotting ds9 regions via 2-way conversion between Ginga canvas
+  types and AstroPy regions
 
 Ver 2.7.2 (2018-11-05)
 ======================

--- a/doc/dev_manual/canvas.rst
+++ b/doc/dev_manual/canvas.rst
@@ -93,19 +93,19 @@ different widget set's "native" canvas using a ``CanvasRenderer``
 customized for that target. 
 
 
-Support for astropy regions
+Support for Astropy regions
 ===========================
-Ginga provides a module for plotting `astropy` `regions` shapes on
+Ginga provides a module for plotting Astropy ``regions`` shapes on
 canvases.  To use this, import the ``ginga.util.ap_regions`` module and
 use one of the three module functions
 ``astropy_region_to_ginga_canvas_object``, ``add_region``, or
 ``ginga_canvas_object_to_astropy_region``.
 
-``astropy_region_to_ginga_canvas_object`` takes a regions shape and
-returns a ginga canvas object that most closely implements the shape.
-The object returned can be used like any ginga canvas object: it can be
+``astropy_region_to_ginga_canvas_object`` takes a ``regions`` shape and
+returns a Ginga canvas object that most closely implements the shape.
+The object returned can be used like any Ginga canvas object: it can be
 used in a compound object, added to a canvas, etc.
-Assuming you have a viewer `v` and an astropy region `r`:
+Assuming you have a viewer ``v`` and an Astropy region ``r``:
 
 .. code-block:: python
 
@@ -119,11 +119,11 @@ adding it to a canvas.
 
 .. code-block:: python
 
-    ap_region.add_canvas(canvas, r)
+    ap_region.add_region(canvas, r)
 
 ``ginga_canvas_object_to_astropy_region`` provides the reverse
-transformation, taking a ginga canvas object and converting it to the
-closest representation as an astropy region.
+transformation, taking a Ginga canvas object and converting it to the
+closest representation as an Astropy region.
 
 .. code-block:: python
 

--- a/doc/dev_manual/canvas.rst
+++ b/doc/dev_manual/canvas.rst
@@ -92,3 +92,40 @@ The various subclasses of ``ImageView`` are designed to render into a
 different widget set's "native" canvas using a ``CanvasRenderer``
 customized for that target. 
 
+
+Support for astropy regions
+===========================
+Ginga provides a module for plotting `astropy` `regions` shapes on
+canvases.  To use this, import the ``ginga.util.ap_regions`` module and
+use one of the three module functions
+``astropy_region_to_ginga_canvas_object``, ``add_region``, or
+``ginga_canvas_object_to_astropy_region``.
+
+``astropy_region_to_ginga_canvas_object`` takes a regions shape and
+returns a ginga canvas object that most closely implements the shape.
+The object returned can be used like any ginga canvas object: it can be
+used in a compound object, added to a canvas, etc.
+Assuming you have a viewer `v` and an astropy region `r`:
+
+.. code-block:: python
+
+    from ginga.util import ap_region
+    obj = ap_region.astropy_region_to_ginga_canvas_object(r)
+    canvas = v.get_canvas()
+    canvas.add(obj)
+
+``add_region`` is a convenience method for both converting an object and
+adding it to a canvas.  
+
+.. code-block:: python
+
+    ap_region.add_canvas(canvas, r)
+
+``ginga_canvas_object_to_astropy_region`` provides the reverse
+transformation, taking a ginga canvas object and converting it to the
+closest representation as an astropy region.
+
+.. code-block:: python
+
+    r = ap_region.ginga_canvas_object_to_astropy_region(obj)
+

--- a/doc/dev_manual/canvas.rst
+++ b/doc/dev_manual/canvas.rst
@@ -34,7 +34,8 @@ objects includes:
 * ``Compass`` -- a compass defined by a point and a radius.
 * ``Ruler`` -- a ruler defined by two points.
 * ``Crosshair`` -- a crosshair defined by one point.
-* ``Annulus`` -- an annulus defined by one point and two radii.
+* ``Annulus`` -- an annulus defined by one point, a radius and a width.
+* ``Annulus2R`` -- an annulus defined by one point, two radii and two widths.
 * ``Image`` -- a raster image anchored by a point.
 * ``NormImage`` -- a subclass of ``Image``, with rendering done with the
   aid of a colormap, a color distribution algorithm (linear, log, etc),

--- a/doc/ref_api.rst
+++ b/doc/ref_api.rst
@@ -36,3 +36,6 @@ Reference/API
 
 .. automodapi:: ginga.util.wcs
    :no-inheritance-diagram:
+
+.. automodapi:: ginga.util.ap_region
+   :no-inheritance-diagram:

--- a/ginga/canvas/types/astro.py
+++ b/ginga/canvas/types/astro.py
@@ -777,7 +777,7 @@ class Annulus2R(AnnulusMixin, OnePointTwoRadiusMixin, CompoundObject):
             Param(name='ywidth', type=float, default=None,
                   min=0.0,
                   description="Width in Y of annulus"),
-            Param(name='atype', type=str, default='circle',
+            Param(name='atype', type=str, default='ellipse',
                   valid=['ellipse', 'box'],
                   description="Type of annulus"),
             Param(name='linewidth', type=int, default=1,
@@ -803,7 +803,7 @@ class Annulus2R(AnnulusMixin, OnePointTwoRadiusMixin, CompoundObject):
         return cls(cxt.start_x, cxt.start_y, xradius, yradius, **cxt.drawparams)
 
     def __init__(self, x, y, xradius, yradius, xwidth=None,
-                 ywidth=None, atype='box', color='yellow',
+                 ywidth=None, atype='ellipse', color='yellow',
                  linewidth=1, linestyle='solid', alpha=1.0,
                  rot_deg=0.0, **kwdargs):
 

--- a/ginga/canvas/types/astro.py
+++ b/ginga/canvas/types/astro.py
@@ -19,11 +19,12 @@ from ginga.misc import Bunch
 from ginga.util import wcs
 from ginga.util.wcs import raDegToString, decDegToString
 
-from .mixins import OnePointMixin, TwoPointMixin, OnePointOneRadiusMixin
+from .mixins import (OnePointMixin, TwoPointMixin, OnePointOneRadiusMixin,
+                     OnePointTwoRadiusMixin)
 from .layer import CompoundObject
 
 __all__ = ['Ruler', 'Compass', 'Crosshair', 'AnnulusMixin', 'Annulus',
-           'WCSAxes']
+           'Annulus2R', 'WCSAxes']
 
 
 class Ruler(TwoPointMixin, CanvasObjectBase):
@@ -741,6 +742,210 @@ class Annulus(AnnulusMixin, OnePointOneRadiusMixin, CompoundObject):
         self.set_data_points([dst_pt])
 
 
+class Annulus2R(AnnulusMixin, OnePointTwoRadiusMixin, CompoundObject):
+    """
+    Special compound object to handle annulus shape that
+    consists of two objects, (one center point, plus two radii).
+
+    Examples
+    --------
+    >>> tag = canvas.add(Annulus2R(100, 200, 10, 20, width=5, atype='box'))
+    >>> obj = canvas.get_object_by_tag(tag)
+    >>> arr_masked = image.cutout_shape(obj)
+
+    """
+    @classmethod
+    def get_params_metadata(cls):
+        return [
+            Param(name='coord', type=str, default='data',
+                  valid=coord_names,
+                  description="Set type of coordinates"),
+            Param(name='x', type=float, default=0.0, argpos=0,
+                  description="X coordinate of center of object"),
+            Param(name='y', type=float, default=0.0, argpos=1,
+                  description="Y coordinate of center of object"),
+            Param(name='xradius', type=float, default=1.0, argpos=2,
+                  min=0.0,
+                  description="Inner X radius of annulus"),
+            Param(name='yradius', type=float, default=1.0, argpos=2,
+                  min=0.0,
+                  description="Inner Y radius of annulus"),
+            Param(name='xwidth', type=float, default=None,
+                  min=0.0,
+                  description="Width in X of annulus"),
+            Param(name='ywidth', type=float, default=None,
+                  min=0.0,
+                  description="Width in Y of annulus"),
+            Param(name='atype', type=str, default='circle',
+                  valid=['ellipse', 'box'],
+                  description="Type of annulus"),
+            Param(name='linewidth', type=int, default=1,
+                  min=1, max=20, widget='spinbutton', incr=1,
+                  description="Width of outline"),
+            Param(name='linestyle', type=str, default='solid',
+                  valid=['solid', 'dash'],
+                  description="Style of outline (default solid)"),
+            Param(name='color',
+                  valid=colors_plus_none, type=_color, default='yellow',
+                  description="Color of outline"),
+            Param(name='alpha', type=float, default=1.0,
+                  min=0.0, max=1.0, widget='spinfloat', incr=0.05,
+                  description="Opacity of outline"),
+            Param(name='rot_deg', type=float, default=0.0,
+                  min=-359.999, max=359.999, widget='spinfloat', incr=1.0,
+                  description="Rotation about center of object"),
+        ]
+
+    @classmethod
+    def idraw(cls, canvas, cxt):
+        xradius, yradius = abs(cxt.start_x - cxt.x), abs(cxt.start_y - cxt.y)
+        return cls(cxt.start_x, cxt.start_y, xradius, yradius, **cxt.drawparams)
+
+    def __init__(self, x, y, xradius, yradius, xwidth=None,
+                 ywidth=None, atype='box', color='yellow',
+                 linewidth=1, linestyle='solid', alpha=1.0,
+                 rot_deg=0.0, **kwdargs):
+
+        if xwidth is None:
+            # default X width is 15% of X radius
+            xwidth = 0.15 * xradius
+        if ywidth is None:
+            # default Y width is X width
+            ywidth = xwidth
+        oxradius = xradius + xwidth
+        oyradius = yradius + ywidth
+
+        if oxradius < xradius or oyradius < yradius:
+            raise ValueError('Outer boundary < inner boundary')
+
+        coord = kwdargs.get('coord', None)
+
+        klass = get_canvas_type(atype)
+        obj1 = klass(x, y, xradius, yradius, color=color,
+                     linewidth=linewidth,
+                     linestyle=linestyle, alpha=alpha,
+                     coord=coord, rot_deg=rot_deg)
+        obj1.editable = False
+
+        obj2 = klass(x, y, oxradius, oyradius, color=color,
+                     linewidth=linewidth,
+                     linestyle=linestyle, alpha=alpha,
+                     coord=coord, rot_deg=rot_deg)
+        obj2.editable = False
+
+        points = np.asarray([(x, y)], dtype=np.float)
+
+        CompoundObject.__init__(self, obj1, obj2,
+                                points=points, xradius=xradius, yradius=yradius,
+                                xwidth=xwidth, ywidth=ywidth, color=color,
+                                linewidth=linewidth, linestyle=linestyle,
+                                alpha=alpha, rot_deg=rot_deg, **kwdargs)
+        OnePointTwoRadiusMixin.__init__(self)
+
+        self.editable = True
+        self.opaque = True
+        self.kind = 'annulus2r'
+
+    def get_edit_points(self, viewer):
+        move_pt, scale_pt, rotate_pt = self.get_move_scale_rotate_pts(viewer)
+
+        points = (self.crdmap.offset_pt((self.x, self.y),
+                                        (self.xradius, 0)),
+                  self.crdmap.offset_pt((self.x, self.y),
+                                        (0, self.yradius)),
+                  self.crdmap.offset_pt((self.x, self.y),
+                                        (self.xradius + self.xwidth, 0)),
+                  self.crdmap.offset_pt((self.x, self.y),
+                                        (0, self.yradius + self.ywidth)),
+                  )
+        points = self.get_data_points(points=points)
+        return [move_pt,    # location
+                Point(*points[0]),  # adj inner X radius
+                Point(*points[1]),  # adj inner Y radius
+                Point(*points[2]),  # adj X width
+                Point(*points[3]),  # adj Y width
+                scale_pt,
+                rotate_pt,
+                ]
+
+    def setup_edit(self, detail):
+        detail.center_pos = self.get_center_pt()
+        detail.xradius = self.xradius
+        detail.yradius = self.yradius
+        detail.xwidth = self.xwidth
+        detail.ywidth = self.ywidth
+
+    def set_edit_point(self, i, pt, detail):
+        if i == 0:
+            self.move_to_pt(pt)
+        elif i == 1:
+            # Adjust inner X radius
+            scale_x, scale_y = self.calc_dual_scale_from_pt(pt, detail)
+            self.xradius = detail.xradius * scale_x
+            #scalef = self.calc_scale_from_pt(pt, detail)
+            # inner obj radius control pt
+            #self.xradius = detail.xradius * scalef
+        elif i == 2:
+            # Adjust inner Y radius
+            scale_x, scale_y = self.calc_dual_scale_from_pt(pt, detail)
+            self.yradius = detail.yradius * scale_y
+            #scalef = self.calc_scale_from_pt(pt, detail)
+            #self.yradius = detail.yradius * scalef
+        elif i == 3:
+            # Adjust X width
+            scale_x, scale_y = self.calc_dual_scale_from_pt(pt, detail)
+            xwidth = detail.xwidth * scale_x
+            # outer obj radius control pt--calculate new width
+            assert xwidth > 0, ValueError("Must have a positive width")
+            self.xwidth = xwidth
+        elif i == 4:
+            # Adjust Y width
+            scale_x, scale_y = self.calc_dual_scale_from_pt(pt, detail)
+            ywidth = detail.ywidth * scale_y
+            # outer obj radius control pt--calculate new width
+            assert ywidth > 0, ValueError("Must have a positive width")
+            self.ywidth = ywidth
+        elif i == 5:
+            # Adjust overall scale
+            scalef = self.calc_scale_from_pt(pt, detail)
+            self.xradius = detail.xradius * scalef
+            self.yradius = detail.yradius * scalef
+        elif i == 6:
+            # Adjust rotation
+            delta_deg = self.calc_rotation_from_pt(pt, detail)
+            self.rotate_by_deg([delta_deg])
+        else:
+            raise ValueError("No point corresponding to index %d" % (i))
+
+        self.sync_state()
+
+    def sync_state(self):
+        """Called to synchronize state (e.g. when parameters have changed).
+        """
+        oxradius = self.xradius + self.xwidth
+        oyradius = self.yradius + self.ywidth
+        if oxradius < self.xradius or oyradius < self.yradius:
+            raise ValueError('Outer boundary < inner boundary')
+
+        d = dict(points=self.points, xradius=self.xradius,
+                 yradius=self.yradius, color=self.color,
+                 linewidth=self.linewidth, linestyle=self.linestyle,
+                 alpha=self.alpha, rot_deg=self.rot_deg)
+
+        # update inner object
+        self.objects[0].__dict__.update(d)
+
+        # update outer object
+        d['xradius'] = oxradius
+        d['yradius'] = oyradius
+        self.objects[1].__dict__.update(d)
+
+    def move_to_pt(self, dst_pt):
+        super(Annulus2R, self).move_to_pt(dst_pt)
+
+        self.set_data_points([dst_pt])
+
+
 class WCSAxes(CompoundObject):
     """
     Special compound object to draw WCS axes.
@@ -987,6 +1192,6 @@ class WCSAxes(CompoundObject):
 
 register_canvas_types(dict(ruler=Ruler, compass=Compass,
                            crosshair=Crosshair, annulus=Annulus,
-                           wcsaxes=WCSAxes))
+                           annulus2r=Annulus2R, wcsaxes=WCSAxes))
 
 # END

--- a/ginga/canvas/types/astro.py
+++ b/ginga/canvas/types/astro.py
@@ -679,6 +679,7 @@ class Annulus(AnnulusMixin, OnePointOneRadiusMixin, CompoundObject):
 
         self.editable = True
         self.opaque = True
+        self.atype = atype
         self.kind = 'annulus'
 
     def get_edit_points(self, viewer):
@@ -844,6 +845,7 @@ class Annulus2R(AnnulusMixin, OnePointTwoRadiusMixin, CompoundObject):
 
         self.editable = True
         self.opaque = True
+        self.atype = atype
         self.kind = 'annulus2r'
 
     def get_edit_points(self, viewer):

--- a/ginga/examples/gw/plot_ds9_regions.py
+++ b/ginga/examples/gw/plot_ds9_regions.py
@@ -1,7 +1,7 @@
 #
-# Plot ds9 regions in a Ginga viewer
+# Plot DS9 regions in a Ginga viewer
 #
-# NOTE: you need the astropy "regions" package for this to work
+# NOTE: You need the Astropy "regions" package for this to work.
 #
 from ginga import toolkit
 toolkit.use('qt5')

--- a/ginga/examples/gw/plot_ds9_regions.py
+++ b/ginga/examples/gw/plot_ds9_regions.py
@@ -1,0 +1,29 @@
+#
+# Plot ds9 regions in a Ginga viewer
+#
+# NOTE: you need the astropy "regions" package for this to work
+#
+from ginga import toolkit
+toolkit.use('qt5')
+
+from astropy.utils.data import get_pkg_data_filename
+import regions
+
+from ginga.gw import sv
+from ginga.util import ap_region
+
+vf = sv.ViewerFactory()
+v = vf.make_viewer(name="Ginga regions example", width=1000, height=1000)
+
+image_file = get_pkg_data_filename('tutorials/FITS-images/HorseHead.fits')
+v.load(image_file)
+
+ds9_file = get_pkg_data_filename('data/plot_image.reg',
+                                 package='regions.io.ds9.tests')
+regs = regions.read_ds9(ds9_file)
+
+canvas = v.add_canvas()
+for i, reg in enumerate(regs):
+    ap_region.add_region(canvas, reg)
+
+vf.mainloop()

--- a/ginga/gw/sv.py
+++ b/ginga/gw/sv.py
@@ -1,0 +1,248 @@
+#
+# sv.py -- Module for generating simple Ginga viewers
+#
+# This is open-source software licensed under a BSD license.
+# Please see the file LICENSE.txt for details.
+#
+"""
+This is a module for generating simple Ginga viewers.
+
+Example program:
+
+    from ginga import toolkit
+    toolkit.use('qt5')
+
+    from ginga.gw import sv
+
+    vf = sv.ViewerFactory()
+    v = vf.make_viewer(name="Test", width=500, height=500)
+
+    v.load("some.fits")
+    vf.mainloop()
+"""
+
+import os.path
+
+from ginga import AstroImage
+from ginga.canvas.CanvasObject import get_canvas_types
+from ginga.misc import log
+from ginga.Bindings import ImageViewBindings
+from ginga.misc.Settings import SettingGroup
+from ginga.util.paths import ginga_home
+from ginga.util import loader
+
+from ginga.gw import Widgets, Viewers
+
+
+class BasicCanvasView(Viewers.CanvasView):
+
+    def build_gui(self, container):
+        """
+        This is responsible for building the viewer's UI.  It should
+        place the UI in `container`.  Override this to make a custom
+        UI.
+        """
+        self.frame = Viewers.GingaScrolledViewerWidget(viewer=self)
+        container.set_widget(self.frame)
+
+    def load(self, filepath):
+        """
+        Load a file into the viewer.
+        """
+        image = loader.load_data(filepath, logger=self.logger)
+        self.set_image(image)
+
+    def load_hdu(self, hdu):
+        """
+        Load an HDU into the viewer.
+        """
+        image = AstroImage.AstroImage(logger=self.logger)
+        image.load_hdu(hdu)
+
+        self.set_image(image)
+
+    def load_data(self, data_np):
+        """
+        Load raw numpy data into the viewer.
+        """
+        image = AstroImage.AstroImage(logger=self.logger)
+        image.set_data(data_np)
+
+        self.set_image(image)
+
+    def add_canvas(self, tag=None):
+        # add a canvas to the view
+        my_canvas = self.get_canvas()
+        DrawingCanvas = my_canvas.get_draw_class('drawingcanvas')
+        canvas = DrawingCanvas()
+        # enable drawing on the canvas
+        canvas.enable_draw(True)
+        canvas.enable_edit(True)
+        canvas.set_drawtype(None)
+        canvas.ui_set_active(True)
+        canvas.set_surface(self)
+        canvas.register_for_cursor_drawing(self)
+        # add the canvas to the view.
+        my_canvas.add(canvas, tag=tag)
+        canvas.set_draw_mode(None)
+
+        return canvas
+
+    def scroll_bars(self, onoff):
+        self.frame.scroll_bars(horizontal=onoff, vertical=onoff)
+
+
+class EnhancedCanvasView(BasicCanvasView):
+    """
+    Like BasicCanvasView, but includes a readout widget for when the
+    cursor is moved over the canvas to display the coordinates.
+    """
+
+    def build_gui(self, container):
+        """
+        This is responsible for building the viewer's UI.  It should
+        place the UI in `container`.
+        """
+        vbox = Widgets.VBox()
+        vbox.set_border_width(2)
+        vbox.set_spacing(1)
+
+        self.frame = Viewers.GingaScrolledViewerWidget(viewer=self)
+        vbox.add_widget(self.frame, stretch=1)
+
+        # set up to capture cursor movement for reading out coordinates
+
+        # coordinates reported in base 1 or 0?
+        self.pixel_base = 1.0
+
+        self.readout = Widgets.Label("")
+        vbox.add_widget(self.readout, stretch=0)
+
+        self.set_callback('cursor-changed', self.motion_cb)
+
+        container.set_widget(vbox)
+
+    def motion_cb(self, viewer, button, data_x, data_y):
+
+        # Get the value under the data coordinates
+        try:
+            # We report the value across the pixel, even though the coords
+            # change halfway across the pixel
+            value = viewer.get_data(int(data_x + 0.5), int(data_y + 0.5))
+
+        except Exception:
+            value = None
+
+        pb = self.pixel_base
+        fits_x, fits_y = data_x + pb, data_y + pb
+
+        # Calculate WCS RA
+        try:
+            # NOTE: image function operates on DATA space coords
+            image = viewer.get_image()
+            if image is None:
+                # No image loaded
+                return
+            ra_txt, dec_txt = image.pixtoradec(fits_x, fits_y,
+                                               format='str', coords='fits')
+        except Exception as e:
+            self.logger.warning("Bad coordinate conversion: %s" % (
+                str(e)))
+            ra_txt = 'BAD WCS'
+            dec_txt = 'BAD WCS'
+
+        text = "RA: %s  DEC: %s  X: %.2f  Y: %.2f  Value: %s" % (
+            ra_txt, dec_txt, fits_x, fits_y, value)
+        self.readout.set_text(text)
+
+    def set_readout_text(self, text):
+        self.readout.set_text(text)
+
+
+class ViewerFactory(object):
+    """
+    This is a factory class that churns out viewers.
+
+    The most important method of interest is get_viewer().
+    """
+
+    def __init__(self, logger=None, app=None):
+        if app is not None and logger is None:
+            logger = app.logger
+        if logger is None:
+            logger = log.NullLogger()
+        self.logger = logger
+
+        if app is None:
+            app = Widgets.Application(logger=self.logger)
+        self.app = app
+        self.dc = get_canvas_types()
+
+        self.count = 0
+
+    def make_viewer(self, viewer_class=None, name=None,
+                    width=500, height=500):
+        if viewer_class is None:
+            viewer_class = BasicCanvasView
+
+        self.count += 1
+        if name is None:
+            name = 'Viewer {}'.format(self.count)
+
+        # load binding preferences if available
+        cfgfile = os.path.join(ginga_home, "sv_bindings.cfg")
+        bindprefs = SettingGroup(name='bindings', logger=self.logger,
+                                 preffile=cfgfile)
+        bindprefs.load(onError='silent')
+
+        bd = ImageViewBindings(self.logger, settings=bindprefs)
+
+        fi = viewer_class(self.logger, bindings=bd)
+
+        # set up some reasonable defaults--user can change these later
+        # if desired
+        fi.set_autocut_params('zscale')
+        fi.enable_autocuts('on')
+        fi.enable_autozoom('on')
+        fi.set_bg(0.2, 0.2, 0.2)
+        fi.ui_set_active(True)
+        fi.sv_parent = self
+
+        # enable most key/mouse operations
+        bd = fi.get_bindings()
+        bd.enable_all(True)
+
+        # set up a non-private canvas for drawing
+        canvas = self.dc.DrawingCanvas()
+        canvas.set_surface(fi)
+        # add canvas to view
+        private_canvas = fi.get_canvas()
+        private_canvas.add(canvas)
+        canvas.ui_set_active(True)
+        fi.set_canvas(canvas)
+
+        fi.set_desired_size(width, height)
+
+        # add little mode indicator that shows modal states in
+        # the corner
+        fi.show_mode_indicator(True)
+
+        # Have the viewer build it's UI into the container
+        window = self.app.make_window(name)
+        window.add_callback('close', self.close)
+        fi.build_gui(window)
+        wd, ht = fi.get_desired_size()
+
+        window.show()
+        window.resize(wd, ht)
+
+        return fi
+
+    def close(self, w):
+        self.app.quit()
+
+    def quit(self):
+        self.app.quit()
+
+    def mainloop(self):
+        self.app.mainloop()

--- a/ginga/gw/sv.py
+++ b/ginga/gw/sv.py
@@ -39,7 +39,7 @@ class BasicCanvasView(Viewers.CanvasView):
     def build_gui(self, container):
         """
         This is responsible for building the viewer's UI.  It should
-        place the UI in `container`.  Override this to make a custom
+        place the UI in ``container``.  Override this to make a custom
         UI.
         """
         self.frame = Viewers.GingaScrolledViewerWidget(viewer=self)
@@ -101,7 +101,7 @@ class EnhancedCanvasView(BasicCanvasView):
     def build_gui(self, container):
         """
         This is responsible for building the viewer's UI.  It should
-        place the UI in `container`.
+        place the UI in ``container``.
         """
         vbox = Widgets.VBox()
         vbox.set_border_width(2)
@@ -163,7 +163,7 @@ class ViewerFactory(object):
     """
     This is a factory class that churns out viewers.
 
-    The most important method of interest is get_viewer().
+    The most important method of interest is :meth:`get_viewer`.
     """
 
     def __init__(self, logger=None, app=None):

--- a/ginga/tests/test_ap_regions.py
+++ b/ginga/tests/test_ap_regions.py
@@ -3,14 +3,14 @@
 import numpy as np
 import pytest
 
-have_regions = False
+HAVE_REGIONS = False
 try:
     import regions
-    have_regions = True
+    HAVE_REGIONS = True
 except ImportError:
     pass
 
-if not have_regions:
+if not HAVE_REGIONS:
     pytest.skip("skipping astropy regions tests; 'regions' not installed",
                 allow_module_level=True)
 

--- a/ginga/tests/test_ap_regions.py
+++ b/ginga/tests/test_ap_regions.py
@@ -131,7 +131,6 @@ class Test_R2G(object):
                                   r.angle.to(u.deg).value)))
 
 
-
 class Test_G2R(object):
     """Test conversions from Ginga canvas types to AstroPy regions."""
 

--- a/ginga/tests/test_ap_regions.py
+++ b/ginga/tests/test_ap_regions.py
@@ -1,0 +1,217 @@
+"""Test ap_regions.py"""
+
+import numpy as np
+import pytest
+
+have_regions = False
+try:
+    import regions
+    have_regions = True
+except ImportError:
+    pass
+
+if not have_regions:
+    pytest.skip("skipping astropy regions tests; 'regions' not installed",
+                allow_module_level=True)
+
+from astropy import units as u
+
+from ginga.util.ap_region import (astropy_region_to_ginga_canvas_object as r2g,
+                                  ginga_canvas_object_to_astropy_region as g2r)
+from ginga.canvas.CanvasObject import get_canvas_types
+
+
+dc = get_canvas_types()
+
+
+class Test_R2G(object):
+    """Test conversions from AstroPy regions to Ginga canvas types."""
+
+    def test_point1(self):
+        r = regions.PointPixelRegion(center=regions.PixCoord(x=42, y=43),
+                                     visual=regions.RegionVisual(symbol='x'))
+        o = r2g(r)
+        assert isinstance(o, dc.Point) and o.style == 'cross'
+        assert np.all(np.isclose((o.x, o.y), (r.center.x, r.center.y)))
+
+    def test_point2(self):
+        r = regions.PointPixelRegion(center=regions.PixCoord(x=42, y=43),
+                                     visual=regions.RegionVisual(symbol='+'))
+        o = r2g(r)
+        assert isinstance(o, dc.Point) and o.style == 'plus'
+
+    def test_point3(self):
+        r = regions.PointPixelRegion(center=regions.PixCoord(x=42, y=43),
+                                     visual=regions.RegionVisual(symbol='*'))
+        o = r2g(r)
+        assert isinstance(o, dc.SquareBox)
+        assert np.all(np.isclose((o.x, o.y), (r.center.x, r.center.y)))
+
+    def test_text(self):
+        r = regions.TextPixelRegion(center=regions.PixCoord(x=42, y=43),
+                                    text='Foo',
+                                    visual=regions.RegionVisual(textangle='45'))
+        o = r2g(r)
+        assert isinstance(o, dc.Text) and o.text == 'Foo'
+        assert np.all(np.isclose((o.x, o.y, o.rot_deg),
+                                 (r.center.x, r.center.y, float(r.visual['textangle']))))
+
+    def test_line(self):
+        r = regions.LinePixelRegion(start=regions.PixCoord(x=42, y=43),
+                                    end=regions.PixCoord(x=42, y=43))
+        o = r2g(r)
+        assert isinstance(o, dc.Line)
+        assert np.all(np.isclose((o.x1, o.y1, o.x2, o.y2),
+                                 (r.start.x, r.start.y, r.end.x, r.end.y)))
+
+    def test_rectangle(self):
+        r = regions.RectanglePixelRegion(center=regions.PixCoord(x=42, y=43),
+                                         width=3, height=4,
+                                         angle=5 * u.deg)
+        o = r2g(r)
+        assert isinstance(o, dc.Box)
+        assert np.all(np.isclose((o.x, o.y, o.xradius, o.yradius, o.rot_deg),
+                                 (r.center.x, r.center.y, r.width / 2.0, r.height / 2.0,
+                                  r.angle.to(u.deg).value)))
+
+    def test_circle(self):
+        r = regions.CirclePixelRegion(center=regions.PixCoord(x=42, y=43),
+                                      radius=4.2)
+        o = r2g(r)
+        assert isinstance(o, dc.Circle)
+        assert np.all(np.isclose((o.x, o.y, o.radius), (r.center.x, r.center.y, r.radius)))
+
+    def test_ellipse(self):
+        r = regions.EllipsePixelRegion(center=regions.PixCoord(x=42, y=43),
+                                       height=4.2, width=4.2, angle=5 * u.deg)
+        o = r2g(r)
+        assert isinstance(o, dc.Ellipse)
+        assert np.all(np.isclose((o.x, o.y, o.xradius, o.yradius, o.rot_deg),
+                                 (r.center.x, r.center.y, r.width / 2., r.height / 2.,
+                                  r.angle.to(u.deg).value)))
+
+    def test_polygon(self):
+        r = regions.PolygonPixelRegion(vertices=regions.PixCoord(x=[1, 2, 2], y=[1, 1, 2]))
+        o = r2g(r)
+        assert isinstance(o, dc.Polygon)
+        assert np.all(np.isclose(o.points, np.array(r.vertices.xy).T))
+
+    def test_circle_annulus(self):
+        r = regions.CircleAnnulusPixelRegion(center=regions.PixCoord(x=42, y=43),
+                                             inner_radius=4.2, outer_radius=5.2)
+        o = r2g(r)
+        assert isinstance(o, dc.Annulus)
+        assert np.all(np.isclose((o.x, o.y, o.radius, o.radius + o.width),
+                                 (r.center.x, r.center.y, r.inner_radius, r.outer_radius)))
+
+    def test_ellipse_annulus(self):
+        r = regions.EllipseAnnulusPixelRegion(center=regions.PixCoord(x=42, y=43),
+                                              inner_width=4.2, outer_width=5.2,
+                                              inner_height=7.2, outer_height=8.2,
+                                              angle=5 * u.deg)
+        o = r2g(r)
+        assert isinstance(o, dc.Annulus2R) and o.atype == 'ellipse'
+        assert np.all(np.isclose((o.x, o.y, o.xradius, o.yradius, o.xradius + o.xwidth,
+                                  o.yradius + o.ywidth, o.rot_deg),
+                                 (r.center.x, r.center.y, r.inner_width / 2., r.inner_height / 2.,
+                                  r.outer_width / 2., r.outer_height / 2.,
+                                  r.angle.to(u.deg).value)))
+
+    def test_rectangle_annulus(self):
+        r = regions.RectangleAnnulusPixelRegion(center=regions.PixCoord(x=42, y=43),
+                                                inner_width=4.2, outer_width=5.2,
+                                                inner_height=7.2, outer_height=8.2,
+                                                angle=5 * u.deg)
+        o = r2g(r)
+        assert isinstance(o, dc.Annulus2R) and o.atype == 'box'
+        assert np.all(np.isclose((o.x, o.y, o.xradius, o.yradius, o.xradius + o.xwidth,
+                                  o.yradius + o.ywidth, o.rot_deg),
+                                 (r.center.x, r.center.y, r.inner_width / 2., r.inner_height / 2.,
+                                  r.outer_width / 2., r.outer_height / 2.,
+                                  r.angle.to(u.deg).value)))
+
+
+
+class Test_G2R(object):
+    """Test conversions from Ginga canvas types to AstroPy regions."""
+
+    def test_point1(self):
+        o = dc.Point(42, 43, radius=5, style='cross')
+        r = g2r(o)
+        assert isinstance(r, regions.PointPixelRegion)
+        assert np.all(np.isclose((o.x, o.y), (r.center.x, r.center.y)))
+        assert r.visual['symbol'] == 'x'
+
+    def test_point2(self):
+        o = dc.Point(42, 43, radius=5, style='plus')
+        r = g2r(o)
+        assert isinstance(r, regions.PointPixelRegion)
+        assert r.visual['symbol'] == '+'
+
+    def test_text(self):
+        o = dc.Text(42, 43, text='Foo', rot_deg=45.0)
+        r = g2r(o)
+        assert isinstance(r, regions.TextPixelRegion) and r.text == 'Foo'
+        assert np.all(np.isclose((o.x, o.y, o.rot_deg),
+                                 (r.center.x, r.center.y, float(r.visual['textangle']))))
+
+    def test_line(self):
+        o = dc.Line(42, 43, 52, 53)
+        r = g2r(o)
+        assert isinstance(r, regions.LinePixelRegion)
+        assert np.all(np.isclose((o.x1, o.y1, o.x2, o.y2),
+                                 (r.start.x, r.start.y, r.end.x, r.end.y)))
+
+    def test_box(self):
+        o = dc.Box(42, 43, 10, 10)
+        r = g2r(o)
+        assert isinstance(r, regions.RectanglePixelRegion)
+        assert np.all(np.isclose((o.x, o.y, o.xradius, o.yradius),
+                                 (r.center.x, r.center.y, r.width / 2.0, r.height / 2.0)))
+
+    def test_circle(self):
+        o = dc.Circle(42, 43, 4.2)
+        r = g2r(o)
+        assert isinstance(r, regions.CirclePixelRegion)
+        assert np.all(np.isclose((o.x, o.y, o.radius), (r.center.x, r.center.y, r.radius)))
+
+    def test_ellipse(self):
+        o = dc.Ellipse(42, 43, 4.2, 4.2, rot_deg=5.0)
+        r = g2r(o)
+        assert isinstance(r, regions.EllipsePixelRegion)
+        assert np.all(np.isclose((o.x, o.y, o.xradius, o.yradius, o.rot_deg),
+                                 (r.center.x, r.center.y, r.width / 2., r.height / 2.,
+                                  r.angle.to(u.deg).value)))
+
+    def test_polygon(self):
+        o = dc.Polygon([(1, 1), (2, 1), (2, 2)])
+        r = g2r(o)
+        assert isinstance(r, regions.PolygonPixelRegion)
+        assert np.all(np.isclose(o.points, np.array(r.vertices.xy).T))
+
+    def test_circle_annulus(self):
+        o = dc.Annulus(42, 43, 4.2, width=1, atype='circle')
+        r = g2r(o)
+        assert isinstance(r, regions.CircleAnnulusPixelRegion)
+        assert np.all(np.isclose((o.x, o.y, o.radius, o.radius + o.width),
+                                 (r.center.x, r.center.y, r.inner_radius, r.outer_radius)))
+
+    def test_ellipse_annulus(self):
+        o = dc.Annulus2R(42, 43, 4.2, 7.2, xwidth=1, ywidth=1, rot_deg=5.0, atype='ellipse')
+        r = g2r(o)
+        assert isinstance(r, regions.EllipseAnnulusPixelRegion)
+        assert np.all(np.isclose((o.x, o.y, o.xradius, o.yradius, o.xradius + o.xwidth,
+                                  o.yradius + o.ywidth, o.rot_deg),
+                                 (r.center.x, r.center.y, r.inner_width / 2., r.inner_height / 2.,
+                                  r.outer_width / 2., r.outer_height / 2.,
+                                  r.angle.to(u.deg).value)))
+
+    def test_rectangle_annulus(self):
+        o = dc.Annulus2R(42, 43, 4.2, 7.2, xwidth=1, ywidth=1, rot_deg=5.0, atype='box')
+        r = g2r(o)
+        assert isinstance(r, regions.RectangleAnnulusPixelRegion)
+        assert np.all(np.isclose((o.x, o.y, o.xradius, o.yradius, o.xradius + o.xwidth,
+                                  o.yradius + o.ywidth, o.rot_deg),
+                                 (r.center.x, r.center.y, r.inner_width / 2., r.inner_height / 2.,
+                                  r.outer_width / 2., r.outer_height / 2.,
+                                  r.angle.to(u.deg).value)))

--- a/ginga/tests/test_ap_regions.py
+++ b/ginga/tests/test_ap_regions.py
@@ -3,16 +3,7 @@
 import numpy as np
 import pytest
 
-HAVE_REGIONS = False
-try:
-    import regions
-    HAVE_REGIONS = True
-except ImportError:
-    pass
-
-if not HAVE_REGIONS:
-    pytest.skip("skipping astropy regions tests; 'regions' not installed",
-                allow_module_level=True)
+regions = pytest.importorskip('regions')
 
 from astropy import units as u
 

--- a/ginga/tests/test_ap_regions.py
+++ b/ginga/tests/test_ap_regions.py
@@ -44,8 +44,7 @@ class Test_R2G(object):
         r = regions.PointPixelRegion(center=regions.PixCoord(x=42, y=43),
                                      visual=regions.RegionVisual(symbol='*'))
         o = r2g(r)
-        assert isinstance(o, dc.SquareBox)
-        assert np.all(np.isclose((o.x, o.y), (r.center.x, r.center.y)))
+        assert isinstance(o, dc.Point) and o.style == 'square'
 
     def test_text(self):
         r = regions.TextPixelRegion(center=regions.PixCoord(x=42, y=43),
@@ -146,6 +145,12 @@ class Test_G2R(object):
         r = g2r(o)
         assert isinstance(r, regions.PointPixelRegion)
         assert r.visual['symbol'] == '+'
+
+    def test_point3(self):
+        o = dc.Point(42, 43, radius=5, style='square')
+        r = g2r(o)
+        assert isinstance(r, regions.PointPixelRegion)
+        assert r.visual['symbol'] == '*'
 
     def test_text(self):
         o = dc.Text(42, 43, text='Foo', rot_deg=45.0)

--- a/ginga/util/ap_region.py
+++ b/ginga/util/ap_region.py
@@ -14,10 +14,10 @@ from ginga.canvas.CanvasObject import get_canvas_types
 
 from astropy import units as u
 
-have_regions = False
+HAVE_REGIONS = False
 try:
     import regions
-    have_regions = True
+    HAVE_REGIONS = True
 except ImportError:
     pass
 
@@ -46,7 +46,7 @@ def astropy_region_to_ginga_canvas_object(r):
         The corresponding Ginga canvas object
 
     """
-    if not have_regions:
+    if not HAVE_REGIONS:
         raise ValueError("Please install the Astropy 'regions' package to use this function")
 
     dc = get_canvas_types()
@@ -182,7 +182,7 @@ def ginga_canvas_object_to_astropy_region(obj):
         The corresponding AstroPy region object
 
     """
-    if not have_regions:
+    if not HAVE_REGIONS:
         raise ValueError("Please install the Astropy 'regions' package to use this function")
 
     dc = get_canvas_types()

--- a/ginga/util/ap_region.py
+++ b/ginga/util/ap_region.py
@@ -148,6 +148,7 @@ def add_region(canvas, r, redraw=True):
     tag = obj.get_data('name')
     if obj is not None:
         canvas.add(obj, tag=tag, redraw=redraw)
+        return obj
 
 
 def ginga_canvas_object_to_astropy_region(obj):

--- a/ginga/util/ap_region.py
+++ b/ginga/util/ap_region.py
@@ -138,7 +138,7 @@ def astropy_region_to_ginga_canvas_object(r):
     return obj
 
 
-def add_region(canvas, r, redraw=True):
+def add_region(canvas, r, tag=None, redraw=True):
     """
     Convenience function to plot an Astropy regions object on a Ginga
     canvas.
@@ -151,13 +151,17 @@ def add_region(canvas, r, redraw=True):
     r : subclass of `~regions.PixelRegion`
         The region object to be plotted
 
+    tag : str or None (optional, default: None)
+        Caller can optionally pass a specific tag for the canvas object
+
     redraw : bool (optional, default: True)
         True if the viewers of the canvas should be updated immediately
 
     """
     obj = astropy_region_to_ginga_canvas_object(r)
 
-    tag = obj.get_data('name')
+    if tag is None:
+        tag = obj.get_data('name')
     if obj is not None:
         canvas.add(obj, tag=tag, redraw=redraw)
         return obj

--- a/ginga/util/ap_region.py
+++ b/ginga/util/ap_region.py
@@ -82,6 +82,22 @@ def astropy_region_to_ginga_canvas_object(r):
         obj = dc.Annulus(r.center.x, r.center.y, rin, width=wd,
                          atype='circle')
 
+    elif isinstance(r, (regions.EllipseAnnulusPixelRegion,)):
+        xwd = r.outer_width - r.inner_width
+        ywd = r.outer_height - r.inner_height
+        obj = dc.Annulus2R(r.center.x, r.center.y,
+                           r.inner_width / 2.0, r.inner_height / 2.0,
+                           xwidth=wd, ywidth=ywd,
+                           atype='ellipse')
+
+    elif isinstance(r, (regions.RectangleAnnulusPixelRegion,)):
+        xwd = r.outer_width - r.inner_width
+        ywd = r.outer_height - r.inner_height
+        obj = dc.Annulus2R(r.center.x, r.center.y,
+                           r.inner_width / 2.0, r.inner_height / 2.0,
+                           xwidth=wd, ywidth=ywd,
+                           atype='box')
+
     else:
         raise ValueError("Don't know how to convert this object")
 
@@ -202,6 +218,24 @@ def ginga_canvas_object_to_astropy_region(obj):
                                                                      y=obj.y),
                                              inner_radius=rin,
                                              outer_radius=rout)
+
+    elif isinstance(obj, (dc.Annulus2R,)) and obj.atype == 'ellipse':
+        r = regions.EllipseAnnulusPixelRegion(center=regions.PixCoord(x=obj.x,
+                                                                      y=obj.y),
+                                              inner_width=obj.xradius * 2,
+                                              inner_height=obj.yradius * 2,
+                                              outer_width=obj.xradius * 2 + obj.xwidth * 2,
+                                              outer_height=obj.yradius * 2 + obj.ywidth * 2,
+                                              angle=obj.rot_deg * u.deg)
+
+    elif isinstance(obj, (dc.Annulus2R,)) and obj.atype == 'box':
+        r = regions.RectangleAnnulusPixelRegion(center=regions.PixCoord(x=obj.x,
+                                                                        y=obj.y),
+                                                inner_width=obj.xradius * 2,
+                                                inner_height=obj.yradius * 2,
+                                                outer_width=obj.xradius * 2 + obj.xwidth * 2,
+                                                outer_height=obj.yradius * 2 + obj.ywidth * 2,
+                                                angle=obj.rot_deg * u.deg)
 
     else:
         raise ValueError("Don't know how to convert this object")

--- a/ginga/util/ap_region.py
+++ b/ginga/util/ap_region.py
@@ -12,8 +12,14 @@ import numpy as np
 
 from ginga.canvas.CanvasObject import get_canvas_types
 
-import regions
 from astropy import units as u
+
+have_regions = False
+try:
+    import regions
+    have_regions = True
+except ImportError:
+    pass
 
 
 __all__ = ['astropy_region_to_ginga_canvas_object', 'add_region',
@@ -40,6 +46,9 @@ def astropy_region_to_ginga_canvas_object(r):
         The corresponding Ginga canvas object
 
     """
+    if not have_regions:
+        raise ValueError("Please install the Astropy 'regions' package to use this function")
+
     dc = get_canvas_types()
     obj = None
     if isinstance(r, (regions.CirclePixelRegion,)):
@@ -169,6 +178,9 @@ def ginga_canvas_object_to_astropy_region(obj):
         The corresponding AstroPy region object
 
     """
+    if not have_regions:
+        raise ValueError("Please install the Astropy 'regions' package to use this function")
+
     dc = get_canvas_types()
     r = None
 

--- a/ginga/util/ap_region.py
+++ b/ginga/util/ap_region.py
@@ -1,0 +1,251 @@
+#
+# ap_region.py -- AstroPy regions support
+#
+# This is open-source software licensed under a BSD license.
+# Please see the file LICENSE.txt for details.
+#
+"""
+This module provides Ginga support for ds9 type region files and objects via
+the astropy regions module.
+"""
+import numpy as np
+
+from ginga.canvas.CanvasObject import get_canvas_types
+
+import regions
+from astropy import units as u
+
+
+def astropy_region_to_ginga_canvas_object(r):
+    """
+    Convert an AstroPy region object to a Ginga canvas object.
+
+    Parameters
+    ----------
+    r : subclass of `~regions.PixelRegion`
+        The region object to be converted
+
+    Returns
+    -------
+    obj : subclass of `~ginga.canvas.CanvasObject`
+        The corresponding Ginga canvas object
+
+    """
+    dc = get_canvas_types()
+    obj = None
+    if isinstance(r, (regions.CirclePixelRegion,)):
+        obj = dc.Circle(r.center.x, r.center.y, r.radius)
+
+    elif isinstance(r, (regions.EllipsePixelRegion,)):
+        obj = dc.Ellipse(r.center.x, r.center.y, r.width / 2, r.height / 2.,
+                         rot_deg=r.angle)
+
+    # NOTE: need to check for Text before Point, because Text seems to be
+    # a subclass of Point in regions
+    elif isinstance(r, (regions.TextPixelRegion,)):
+        # NOTE: font needed here, but will be overridden later if specified
+        # in the region's visuals
+        obj = dc.Text(r.center.x, r.center.y, text=r.text, font='sans',
+                      rot_deg=float(r.visual.get('textangle', 0.0)))
+
+    elif isinstance(r, (regions.PointPixelRegion,)):
+        # what is a reasonable default radius?
+        radius = 15
+
+        style = r.visual.get('symbol', '*')
+        if style == '+':
+            obj = dc.Point(r.center.x, r.center.y, radius, style='plus')
+        elif style == 'x':
+            obj = dc.Point(r.center.x, r.center.y, radius, style='cross')
+        else:
+            obj = dc.SquareBox(r.center.x, r.center.y, radius)
+            # for round-tripping
+            obj.set_data(is_point=True)
+
+    elif isinstance(r, (regions.LinePixelRegion,)):
+        obj = dc.Line(r.start.x, r.start.y, r.end.x, r.end.y)
+        if r.meta.get('line', '0') == '1':
+            obj.arrow = 'both'
+
+    elif isinstance(r, (regions.RectanglePixelRegion,)):
+        obj = dc.Box(r.center.x, r.center.y, r.width / 2, r.height / 2.,
+                     rot_deg=r.angle)
+
+    elif isinstance(r, (regions.PolygonPixelRegion,)):
+        points = np.array(r.vertices.xy).T
+        obj = dc.Polygon(points)
+
+    elif isinstance(r, (regions.CircleAnnulusPixelRegion,)):
+        rin = r.inner_radius
+        rout = r.outer_radius
+        wd = rout - rin
+        obj = dc.Annulus(r.center.x, r.center.y, rin, width=wd,
+                         atype='circle')
+
+    else:
+        raise ValueError("Don't know how to convert this object")
+
+    # Set visual styling attributes
+    obj.color = r.visual.get('color', 'green')
+    if hasattr(obj, 'font'):
+        obj.font = r.visual.get('font', 'Sans')
+        if 'fontsize' in r.visual:
+            obj.fontsize = int(r.visual['fontsize'])
+
+    if hasattr(obj, 'linewidth'):
+        obj.linewidth = r.visual.get('linewidth', 1)
+
+    if hasattr(obj, 'fill'):
+        obj.fill = r.visual.get('fill', False)
+
+    # Limited support for other metadata
+    obj.editable = r.meta.get('edit', True)
+    obj.set_data(name=r.meta.get('name', None))
+
+    # needed for compound objects like annulus
+    obj.sync_state()
+
+    return obj
+
+
+def add_region(canvas, r, redraw=True):
+    """
+    Convenience function to plot an AstroPy regions object on a Ginga
+    canvas.
+
+    Parameters
+    ----------
+    canvas : `~ginga.canvas.types.layer.DrawingCanvas`
+        The Ginga canvas on which the region should be plotted.
+
+    r : subclass of `~regions.PixelRegion`
+        The region object to be plotted
+
+    redraw : bool (optional, default: True)
+        True if the viewers of the canvas should be updated immediately
+
+    """
+    obj = astropy_region_to_ginga_canvas_object(r)
+
+    tag = obj.get_data('name')
+    if obj is not None:
+        canvas.add(obj, tag=tag, redraw=redraw)
+
+
+def ginga_canvas_object_to_astropy_region(obj):
+    """
+    Convert a Ginga canvas object to an AstroPy region object.
+
+    Parameters
+    ----------
+    obj : subclass of `~ginga.canvas.CanvasObject`
+        The Ginga canvas object to be converted
+
+    Returns
+    -------
+    r : subclass of `~regions.PixelRegion`
+        The corresponding AstroPy region object
+
+    """
+    dc = get_canvas_types()
+    r = None
+
+    if isinstance(obj, (dc.Circle,)):
+        r = regions.CirclePixelRegion(center=regions.PixCoord(x=obj.x, y=obj.y),
+                                      radius=obj.radius)
+
+    elif isinstance(obj, (dc.Ellipse,)):
+        r = regions.EllipsePixelRegion(center=regions.PixCoord(x=obj.x, y=obj.y),
+                                       width=obj.xradius * 2,
+                                       height=obj.yradius * 2,
+                                       angle=obj.rot_deg * u.deg)
+
+    elif isinstance(obj, (dc.Text,)):
+        r = regions.TextPixelRegion(center=regions.PixCoord(x=obj.x, y=obj.y),
+                                    text=obj.text)
+        r.visual['textangle'] = str(r.rot_deg)
+
+    elif isinstance(obj, (dc.Point,)):
+        r = regions.PointPixelRegion(center=regions.PixCoord(x=obj.x, y=obj.y))
+        if obj.style == 'plus':
+            r.visual['symbol'] = '+'
+        else:
+            r.visual['symbol'] = 'x'
+
+    elif isinstance(obj, (dc.Line,)):
+        r = regions.LinePixelRegion(start=regions.PixCoord(x=obj.x1, y=obj.y1),
+                                    end=regions.PixCoord(x=obj.x2, y=obj.y2))
+
+    elif isinstance(obj, (dc.Box,)):
+        meta = obj.get_data()
+        if meta is not None and meta.get('is_point', False):
+            # round-tripped from a region originally
+            r = regions.PointPixelRegion(center=regions.PixCoord(x=obj.x,
+                                                                 y=obj.y))
+            r.visual['symbol'] = '*'
+
+        else:
+            r = regions.RectanglePixelRegion(center=regions.PixCoord(x=obj.x,
+                                                                     y=obj.y),
+                                             width=obj.xradius * 2,
+                                             height=obj.yradius * 2,
+                                             angle=obj.rot_deg * u.deg)
+
+    elif isinstance(obj, (dc.Polygon,)):
+        x, y = np.asarray(obj.points).T
+        r = regions.PolygonPixelRegion(vertices=regions.PixCoord(x=x, y=y))
+
+    elif isinstance(obj, (dc.Annulus,)) and obj.atype == 'circle':
+        rin = obj.radius
+        rout = rin + obj.width
+        r = regions.CircleAnnulusPixelRegion(center=regions.PixCoord(x=obj.x,
+                                                                     y=obj.y),
+                                             inner_radius=rin,
+                                             outer_radius=rout)
+
+    else:
+        raise ValueError("Don't know how to convert this object")
+
+    # Set visual styling attributes
+    r.visual['color'] = obj.color
+
+    if hasattr(obj, 'font'):
+        r.visual['font'] = obj.font
+        if obj.fontsize is not None:
+            r.visual['fontsize'] = str(obj.fontsize)
+
+    if hasattr(obj, 'linewidth'):
+        r.visual['linewidth'] = obj.linewidth
+
+    if hasattr(obj, 'fill'):
+        r.visual['fill'] = obj.fill = r.visual.get('fill', False)
+
+    # Limited support for other metadata
+    r.meta['edit'] = 1 if obj.editable else 0
+    meta = obj.get_data()
+    if meta is not None and meta.get('name', None) is not None:
+        r.meta['name'] = meta.get('name')
+
+    return r
+
+
+def import_ds9_regions(ds9_file):
+    """
+    Convenience function to read a ds9 file containing regions and
+    return a list of matching Ginga canvas objects.
+
+    Parameters
+    ----------
+    ds9_file : str
+        Path of a ds9 like regions file
+
+    Returns
+    -------
+    objs : list
+        Returns a list of Ginga canvas objects that can be added
+        to a Ginga canvas
+    """
+    regs = regions.read_ds9(ds9_file)
+
+    return [astropy_region_to_ginga_canvas_object(r)
+            for r in regs]

--- a/ginga/util/ap_region.py
+++ b/ginga/util/ap_region.py
@@ -5,8 +5,8 @@
 # Please see the file LICENSE.txt for details.
 #
 """
-This module provides Ginga support for ds9 type region files and objects via
-the astropy regions module.
+This module provides Ginga support for DS9 type region files and objects via
+the Astropy ``regions`` module.
 """
 import numpy as np
 
@@ -33,7 +33,7 @@ pt_regions = {v: k for k, v in pt_ginga.items()}
 
 def astropy_region_to_ginga_canvas_object(r):
     """
-    Convert an AstroPy region object to a Ginga canvas object.
+    Convert an Astropy region object to a Ginga canvas object.
 
     Parameters
     ----------
@@ -140,7 +140,7 @@ def astropy_region_to_ginga_canvas_object(r):
 
 def add_region(canvas, r, redraw=True):
     """
-    Convenience function to plot an AstroPy regions object on a Ginga
+    Convenience function to plot an Astropy regions object on a Ginga
     canvas.
 
     Parameters

--- a/ginga/util/ap_region.py
+++ b/ginga/util/ap_region.py
@@ -38,7 +38,7 @@ def astropy_region_to_ginga_canvas_object(r):
 
     elif isinstance(r, (regions.EllipsePixelRegion,)):
         obj = dc.Ellipse(r.center.x, r.center.y, r.width / 2, r.height / 2.,
-                         rot_deg=r.angle)
+                         rot_deg=r.angle.to(u.deg).value)
 
     # NOTE: need to check for Text before Point, because Text seems to be
     # a subclass of Point in regions
@@ -69,7 +69,7 @@ def astropy_region_to_ginga_canvas_object(r):
 
     elif isinstance(r, (regions.RectanglePixelRegion,)):
         obj = dc.Box(r.center.x, r.center.y, r.width / 2, r.height / 2.,
-                     rot_deg=r.angle)
+                     rot_deg=r.angle.to(u.deg).value)
 
     elif isinstance(r, (regions.PolygonPixelRegion,)):
         points = np.array(r.vertices.xy).T
@@ -83,20 +83,22 @@ def astropy_region_to_ginga_canvas_object(r):
                          atype='circle')
 
     elif isinstance(r, (regions.EllipseAnnulusPixelRegion,)):
-        xwd = r.outer_width - r.inner_width
-        ywd = r.outer_height - r.inner_height
+        xwd = (r.outer_width - r.inner_width) / 2.0
+        ywd = (r.outer_height - r.inner_height) / 2.0
         obj = dc.Annulus2R(r.center.x, r.center.y,
                            r.inner_width / 2.0, r.inner_height / 2.0,
-                           xwidth=wd, ywidth=ywd,
-                           atype='ellipse')
+                           xwidth=xwd, ywidth=ywd,
+                           atype='ellipse',
+                           rot_deg=r.angle.to(u.deg).value)
 
     elif isinstance(r, (regions.RectangleAnnulusPixelRegion,)):
-        xwd = r.outer_width - r.inner_width
-        ywd = r.outer_height - r.inner_height
+        xwd = (r.outer_width - r.inner_width) / 2.0
+        ywd = (r.outer_height - r.inner_height) / 2.0
         obj = dc.Annulus2R(r.center.x, r.center.y,
                            r.inner_width / 2.0, r.inner_height / 2.0,
-                           xwidth=wd, ywidth=ywd,
-                           atype='box')
+                           xwidth=xwd, ywidth=ywd,
+                           atype='box',
+                           rot_deg=r.angle.to(u.deg).value)
 
     else:
         raise ValueError("Don't know how to convert this object")
@@ -179,7 +181,7 @@ def ginga_canvas_object_to_astropy_region(obj):
     elif isinstance(obj, (dc.Text,)):
         r = regions.TextPixelRegion(center=regions.PixCoord(x=obj.x, y=obj.y),
                                     text=obj.text)
-        r.visual['textangle'] = str(r.rot_deg)
+        r.visual['textangle'] = str(obj.rot_deg)
 
     elif isinstance(obj, (dc.Point,)):
         r = regions.PointPixelRegion(center=regions.PixCoord(x=obj.x, y=obj.y))

--- a/ginga/util/ap_region.py
+++ b/ginga/util/ap_region.py
@@ -15,6 +15,11 @@ from ginga.canvas.CanvasObject import get_canvas_types
 import regions
 from astropy import units as u
 
+
+__all__ = ['astropy_region_to_ginga_canvas_object', 'add_region',
+           'ginga_canvas_object_to_astropy_region']
+
+
 # mappings of point styles
 pt_ginga = dict(square='*', cross='x', plus='+', diamond='D')
 pt_regions = {v: k for k, v in pt_ginga.items()}


### PR DESCRIPTION
Provides a module (ginga.util.ap_region) that supports converting between astropy region objects and ginga canvas objects. 

Example program to show plotting the objects shown in the example "HorseHead" image for astropy regions.  See `ginga/examples/gw/plot_ds9_regions.py`.
