### PR TITLE
fix link to ds9 bindings

### DIFF
--- a/doc/FAQ.rst
+++ b/doc/FAQ.rst
@@ -51,7 +51,7 @@ Control Bindings
 Can I get DS9-like user interface mappings?
 -------------------------------------------
 Save the file called `bindings.cfg.ds9
-<https://raw.github.com/ejeschke/ginga/master/examples/bindings/bindings.cfg.ds9>`_
+<https://raw.github.com/ejeschke/ginga/master/ginga/examples/bindings/bindings.cfg.ds9>`_
 and drop it in your ``$HOME/.ginga`` folder as "bindings.cfg".
 Then restart Ginga.
 


### PR DESCRIPTION
It looks like the path changed at some point, but this should fix it I think