### PR TITLE
Protections against possible problems from numpy 1.17.0 clip()

### DIFF
--- a/ginga/ColorDist.py
+++ b/ginga/ColorDist.py
@@ -35,7 +35,7 @@ class ColorDistBase(object):
     def hash_array(self, idx):
         # NOTE: data could be assumed to be in the range 0..hashsize-1
         # at this point but clip as a precaution
-        idx = idx.clip(0, self.hashsize - 1)
+        idx = idx.clip(0, self.hashsize - 1).astype(np.uint, copy=False)
         arr = self.hash[idx]
         return arr
 

--- a/ginga/RGBMap.py
+++ b/ginga/RGBMap.py
@@ -415,12 +415,12 @@ class RGBMapper(Callback.Callbacks):
         # but clip as a precaution
         # See NOTE [A]: idx is always an array calculated in the caller and
         #    discarded afterwards
-        # idx = idx.clip(0, self.maxc)
+        # idx = idx.clip(0, self.maxc).astype(np.uint, copy=False)
         idx.clip(0, self.maxc, out=idx)
 
         # run it through the shift array and clip the result
         # See NOTE [A]
-        # idx = self.sarr[idx].clip(0, self.maxc)
+        # idx = self.sarr[idx].clip(0, self.maxc).astype(np.uint, copy=False)
         idx = self.sarr[idx]
         idx.clip(0, self.maxc, out=idx)
 
@@ -509,7 +509,7 @@ class RGBMapper(Callback.Callbacks):
         iscale_x = float(old_wd) / float(new_wd)
 
         xi = (xi * iscale_x).astype(np.uint, copy=False)
-        xi = xi.clip(0, old_wd - 1)
+        xi = xi.clip(0, old_wd - 1).astype(np.uint, copy=False)
         newdata = sarr[xi]
         return newdata
 

--- a/ginga/tests/test_colordist.py
+++ b/ginga/tests/test_colordist.py
@@ -18,7 +18,7 @@ class TestColorDist(object):
         self.nonlinearity = 3.0
 
         # Input data
-        self.data = np.arange(self.hashsize, dtype='int')
+        self.data = np.arange(self.hashsize, dtype=np.int)
 
     def scale_and_rescale(self, disttype, data):
         """This is to generate expected scaled output."""
@@ -28,7 +28,8 @@ class TestColorDist(object):
                 idx.ravel(), self.hashsize, density=False)
             cdf = hist.cumsum()
             ohash = ((cdf - cdf.min()) * (self.colorlen - 1) /
-                     (cdf.max() - cdf.min())).astype('int')
+                     (cdf.max() - cdf.min())).astype(np.int)
+            idx = idx.astype(np.uint)
             result = ohash[idx]
         else:
             x = data / self.hashsize
@@ -48,7 +49,7 @@ class TestColorDist(object):
             elif disttype == 'sinh':
                 out = np.sinh(self.nonlinearity * x) / self.factor
 
-            result = (out.clip(0.0, 1.0) * (self.colorlen - 1)).astype('int')
+            result = (out.clip(0.0, 1.0) * (self.colorlen - 1)).astype(np.int)
 
         return result
 

--- a/ginga/trcalc.py
+++ b/ginga/trcalc.py
@@ -195,8 +195,8 @@ def rotate_clip(data_np, theta_deg, rotctr_x=None, rotctr_y=None,
             ap = (xi * cos_t) - (yi * sin_t) + rotctr_x
             bp = (xi * sin_t) + (yi * cos_t) + rotctr_y
 
-        #ap = np.rint(ap).astype('int').clip(0, wd-1)
-        #bp = np.rint(bp).astype('int').clip(0, ht-1)
+        #ap = np.rint(ap).clip(0, wd-1).astype(np.int)
+        #bp = np.rint(bp).clip(0, ht-1).astype(np.int)
         # Optomizations to reuse existing intermediate arrays
         np.rint(ap, out=ap)
         ap = ap.astype(np.int, copy=False)

--- a/ginga/util/iqcalc.py
+++ b/ginga/util/iqcalc.py
@@ -501,7 +501,7 @@ class IQCalc(object):
                  edgew=0.01):
 
         x1, y1, x2, y2 = int(x1), int(y1), int(x2), int(y2)
-        data = image.cutout_data(x1, y1, x2, y2, astype='float32')
+        data = image.cutout_data(x1, y1, x2, y2, astype=np.float)
 
         qs = self.pick_field(data, peak_radius=radius,
                              bright_radius=bright_radius,


### PR DESCRIPTION
`numpy` changed the behavior of `clip()` in 1.17.0 where it returns a float when operating on an int array.  This PR provides workarounds for potential code sections that could be affected.