### PR TITLE
Fixed broken instances of usage with ArgumentParser

### DIFF
--- a/ginga/examples/bokeh/example2.py
+++ b/ginga/examples/bokeh/example2.py
@@ -47,8 +47,7 @@ if __name__ == "__main__":
     # Parse command line options
     from argparse import ArgumentParser
 
-    usage = "usage: %prog [options] [args]"
-    argprs = ArgumentParser(usage=usage)
+    argprs = ArgumentParser()
 
     argprs.add_argument("--debug", dest="debug", default=False,
                         action="store_true",

--- a/ginga/examples/gl/example2_qt.py
+++ b/ginga/examples/gl/example2_qt.py
@@ -245,8 +245,7 @@ if __name__ == "__main__":
     # Parse command line options
     from argparse import ArgumentParser
 
-    usage = "usage: %prog [options] [args]"
-    argprs = ArgumentParser(usage=usage)
+    argprs = ArgumentParser()
 
     argprs.add_argument("--debug", dest="debug", default=False,
                         action="store_true",

--- a/ginga/examples/gtk3/example2.py
+++ b/ginga/examples/gtk3/example2.py
@@ -243,8 +243,7 @@ if __name__ == "__main__":
     # Parse command line options
     from argparse import ArgumentParser
 
-    usage = "usage: %prog [options] [args]"
-    argprs = ArgumentParser(usage=usage)
+    argprs = ArgumentParser()
 
     argprs.add_argument("--debug", dest="debug", default=False,
                         action="store_true",

--- a/ginga/examples/gw/clocks.py
+++ b/ginga/examples/gw/clocks.py
@@ -366,7 +366,6 @@ if __name__ == "__main__":
     # Parse command line options
     import argparse
 
-    usage = "usage: %prog [options]"
     argprs = argparse.ArgumentParser(description="Parse command line options to clock")
 
     argprs.add_argument("args", type=str, nargs='*',

--- a/ginga/examples/gw/example1_video.py
+++ b/ginga/examples/gw/example1_video.py
@@ -277,8 +277,7 @@ if __name__ == '__main__':
     # Parse command line options
     from argparse import ArgumentParser
 
-    usage = "usage: %prog [options] [args]"
-    argprs = ArgumentParser(usage=usage)
+    argprs = ArgumentParser()
 
     argprs.add_argument("--debug", dest="debug", default=False,
                         action="store_true",

--- a/ginga/examples/gw/example2.py
+++ b/ginga/examples/gw/example2.py
@@ -318,8 +318,7 @@ if __name__ == "__main__":
     # Parse command line options
     from argparse import ArgumentParser
 
-    usage = "usage: %prog [options] [args]"
-    argprs = ArgumentParser(usage=usage)
+    argprs = ArgumentParser()
 
     argprs.add_argument("--debug", dest="debug", default=False,
                         action="store_true",

--- a/ginga/examples/gw/shared_canvas.py
+++ b/ginga/examples/gw/shared_canvas.py
@@ -310,8 +310,7 @@ if __name__ == "__main__":
     # Parse command line options
     from argparse import ArgumentParser
 
-    usage = "usage: %prog [options] [args]"
-    argprs = ArgumentParser(usage=usage)
+    argprs = ArgumentParser()
 
     argprs.add_argument("--debug", dest="debug", default=False,
                         action="store_true",

--- a/ginga/examples/matplotlib/example1_mpl.py
+++ b/ginga/examples/matplotlib/example1_mpl.py
@@ -154,8 +154,7 @@ if __name__ == "__main__":
     # Parse command line options
     from argparse import ArgumentParser
 
-    usage = "usage: %prog [options] [args]"
-    argprs = ArgumentParser(usage=usage)
+    argprs = ArgumentParser()
 
     argprs.add_argument("--debug", dest="debug", default=False,
                         action="store_true",

--- a/ginga/examples/matplotlib/example2_mpl.py
+++ b/ginga/examples/matplotlib/example2_mpl.py
@@ -278,8 +278,7 @@ if __name__ == "__main__":
     # Parse command line options
     from argparse import ArgumentParser
 
-    usage = "usage: %prog [options] [args]"
-    argprs = ArgumentParser(usage=usage)
+    argprs = ArgumentParser()
 
     argprs.add_argument("--debug", dest="debug", default=False,
                         action="store_true",

--- a/ginga/examples/matplotlib/example3_mpl.py
+++ b/ginga/examples/matplotlib/example3_mpl.py
@@ -396,8 +396,7 @@ if __name__ == "__main__":
     # Parse command line options
     from argparse import ArgumentParser
 
-    usage = "usage: %prog [options] [args]"
-    argprs = ArgumentParser(usage=usage)
+    argprs = ArgumentParser()
 
     argprs.add_argument("--debug", dest="debug", default=False,
                         action="store_true",

--- a/ginga/examples/pg/example2_pg.py
+++ b/ginga/examples/pg/example2_pg.py
@@ -313,8 +313,7 @@ if __name__ == "__main__":
     # Parse command line options
     from argparse import ArgumentParser
 
-    usage = "usage: %prog [options] [args]"
-    argprs = ArgumentParser(usage=usage)
+    argprs = ArgumentParser()
 
     argprs.add_argument("--debug", dest="debug", default=False, action="store_true",
                         help="Enter the pdb debugger on main()")

--- a/ginga/examples/qt/example2_qt.py
+++ b/ginga/examples/qt/example2_qt.py
@@ -306,8 +306,7 @@ if __name__ == "__main__":
     # Parse command line options
     from argparse import ArgumentParser
 
-    usage = "usage: %prog [options] [args]"
-    argprs = ArgumentParser(usage=usage)
+    argprs = ArgumentParser()
 
     argprs.add_argument("--debug", dest="debug", default=False,
                         action="store_true",

--- a/ginga/examples/qt/example_asdf.py
+++ b/ginga/examples/qt/example_asdf.py
@@ -312,8 +312,7 @@ if __name__ == "__main__":
     # Parse command line options
     from argparse import ArgumentParser
 
-    usage = "usage: %prog [options] [args]"
-    argprs = ArgumentParser(usage=usage)
+    argprs = ArgumentParser()
 
     argprs.add_argument("--debug", dest="debug", default=False,
                         action="store_true",

--- a/ginga/examples/tk/example2_tk.py
+++ b/ginga/examples/tk/example2_tk.py
@@ -205,8 +205,7 @@ if __name__ == "__main__":
     # Parse command line options
     from argparse import ArgumentParser
 
-    usage = "usage: %prog [options] [args]"
-    argprs = ArgumentParser(usage=usage)
+    argprs = ArgumentParser()
 
     argprs.add_argument("--debug", dest="debug", default=False,
                         action="store_true",

--- a/ginga/misc/grc.py
+++ b/ginga/misc/grc.py
@@ -48,8 +48,7 @@ def main(options, args):
 
 def _main():
     """Run from command line."""
-    usage = "usage: %prog [options] [args]"
-    argprs = ArgumentParser(usage=usage)
+    argprs = ArgumentParser()
 
     argprs.add_argument("--debug", dest="debug", default=False,
                         action="store_true",

--- a/ginga/rv/main.py
+++ b/ginga/rv/main.py
@@ -658,11 +658,12 @@ class ReferenceViewer(object):
             try:
                 # if there is a network component, start it
                 if hasattr(ginga_shell, 'start'):
+                    logger.info("starting network interface...")
                     task = Task.FuncTask2(ginga_shell.start)
                     thread_pool.addTask(task)
 
                 # Main loop to handle GUI events
-                logger.info("Entering mainloop...")
+                logger.info("entering mainloop...")
                 ginga_shell.mainloop(timeout=0.001)
 
             except KeyboardInterrupt:
@@ -710,8 +711,7 @@ def reference_viewer(sys_argv):
     # Parse command line options with argparse module
     from argparse import ArgumentParser
 
-    usage = "usage: %prog [options] cmd [args]"
-    argprs = ArgumentParser(usage=usage)
+    argprs = ArgumentParser(description="Run the Ginga reference viewer.")
     viewer.add_default_options(argprs)
     argprs.add_argument('-V', '--version', action='version',
                         version='%(prog)s {}'.format(version.version))

--- a/ginga/util/mosaic.py
+++ b/ginga/util/mosaic.py
@@ -330,8 +330,7 @@ if __name__ == "__main__":
     # Parse command line options
     from argparse import ArgumentParser
 
-    usage = "usage: %prog [options] [args]"
-    argprs = ArgumentParser(usage=usage)
+    argprs = ArgumentParser()
 
     argprs.add_argument("--debug", dest="debug", default=False,
                         action="store_true",

--- a/ginga/web/pgw/ipg.py
+++ b/ginga/web/pgw/ipg.py
@@ -514,8 +514,7 @@ if __name__ == "__main__":
     # Parse command line options
     from argparse import ArgumentParser
 
-    usage = "usage: %prog [options] [args]"
-    argprs = ArgumentParser(usage=usage)
+    argprs = ArgumentParser()
 
     argprs.add_argument("-d", "--basedir", dest="basedir", metavar="DIR",
                         default=".",


### PR DESCRIPTION
this fixes a number of broken instances of ArgumentParser due to incorrect upgrade of the `usage` parameter.