### PR TITLE
DOC: Fix ico mimetype warning

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -116,7 +116,7 @@ html_logo = '_static/ginga-128x128.png'
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
-#html_favicon = ''
+html_favicon = ''
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.


### PR DESCRIPTION
Follow up of #798 . Not sure why we didn't see the RTD warning (which now causes failure for the PR check) back in #798. Maybe cache was not being cleared until after merge or something. 🤷‍♀ 

```
sphinx.errors.SphinxWarning: unknown mimetype for _static/astropy_logo.ico, ignoring

Warning, treated as error:
unknown mimetype for _static/astropy_logo.ico, ignoring
```