### PR TITLE
Refactor the way viewers initialize renderer 

### DIFF
--- a/ginga/ImageView.py
+++ b/ginga/ImageView.py
@@ -3155,7 +3155,8 @@ class ImageViewBase(Callback.Callbacks):
 
     def reschedule_redraw(self, time_sec):
         """Reschedule redraw event.
-        This must be implemented by subclasses.
+
+        This should be implemented by subclasses.
 
         Parameters
         ----------
@@ -3163,7 +3164,9 @@ class ImageViewBase(Callback.Callbacks):
             Time, in seconds, to wait.
 
         """
-        self.logger.warning("Subclass should override this abstract method!")
+        # subclass implements this method to call delayed_redraw() after
+        # time_sec
+        self.delayed_redraw()
 
     def set_cursor(self, cursor):
         """Set the cursor in the viewer widget.
@@ -3270,14 +3273,24 @@ class ImageViewBase(Callback.Callbacks):
         """
         self.set_cursor(self.cursor[cname])
 
+    def configure_surface(self, width, height):
+        """Reconfigure the renderer for a new size, then reconfigure
+        our viewer for the same.
+
+        This can be overridden by subclasses.
+        """
+        self.renderer.resize((width, height))
+
+        self.configure(width, height)
+
     def get_image_as_array(self):
         """Get the current image shown in the viewer, with any overlaid
         graphics, in a numpy array with channels as needed and ordered
         by the back end widget.
 
-        This should be implemented by subclasses.
+        This can be overridden by subclasses.
         """
-        raise ImageViewError("Subclass should override this abstract method!")
+        return self.renderer.get_surface_as_array(order=self.rgb_order)
 
     def get_image_as_buffer(self, output=None):
         """Get the current image shown in the viewer, with any overlaid
@@ -3318,7 +3331,8 @@ class ImageViewBase(Callback.Callbacks):
         """Get the current image shown in the viewer, with any overlaid
         graphics, in a file IO-like object encoded as a bitmap graphics
         file.
-        This should be implemented by subclasses.
+
+        This can be overridden by subclasses.
 
         Parameters
         ----------
@@ -3339,7 +3353,8 @@ class ImageViewBase(Callback.Callbacks):
             in which case a BytesIO obejct is returned
 
         """
-        raise ImageViewError("Subclass should override this abstract method!")
+        return self.renderer.get_surface_as_rgb_format_buffer(
+            output=output, format=format, quality=quality)
 
     def get_rgb_image_as_bytes(self, format='png', quality=90):
         """Get the current image shown in the viewer, with any overlaid

--- a/ginga/ImageView.py
+++ b/ginga/ImageView.py
@@ -3165,7 +3165,7 @@ class ImageViewBase(Callback.Callbacks):
 
         """
         # subclass implements this method to call delayed_redraw() after
-        # time_sec
+        # time_sec.  If subclass does not override, redraw is immediate.
         self.delayed_redraw()
 
     def set_cursor(self, cursor):

--- a/ginga/aggw/CanvasRenderAgg.py
+++ b/ginga/aggw/CanvasRenderAgg.py
@@ -1,5 +1,5 @@
 #
-# CanvasRenderAgg.py -- for rendering into a ImageViewAgg widget
+# CanvasRenderAgg.py -- for rendering into Ginga widget with aggdraw
 #
 # This is open-source software licensed under a BSD license.
 # Please see the file LICENSE.txt for details.

--- a/ginga/aggw/ImageViewAgg.py
+++ b/ginga/aggw/ImageViewAgg.py
@@ -20,56 +20,11 @@ class ImageViewAgg(ImageView.ImageViewBase):
 
         self.renderer = CanvasRenderer(self)
 
-    def get_surface(self):
-        return self.surface
-
-    def configure_surface(self, width, height):
-        # tell renderer about our new size
-        self.renderer.resize((width, height))
-
-        # inform the base class about the actual window size
-        self.configure(width, height)
-
-    def get_image_as_array(self):
-        # TO BE DEPRECATED: DO NOT USE
-        return self.renderer.get_surface_as_array()
-
-    def get_image_as_buffer(self, output=None):
-        # TO BE DEPRECATED: DO NOT USE
-        return self.renderer.get_surface_as_buffer()
-
-    def get_rgb_image_as_buffer(self, output=None, format='png', quality=90):
-        # TO BE DEPRECATED: DO NOT USE
-        return self.renderer.get_surface_as_rgb_format_buffer(output=output,
-                                                              format=format,
-                                                              quality=quality)
-
-    def get_rgb_image_as_bytes(self, format='png', quality=90):
-        # TO BE DEPRECATED: DO NOT USE
-        return self.renderer.get_surface_as_rgb_format_bytes(format=format,
-                                                             quality=quality)
-
-    def save_rgb_image_as_file(self, filepath, format='png', quality=90):
-        # TO BE DEPRECATED: DO NOT USE
-        return self.renderer.save_surface_as_rgb_format_file(filepath,
-                                                             format=format,
-                                                             quality=quality)
-
     def update_image(self):
-        # subclass implements this method to actually update a widget
-        # from the agg surface
-        self.logger.warning("Subclass should override this method")
-        return False
+        pass
 
-    def set_cursor(self, cursor):
-        # subclass implements this method to actually set a defined
-        # cursor on a widget
-        self.logger.warning("Subclass should override this method")
-
-    def reschedule_redraw(self, time_sec):
-        # subclass implements this method to call delayed_redraw() after
-        # time_sec
-        self.delayed_redraw()
+    def configure_window(self, width, height):
+        self.configure_surface(width, height)
 
 
 class CanvasView(ImageViewAgg):
@@ -92,11 +47,5 @@ class CanvasView(ImageViewAgg):
                                            private_canvas=private_canvas)
 
         self.objects[0] = self.private_canvas
-
-    def update_image(self):
-        pass
-
-    def configure_window(self, width, height):
-        return super(CanvasView, self).configure_surface(width, height)
 
 # END

--- a/ginga/cairow/ImageViewCairo.py
+++ b/ginga/cairow/ImageViewCairo.py
@@ -88,15 +88,5 @@ class ImageViewCairo(ImageView.ImageViewBase):
     def set_cursor(self, cursor):
         pass
 
-    ## def pix2canvas(self, pt):
-    ##     x, y = pt
-    ##     x, y = self.cr.device_to_user(x, y)
-    ##     return (x, y, 0)
-
-    ## def canvas2pix(self, pt):
-    ##     x, y, z = pt
-    ##     x, y = self.cr.user_to_device(x, y)
-    ##     return (x, y)
-
 
 # END

--- a/ginga/cvw/CanvasRenderCv.py
+++ b/ginga/cvw/CanvasRenderCv.py
@@ -1,5 +1,5 @@
 #
-# CanvasRenderCv.py -- for rendering into a ImageViewCv widget
+# CanvasRenderCv.py -- for rendering into a Ginga widget with OpenCv
 #
 # This is open-source software licensed under a BSD license.
 # Please see the file LICENSE.txt for details.

--- a/ginga/cvw/ImageViewCv.py
+++ b/ginga/cvw/ImageViewCv.py
@@ -30,42 +30,12 @@ class ImageViewCv(ImageView.ImageViewBase):
 
         self.renderer = CanvasRenderer(self)
 
-    def get_surface(self):
-        return self.renderer.surface
-
-    def configure_surface(self, width, height):
-        # inform renderer
-        self.renderer.resize((width, height))
-
-        # inform the base class about the actual window size
-        self.configure(width, height)
-
-    def get_image_as_array(self):
-        return self.renderer.get_surface_as_array(order=self.rgb_order)
-
-    def get_rgb_image_as_buffer(self, output=None, format='png', quality=90):
-        return self.renderer.get_surface_as_rgb_format_buffer(
-            output=output, format=format, quality=quality)
-
-    def get_rgb_image_as_bytes(self, format='png', quality=90):
-        return self.renderer.get_surface_as_rgb_format_bytes(
-            format=format, quality=quality)
-
     def update_image(self):
-        # subclass implements this method to actually update a widget
-        # from the cv surface
-        self.logger.warning("Subclass should override this method")
-        return False
+        # no widget to update
+        pass
 
-    def set_cursor(self, cursor):
-        # subclass implements this method to actually set a defined
-        # cursor on a widget
-        self.logger.warning("Subclass should override this method")
-
-    def reschedule_redraw(self, time_sec):
-        # subclass implements this method to call delayed_redraw() after
-        # time_sec
-        self.delayed_redraw()
+    def configure_window(self, width, height):
+        self.configure_surface(width, height)
 
 
 class CanvasView(ImageViewCv):
@@ -87,12 +57,5 @@ class CanvasView(ImageViewCv):
                                            private_canvas=private_canvas)
 
         self.objects[0] = self.private_canvas
-
-    def update_image(self):
-        # no widget to update
-        pass
-
-    def configure_window(self, width, height):
-        return super(CanvasView, self).configure_surface(width, height)
 
 #END

--- a/ginga/gtk3w/ImageViewGtk.py
+++ b/ginga/gtk3w/ImageViewGtk.py
@@ -4,15 +4,14 @@
 # This is open-source software licensed under a BSD license.
 # Please see the file LICENSE.txt for details.
 
+import sys
 import os
 import numpy as np
 
 from ginga.gtk3w import GtkHelp
-from ginga import Mixins, Bindings
+from ginga import ImageView, Mixins, Bindings
 from ginga.util.paths import icondir
-
-from ginga.cairow.ImageViewCairo import (ImageViewCairo as ImageView,
-                                         ImageViewCairoError as ImageViewError)
+from ginga.canvas import render
 
 from gi.repository import Gtk
 from gi.repository import Gdk
@@ -20,16 +19,16 @@ from gi.repository import GdkPixbuf
 import cairo
 
 
-class ImageViewGtkError(ImageViewError):
+class ImageViewGtkError(ImageView.ImageViewError):
     pass
 
 
-class ImageViewGtk(ImageView):
+class ImageViewGtk(ImageView.ImageViewBase):
 
     def __init__(self, logger=None, rgbmap=None, settings=None):
-        ImageView.__init__(self, logger=logger,
-                           rgbmap=rgbmap,
-                           settings=settings)
+        ImageView.ImageViewBase.__init__(self, logger=logger,
+                                         rgbmap=rgbmap,
+                                         settings=settings)
 
         imgwin = Gtk.DrawingArea()
         imgwin.connect("draw", self.draw_event)
@@ -44,6 +43,23 @@ class ImageViewGtk(ImageView):
         self.imgwin = imgwin
         self.imgwin.show_all()
 
+        self.t_.set_defaults(renderer='cairo')
+
+        # create our default double-buffered surface area that we copy
+        # to the widget
+        rect = self.imgwin.get_allocation()
+        x, y, wd, ht = rect.x, rect.y, rect.width, rect.height
+        arr = np.zeros((ht, wd, 4), dtype=np.uint8)
+        stride = cairo.ImageSurface.format_stride_for_width(cairo.FORMAT_ARGB32,
+                                                            wd)
+        self.surface = cairo.ImageSurface.create_for_data(arr,
+                                                          cairo.FORMAT_ARGB32,
+                                                          wd, ht, stride)
+        if sys.byteorder == 'little':
+            self.rgb_order = 'BGRA'
+        else:
+            self.rgb_order = 'ARGB'
+
         # see reschedule_redraw() method
         self._defer_task = GtkHelp.Timer()
         self._defer_task.add_callback('expired',
@@ -52,8 +68,37 @@ class ImageViewGtk(ImageView):
         self.msgtask.add_callback('expired',
                                   lambda timer: self.onscreen_message(None))
 
+        self.renderer = None
+        # Pick a renderer that can work with us
+        renderers = ['cairo', 'agg', 'pil', 'opencv']
+        preferred = self.t_['renderer']
+        if preferred in renderers:
+            renderers.remove(preferred)
+        self.possible_renderers = [preferred] + renderers
+        self.choose_best_renderer()
+
     def get_widget(self):
         return self.imgwin
+
+    def choose_renderer(self, name):
+        klass = render.get_render_class(name)
+        self.renderer = klass(self)
+
+        rect = self.imgwin.get_allocation()
+        x, y, wd, ht = rect.x, rect.y, rect.width, rect.height
+        self.configure_window(wd, ht)
+
+    def choose_best_renderer(self):
+        for name in self.possible_renderers:
+            try:
+                self.choose_renderer(name)
+                self.logger.info("best renderer available is '{}'".format(name))
+                return
+            except Exception as e:
+                self.logger.error("Error choosing renderer '{}': {}".format(name, e))
+                continue
+
+        raise ImageViewGtkError("No valid renderers available: {}".format(str(self.possible_renderers)))
 
     def get_plain_image_as_pixbuf(self):
         arr = self.getwin_array(order='RGB', dtype=np.uint8)

--- a/ginga/pilw/CanvasRenderPil.py
+++ b/ginga/pilw/CanvasRenderPil.py
@@ -1,5 +1,5 @@
 #
-# CanvasRenderPil.py -- for rendering into a PIL Image
+# CanvasRenderPil.py -- for rendering into a Ginga widget with pillow
 #
 # This is open-source software licensed under a BSD license.
 # Please see the file LICENSE.txt for details.

--- a/ginga/pilw/ImageViewPil.py
+++ b/ginga/pilw/ImageViewPil.py
@@ -27,41 +27,17 @@ class ImageViewPil(ImageView.ImageViewBase):
 
         self.renderer = CanvasRenderer(self)
 
-    def get_surface(self):
-        return self.renderer.surface
-
-    def configure_surface(self, width, height):
-        self.renderer.resize((width, height))
-
-        # inform the base class about the actual window size
-        self.configure(width, height)
-
-    def get_image_as_array(self):
-        return self.renderer.get_surface_as_array(order=self.rgb_order)
-
-    def get_rgb_image_as_buffer(self, output=None, format='png', quality=90):
-        return self.renderer.get_surface_as_rgb_format_buffer(
-            output=output, format=format, quality=quality)
-
-    def get_rgb_image_as_bytes(self, format='png', quality=90):
-        return self.renderer.get_surface_as_rgb_format_bytes(
-            format=format, quality=quality)
-
-    def update_image(self):
-        # subclass implements this method to actually update a widget
-        # from the PIL surface
-        self.logger.warning("Subclass should override this method")
-        return False
-
-    def set_cursor(self, cursor):
-        # subclass implements this method to actually set a defined
-        # cursor on a widget
-        self.logger.warning("Subclass should override this method")
-
     def reschedule_redraw(self, time_sec):
         # subclass implements this method to call delayed_redraw() after
         # time_sec
         self.delayed_redraw()
+
+    def update_image(self):
+        # no widget to update
+        pass
+
+    def configure_window(self, width, height):
+        self.configure_surface(width, height)
 
 
 class CanvasView(ImageViewPil):
@@ -83,12 +59,5 @@ class CanvasView(ImageViewPil):
                                            private_canvas=private_canvas)
 
         self.objects[0] = self.private_canvas
-
-    def update_image(self):
-        # no widget to update
-        pass
-
-    def configure_window(self, width, height):
-        return super(CanvasView, self).configure_surface(width, height)
 
 # END

--- a/ginga/tkw/ImageViewTk.py
+++ b/ginga/tkw/ImageViewTk.py
@@ -93,7 +93,7 @@ class ImageViewTk(ImageView.ImageViewBase):
             except Exception as e:
                 continue
 
-        raise ImageViewPgError("No valid renderers available: {}".format(str(possible_renderers)))
+        raise ImageViewTkError("No valid renderers available: {}".format(str(self.possible_renderers)))
 
     def update_image(self):
         if self.tkcanvas is None:

--- a/ginga/web/jupyterw/ImageViewJpw.py
+++ b/ginga/web/jupyterw/ImageViewJpw.py
@@ -65,7 +65,7 @@ class ImageViewJpw(ImageView.ImageViewBase):
                                          rgbmap=rgbmap,
                                          settings=settings)
 
-        self.t_.set_defaults(renderer='pil')
+        self.t_.set_defaults(renderer='cairo')
 
         self.rgb_order = 'RGBA'
         self.jp_img = None
@@ -123,7 +123,7 @@ class ImageViewJpw(ImageView.ImageViewBase):
             except Exception as e:
                 continue
 
-        raise ImageViewJpwError("No valid renderers available: {}".format(str(possible_renderers)))
+        raise ImageViewJpwError("No valid renderers available: {}".format(str(self.possible_renderers)))
 
     def update_image(self):
         fmt = self.jp_img.format

--- a/ginga/web/pgw/ImageViewPg.py
+++ b/ginga/web/pgw/ImageViewPg.py
@@ -6,63 +6,50 @@
 # Please see the file LICENSE.txt for details.
 #
 
-from ginga import Mixins, Bindings
+from ginga import ImageView, Mixins, Bindings
 from ginga.canvas.mixins import DrawingMixin, CanvasMixin, CompoundMixin
+from ginga.canvas import render
 from ginga.util.toolbox import ModeIndicator
-
-
-try:
-    # See if we have aggdraw module--best choice
-    from ginga.aggw.ImageViewAgg import ImageViewAgg as ImageView, \
-        ImageViewAggError as ImageViewError
-
-except ImportError:
-    try:
-        # No, hmm..ok, see if we have PIL module...
-        from ginga.pilw.ImageViewPil import ImageViewPil as ImageView, \
-            ImageViewPilError as ImageViewError
-
-    except ImportError:
-        try:
-            # No dice. How about the OpenCv module?
-            from ginga.cvw.ImageViewCv import ImageViewCv as ImageView, \
-                ImageViewCvError as ImageViewError
-
-        except ImportError:
-            # Fall back to mock--there will be no graphic overlays
-            from ginga.mockw.ImageViewMock import ImageViewMock as ImageView, \
-                ImageViewMockError as ImageViewError
 
 
 default_html_fmt = 'jpeg'
 
 
-class ImageViewPgError(ImageViewError):
+class ImageViewPgError(ImageView.ImageViewError):
     pass
 
 
-class ImageViewPg(ImageView):
+class ImageViewPg(ImageView.ImageViewBase):
 
     def __init__(self, logger=None, rgbmap=None, settings=None):
-        ImageView.__init__(self, logger=logger,
-                           rgbmap=rgbmap,
-                           settings=settings)
+        ImageView.ImageViewBase.__init__(self, logger=logger,
+                                         rgbmap=rgbmap,
+                                         settings=settings)
 
         self.pgcanvas = None
 
         # format for rendering image on HTML5 canvas
         # NOTE: 'jpeg' has much better performance than 'png', but can show
         # some artifacts, especially noticeable with small text
-        self.t_.set_defaults(html5_canvas_format=default_html_fmt)
+        self.t_.set_defaults(html5_canvas_format=default_html_fmt,
+                             renderer='cairo')
 
-        # Format 'png' is ok with 'RGBA', but 'jpeg' only works with 'RGB'
-        self.rgb_order = 'RGB'
+        self.rgb_order = 'RGBA'
         # this should already be so, but just in case...
         self.defer_redraw = True
 
         # these will be assigned in set_widget()
         self.timer_redraw = None
         self.timer_msg = None
+
+        self.renderer = None
+        # Pick a renderer that can work with us
+        renderers = ['cairo', 'agg', 'pil', 'opencv']
+        preferred = self.t_['renderer']
+        if preferred in renderers:
+            renderers.remove(preferred)
+        self.possible_renderers = [preferred] + renderers
+        self.choose_best_renderer()
 
     def set_widget(self, canvas_w):
         """Call this method with the widget that will be used
@@ -79,11 +66,30 @@ class ImageViewPg(ImageView):
         self.timer_msg.add_callback('expired',
                                     lambda t: self.clear_onscreen_message())
 
-        ## wd, ht = canvas_w.get_size()
-        ## self.configure_window(wd, ht)
+        wd, ht = canvas_w.get_size()
+        self.configure_window(wd, ht)
 
     def get_widget(self):
         return self.pgcanvas
+
+    def choose_renderer(self, name):
+        klass = render.get_render_class(name)
+        self.renderer = klass(self)
+
+        if self.pgcanvas is not None:
+            wd, ht = self.pgcanvas_w.get_size()
+            self.configure_window(wd, ht)
+
+    def choose_best_renderer(self):
+        for name in self.possible_renderers:
+            try:
+                self.choose_renderer(name)
+                self.logger.info("best renderer available is '{}'".format(name))
+                return
+            except Exception as e:
+                continue
+
+        raise ImageViewPgError("No valid renderers available: {}".format(str(possible_renderers)))
 
     def update_image(self):
         self.logger.debug("update_image pgcanvas=%s" % self.pgcanvas)

--- a/ginga/web/pgw/ImageViewPg.py
+++ b/ginga/web/pgw/ImageViewPg.py
@@ -89,7 +89,7 @@ class ImageViewPg(ImageView.ImageViewBase):
             except Exception as e:
                 continue
 
-        raise ImageViewPgError("No valid renderers available: {}".format(str(possible_renderers)))
+        raise ImageViewPgError("No valid renderers available: {}".format(str(self.possible_renderers)))
 
     def update_image(self):
         self.logger.debug("update_image pgcanvas=%s" % self.pgcanvas)


### PR DESCRIPTION
This refactors the way viewers initialize their initial renderer. It allows for a flattening of the image viewer class hierarchy.  Some redundant code is removed.  Dynamic switching of the renderer in a live viewer is supported via the `choose_renderer` method.

The `cairo` renderer is made available to the Pg and Jupyter viewers, if the user has the `cairo` (`pycairo`?) package installed.  This renderer provides the most supported features (e.g. rotated text) and nicest text rendering for those viewers.


