### PR TITLE
Fix an issue where home directory is not defined

### DIFF
--- a/ginga/util/paths.py
+++ b/ginga/util/paths.py
@@ -8,8 +8,10 @@ import os
 
 import ginga.icons
 
-home = None
 ginga_home = None
+# this is supposedly the canonical method to get home directory
+# across platforms
+home = os.path.expanduser('~')
 
 # path to our icons
 icondir = os.path.split(ginga.icons.__file__)[0]
@@ -19,18 +21,8 @@ if 'GINGA_HOME' in os.environ:
     # User override
     ginga_home = os.environ['GINGA_HOME']
 
-elif 'HOME' in os.environ:
-    # Posix/Linux/Mac
-    home = os.environ['HOME']
-    ginga_home = os.path.join(home, '.ginga')
-
-elif ('HOMEDRIVE' in os.environ) and ('HOMEPATH' in os.environ):
-    # MS
-    home = os.path.join(os.environ['HOMEDRIVE'], os.environ['HOMEPATH'])
-    ginga_home = os.path.join(home, '.ginga')
-
 else:
-    raise Exception("Can't find home directory, please set HOME or "
-                    "GINGA_HOME environment variables")
+    ginga_home = os.path.join(home, '.ginga')
+
 
 # END


### PR DESCRIPTION
This fixes an issue where if the user sets their GINGA_HOME environment variable then the home directory is not defined in ginga.util.paths