### PR TITLE
Unify the coordinate API for canvas types

### DIFF
--- a/ginga/canvas/types/astro.py
+++ b/ginga/canvas/types/astro.py
@@ -27,7 +27,7 @@ __all__ = ['Ruler', 'Compass', 'Crosshair', 'AnnulusMixin', 'Annulus',
            'Annulus2R', 'WCSAxes']
 
 
-class Ruler(TwoPointMixin, CanvasObjectBase):
+class RulerP(TwoPointMixin, CanvasObjectBase):
     """
     Draws a WCS ruler (like a right triangle) on a DrawingCanvas.
     Parameters are:
@@ -86,14 +86,14 @@ class Ruler(TwoPointMixin, CanvasObjectBase):
 
     @classmethod
     def idraw(cls, canvas, cxt):
-        return cls(cxt.start_x, cxt.start_y, cxt.x, cxt.y, **cxt.drawparams)
+        return cls((cxt.start_x, cxt.start_y), (cxt.x, cxt.y), **cxt.drawparams)
 
-    def __init__(self, x1, y1, x2, y2, color='green', color2='skyblue',
+    def __init__(self, pt1, pt2, color='green', color2='skyblue',
                  alpha=1.0, linewidth=1, linestyle='solid',
                  showcap=True, showplumb=True, showends=False, units='arcmin',
                  font='Sans Serif', fontsize=None, **kwdargs):
         self.kind = 'ruler'
-        points = np.asarray([(x1, y1), (x2, y2)], dtype=np.float)
+        points = np.asarray([pt1, pt2], dtype=np.float)
         CanvasObjectBase.__init__(self, color=color, color2=color2,
                                   alpha=alpha, units=units,
                                   showplumb=showplumb, showends=showends,
@@ -247,7 +247,25 @@ class Ruler(TwoPointMixin, CanvasObjectBase):
             self.draw_caps(cr, self.cap, ((cx2, cy1), ))
 
 
-class Compass(OnePointOneRadiusMixin, CanvasObjectBase):
+class Ruler(RulerP):
+
+    @classmethod
+    def idraw(cls, canvas, cxt):
+        return cls(cxt.start_x, cxt.start_y, cxt.x, cxt.y, **cxt.drawparams)
+
+    def __init__(self, x1, y1, x2, y2, color='green', color2='skyblue',
+                 alpha=1.0, linewidth=1, linestyle='solid',
+                 showcap=True, showplumb=True, showends=False, units='arcmin',
+                 font='Sans Serif', fontsize=None, **kwdargs):
+        RulerP.__init__(self, (x1, y1), (x2, y2), color=color, color2=color2,
+                        alpha=alpha, units=units,
+                        showplumb=showplumb, showends=showends,
+                        linewidth=linewidth, showcap=showcap,
+                        linestyle=linestyle, font=font, fontsize=fontsize,
+                        **kwdargs)
+
+
+class CompassP(OnePointOneRadiusMixin, CanvasObjectBase):
     """
     Draws a WCS compass on a DrawingCanvas.
     Parameters are:
@@ -298,13 +316,13 @@ class Compass(OnePointOneRadiusMixin, CanvasObjectBase):
     def idraw(cls, canvas, cxt):
         radius = np.sqrt(abs(cxt.start_x - cxt.x) ** 2 +
                          abs(cxt.start_y - cxt.y) ** 2)
-        return cls(cxt.start_x, cxt.start_y, radius, **cxt.drawparams)
+        return cls((cxt.start_x, cxt.start_y), radius, **cxt.drawparams)
 
-    def __init__(self, x, y, radius, ctype='wcs', color='skyblue',
+    def __init__(self, pt, radius, ctype='wcs', color='skyblue',
                  linewidth=1, fontsize=None, font='Sans Serif',
                  alpha=1.0, linestyle='solid', showcap=True, **kwdargs):
         self.kind = 'compass'
-        points = np.asarray([(x, y)], dtype=np.float)
+        points = np.asarray([pt], dtype=np.float)
         CanvasObjectBase.__init__(self, ctype=ctype, color=color, alpha=alpha,
                                   linewidth=linewidth, showcap=showcap,
                                   linestyle=linestyle,
@@ -440,7 +458,24 @@ class Compass(OnePointOneRadiusMixin, CanvasObjectBase):
         return (xd, yd)
 
 
-class Crosshair(OnePointMixin, CanvasObjectBase):
+class Compass(CompassP):
+
+    @classmethod
+    def idraw(cls, canvas, cxt):
+        radius = np.sqrt(abs(cxt.start_x - cxt.x) ** 2 +
+                         abs(cxt.start_y - cxt.y) ** 2)
+        return cls(cxt.start_x, cxt.start_y, radius, **cxt.drawparams)
+
+    def __init__(self, x, y, radius, ctype='wcs', color='skyblue',
+                 linewidth=1, fontsize=None, font='Sans Serif',
+                 alpha=1.0, linestyle='solid', showcap=True, **kwdargs):
+        CompassP.__init__(self, (x, y), radius, ctype=ctype, color=color,
+                          alpha=alpha, linewidth=linewidth, showcap=showcap,
+                          linestyle=linestyle, font=font, fontsize=fontsize,
+                          **kwdargs)
+
+
+class CrosshairP(OnePointMixin, CanvasObjectBase):
     """
     Draws a crosshair on a DrawingCanvas.
     Parameters are:
@@ -490,15 +525,15 @@ class Crosshair(OnePointMixin, CanvasObjectBase):
 
     @classmethod
     def idraw(cls, canvas, cxt):
-        return cls(cxt.x, cxt.y, **cxt.drawparams)
+        return cls((cxt.x, cxt.y), **cxt.drawparams)
 
-    def __init__(self, x, y, color='green',
+    def __init__(self, pt, color='green',
                  linewidth=1, alpha=1.0, linestyle='solid',
                  text=None, textcolor='yellow',
                  fontsize=10.0, font='Sans Serif', fontscale=True,
                  format='xy', **kwdargs):
         self.kind = 'crosshair'
-        points = np.asarray([(x, y)], dtype=np.float)
+        points = np.asarray([pt], dtype=np.float)
         CanvasObjectBase.__init__(self, color=color, alpha=alpha,
                                   linewidth=linewidth, linestyle=linestyle,
                                   text=text, textcolor=textcolor,
@@ -564,6 +599,25 @@ class Crosshair(OnePointMixin, CanvasObjectBase):
         cr.draw_text(cx + 10, cy + 4 + txtht, text)
 
 
+class Crosshair(CrosshairP):
+
+    @classmethod
+    def idraw(cls, canvas, cxt):
+        return cls(cxt.x, cxt.y, **cxt.drawparams)
+
+    def __init__(self, x, y, color='green',
+                 linewidth=1, alpha=1.0, linestyle='solid',
+                 text=None, textcolor='yellow',
+                 fontsize=10.0, font='Sans Serif', fontscale=True,
+                 format='xy', **kwdargs):
+        CrosshairP.__init__(self, (x, y), color=color, alpha=alpha,
+                            linewidth=linewidth, linestyle=linestyle,
+                            text=text, textcolor=textcolor,
+                            fontsize=fontsize, font=font,
+                            fontscale=fontscale,
+                            format=format, **kwdargs)
+
+
 class AnnulusMixin(object):
 
     def contains_pt(self, pt):
@@ -588,7 +642,7 @@ class AnnulusMixin(object):
         return obj2.select_contains_pt(viewer, pt)
 
 
-class Annulus(AnnulusMixin, OnePointOneRadiusMixin, CompoundObject):
+class AnnulusP(AnnulusMixin, OnePointOneRadiusMixin, CompoundObject):
     """
     Special compound object to handle annulus shape that
     consists of two objects with the same centroid.
@@ -637,14 +691,13 @@ class Annulus(AnnulusMixin, OnePointOneRadiusMixin, CompoundObject):
     def idraw(cls, canvas, cxt):
         radius = np.sqrt(abs(cxt.start_x - cxt.x)**2 +
                          abs(cxt.start_y - cxt.y)**2)
-        return cls(cxt.start_x, cxt.start_y, radius,
+        return cls((cxt.start_x, cxt.start_y), radius,
                    **cxt.drawparams)
 
-    def __init__(self, x, y, radius, width=None,
+    def __init__(self, pt, radius, width=None,
                  atype='circle', color='yellow',
                  linewidth=1, linestyle='solid', alpha=1.0,
                  **kwdargs):
-
         if width is None:
             # default width is 15% of radius
             width = 0.15 * radius
@@ -656,19 +709,19 @@ class Annulus(AnnulusMixin, OnePointOneRadiusMixin, CompoundObject):
         coord = kwdargs.get('coord', None)
 
         klass = get_canvas_type(atype)
-        obj1 = klass(x, y, radius, color=color,
+        obj1 = klass(pt[0], pt[1], radius, color=color,
                      linewidth=linewidth,
                      linestyle=linestyle, alpha=alpha,
                      coord=coord)
         obj1.editable = False
 
-        obj2 = klass(x, y, oradius, color=color,
+        obj2 = klass(pt[0], pt[1], oradius, color=color,
                      linewidth=linewidth,
                      linestyle=linestyle, alpha=alpha,
                      coord=coord)
         obj2.editable = False
 
-        points = np.asarray([(x, y)], dtype=np.float)
+        points = np.asarray([pt], dtype=np.float)
 
         CompoundObject.__init__(self, obj1, obj2,
                                 points=points, radius=radius,
@@ -743,7 +796,25 @@ class Annulus(AnnulusMixin, OnePointOneRadiusMixin, CompoundObject):
         self.set_data_points([dst_pt])
 
 
-class Annulus2R(AnnulusMixin, OnePointTwoRadiusMixin, CompoundObject):
+class Annulus(AnnulusP):
+
+    @classmethod
+    def idraw(cls, canvas, cxt):
+        radius = np.sqrt(abs(cxt.start_x - cxt.x)**2 +
+                         abs(cxt.start_y - cxt.y)**2)
+        return cls(cxt.start_x, cxt.start_y, radius,
+                   **cxt.drawparams)
+
+    def __init__(self, x, y, radius, width=None,
+                 atype='circle', color='yellow',
+                 linewidth=1, linestyle='solid', alpha=1.0,
+                 **kwdargs):
+        AnnulusP.__init__(self, (x, y), radius, width=width, atype=atype,
+                          color=color, linewidth=linewidth,
+                          linestyle=linestyle, alpha=alpha, **kwdargs)
+
+
+class Annulus2RP(AnnulusMixin, OnePointTwoRadiusMixin, CompoundObject):
     """
     Special compound object to handle annulus shape that
     consists of two objects, (one center point, plus two radii).
@@ -800,13 +871,14 @@ class Annulus2R(AnnulusMixin, OnePointTwoRadiusMixin, CompoundObject):
     @classmethod
     def idraw(cls, canvas, cxt):
         xradius, yradius = abs(cxt.start_x - cxt.x), abs(cxt.start_y - cxt.y)
-        return cls(cxt.start_x, cxt.start_y, xradius, yradius, **cxt.drawparams)
+        return cls((cxt.start_x, cxt.start_y), (xradius, yradius),
+                   **cxt.drawparams)
 
-    def __init__(self, x, y, xradius, yradius, xwidth=None,
+    def __init__(self, pt, radii, xwidth=None,
                  ywidth=None, atype='ellipse', color='yellow',
                  linewidth=1, linestyle='solid', alpha=1.0,
                  rot_deg=0.0, **kwdargs):
-
+        xradius, yradius = radii
         if xwidth is None:
             # default X width is 15% of X radius
             xwidth = 0.15 * xradius
@@ -822,19 +894,19 @@ class Annulus2R(AnnulusMixin, OnePointTwoRadiusMixin, CompoundObject):
         coord = kwdargs.get('coord', None)
 
         klass = get_canvas_type(atype)
-        obj1 = klass(x, y, xradius, yradius, color=color,
+        obj1 = klass(pt[0], pt[1], radii[0], radii[1], color=color,
                      linewidth=linewidth,
                      linestyle=linestyle, alpha=alpha,
                      coord=coord, rot_deg=rot_deg)
         obj1.editable = False
 
-        obj2 = klass(x, y, oxradius, oyradius, color=color,
+        obj2 = klass(pt[0], pt[1], oxradius, oyradius, color=color,
                      linewidth=linewidth,
                      linestyle=linestyle, alpha=alpha,
                      coord=coord, rot_deg=rot_deg)
         obj2.editable = False
 
-        points = np.asarray([(x, y)], dtype=np.float)
+        points = np.asarray([pt], dtype=np.float)
 
         CompoundObject.__init__(self, obj1, obj2,
                                 points=points, xradius=xradius, yradius=yradius,
@@ -946,6 +1018,25 @@ class Annulus2R(AnnulusMixin, OnePointTwoRadiusMixin, CompoundObject):
         super(Annulus2R, self).move_to_pt(dst_pt)
 
         self.set_data_points([dst_pt])
+
+
+class Annulus2R(Annulus2RP):
+
+    @classmethod
+    def idraw(cls, canvas, cxt):
+        xradius, yradius = abs(cxt.start_x - cxt.x), abs(cxt.start_y - cxt.y)
+        return cls(cxt.start_x, cxt.start_y, xradius, yradius,
+                   **cxt.drawparams)
+
+    def __init__(self, x, y, xradius, yradius, xwidth=None,
+                 ywidth=None, atype='ellipse', color='yellow',
+                 linewidth=1, linestyle='solid', alpha=1.0,
+                 rot_deg=0.0, **kwdargs):
+        Annulus2RP.__init__(self, (x, y), (xradius, yradius),
+                            xwidth=xwidth, ywidth=ywidth, atype=atype,
+                            color=color, linewidth=linewidth,
+                            linestyle=linestyle, alpha=alpha,
+                            rot_deg=rot_deg, **kwdargs)
 
 
 class WCSAxes(CompoundObject):

--- a/ginga/canvas/types/image.py
+++ b/ginga/canvas/types/image.py
@@ -18,7 +18,7 @@ from ginga import trcalc
 from .mixins import OnePointMixin
 
 
-class Image(OnePointMixin, CanvasObjectBase):
+class ImageP(OnePointMixin, CanvasObjectBase):
     """Draws an image on a ImageViewCanvas.
     Parameters are:
     x, y: 0-based coordinates of one corner in the data space
@@ -66,13 +66,13 @@ class Image(OnePointMixin, CanvasObjectBase):
                   description="Optimize rendering for this object"),
         ]
 
-    def __init__(self, x, y, image, alpha=1.0, scale_x=1.0, scale_y=1.0,
+    def __init__(self, pt, image, alpha=1.0, scale_x=1.0, scale_y=1.0,
                  interpolation=None,
                  linewidth=0, linestyle='solid', color='lightgreen',
                  showcap=False, flipy=False, optimize=True,
                  **kwdargs):
         self.kind = 'image'
-        points = np.asarray([(x, y)], dtype=np.float)
+        points = np.asarray([pt], dtype=np.float)
         CanvasObjectBase.__init__(self, points=points, image=image, alpha=alpha,
                                   scale_x=scale_x, scale_y=scale_y,
                                   interpolation=interpolation,
@@ -334,7 +334,23 @@ class Image(OnePointMixin, CanvasObjectBase):
         self.reset_optimize()
 
 
-class NormImage(Image):
+class Image(ImageP):
+
+    def __init__(self, x, y, image, alpha=1.0, scale_x=1.0, scale_y=1.0,
+                 interpolation=None,
+                 linewidth=0, linestyle='solid', color='lightgreen',
+                 showcap=False, flipy=False, optimize=True,
+                 **kwdargs):
+        ImageP.__init__(self, (x, y), image, alpha=alpha,
+                        scale_x=scale_x, scale_y=scale_y,
+                        interpolation=interpolation,
+                        linewidth=linewidth, linestyle=linestyle,
+                        color=color, showcap=showcap,
+                        flipy=flipy, optimize=optimize,
+                        **kwdargs)
+
+
+class NormImageP(ImageP):
     """Draws an image on a ImageViewCanvas.
 
     Parameters are:
@@ -389,18 +405,18 @@ class NormImage(Image):
             ##       description="Cuts manager for the image"),
         ]
 
-    def __init__(self, x, y, image, alpha=1.0, scale_x=1.0, scale_y=1.0,
+    def __init__(self, pt, image, alpha=1.0, scale_x=1.0, scale_y=1.0,
                  interpolation=None, cuts=None, linewidth=0, linestyle='solid',
                  color='lightgreen', showcap=False,
                  optimize=True, rgbmap=None, autocuts=None, **kwdargs):
         self.kind = 'normimage'
-        super(NormImage, self).__init__(x, y, image=image, alpha=alpha,
-                                        scale_x=scale_x, scale_y=scale_y,
-                                        interpolation=interpolation,
-                                        linewidth=linewidth, linestyle=linestyle,
-                                        color=color,
-                                        showcap=showcap, optimize=optimize,
-                                        **kwdargs)
+        super(NormImageP, self).__init__(pt, image, alpha=alpha,
+                                         scale_x=scale_x, scale_y=scale_y,
+                                         interpolation=interpolation,
+                                         linewidth=linewidth, linestyle=linestyle,
+                                         color=color,
+                                         showcap=showcap, optimize=optimize,
+                                         **kwdargs)
         self.rgbmap = rgbmap
         self.cuts = cuts
         self.autocuts = autocuts
@@ -508,6 +524,20 @@ class NormImage(Image):
         self.scale_x *= scale_x
         self.scale_y *= scale_y
         self.reset_optimize()
+
+
+class NormImage(NormImageP):
+
+    def __init__(self, x, y, image, alpha=1.0, scale_x=1.0, scale_y=1.0,
+                 interpolation=None, cuts=None, linewidth=0, linestyle='solid',
+                 color='lightgreen', showcap=False,
+                 optimize=True, rgbmap=None, autocuts=None, **kwdargs):
+        NormImageP.__init__(self, (x, y), image, alpha=alpha,
+                            scale_x=scale_x, scale_y=scale_y,
+                            interpolation=interpolation,
+                            linewidth=linewidth, linestyle=linestyle,
+                            color=color, showcap=showcap, optimize=optimize,
+                            **kwdargs)
 
 
 # register our types

--- a/ginga/canvas/types/utils.py
+++ b/ginga/canvas/types/utils.py
@@ -7,7 +7,7 @@
 from ginga.canvas.CanvasObject import (CanvasObjectBase, _bool, _color,
                                        register_canvas_types,
                                        colors_plus_none, coord_names)
-from .basic import Rectangle
+from .basic import RectangleP
 from ginga.misc.ParamSet import Param
 
 
@@ -197,7 +197,7 @@ class ColorBar(CanvasObjectBase):
             cr.draw_polygon(tr.to_(cpoints))
 
 
-class DrawableColorBar(Rectangle):
+class DrawableColorBarP(RectangleP):
 
     @classmethod
     def get_params_metadata(cls):
@@ -243,16 +243,16 @@ class DrawableColorBar(Rectangle):
                   description="Opacity of fill"),
         ]
 
-    def __init__(self, x1, y1, x2, y2, showrange=True,
+    def __init__(self, p1, p2, showrange=True,
                  font='Sans Serif', fontsize=8,
                  color='black', bgcolor='white',
                  linewidth=1, linestyle='solid', alpha=1.0,
                  fillalpha=1.0, rgbmap=None, optimize=True, **kwdargs):
-        Rectangle.__init__(self, x1, y1, x2, y2,
-                           font=font, fontsize=fontsize,
-                           color=color, bgcolor=bgcolor, linewidth=linewidth,
-                           linestyle=linestyle, alpha=alpha,
-                           fillalpha=fillalpha, **kwdargs)
+        RectangleP.__init__(self, p1, p2,
+                            font=font, fontsize=fontsize,
+                            color=color, bgcolor=bgcolor, linewidth=linewidth,
+                            linestyle=linestyle, alpha=alpha,
+                            fillalpha=fillalpha, **kwdargs)
         self.showrange = showrange
         self.rgbmap = rgbmap
         self.kind = 'drawablecolorbar'
@@ -383,6 +383,26 @@ class DrawableColorBar(Rectangle):
             cx1, cy1, cx2, cy2 = x_base, y_base, x_top, y_top
             cpoints = ((cx1, cy1), (cx2, cy1), (cx2, cy2), (cx1, cy2))
             cr.draw_polygon(tr.to_(cpoints))
+
+
+class DrawableColorBar(DrawableColorBarP):
+
+    @classmethod
+    def idraw(cls, canvas, cxt):
+        return cls(cxt.start_x, cxt.start_y, cxt.x, cxt.y, **cxt.drawparams)
+
+    def __init__(self, x1, y1, x2, y2, showrange=True,
+                 font='Sans Serif', fontsize=8,
+                 color='black', bgcolor='white',
+                 linewidth=1, linestyle='solid', alpha=1.0,
+                 fillalpha=1.0, rgbmap=None, optimize=True, **kwdargs):
+        DrawableColorBarP.__init__(self, (x1, y1), (x2, y2),
+                                   showrange=showrange, font=font,
+                                   fontsize=fontsize,
+                                   color=color, bgcolor=bgcolor,
+                                   linewidth=linewidth, linestyle=linestyle,
+                                   alpha=alpha, fillalpha=fillalpha,
+                                   rgbmap=rgbmap, optimize=optimize, **kwdargs)
 
 
 class ModeIndicator(CanvasObjectBase):


### PR DESCRIPTION
This adds alternative classes for many canvas types so that *all* types use an API where points are specified as single parameters.  This will be beneficial if we ever want to make a common change to coordinate handling across all canvas objects.

To illustrate, before:
```python
>>> canvas.add(Rectangle(x1, y1, x2, y2, ...))
```
after:
```python
>>> canvas.add(RectangleP(p1, p2, ...))
```
Subclasses are used to keep API compatible versions of the old class constructors available, and the new classes are not exposed as drawing catalog members yet (although you can explictly import them and use them. So there is no API change visible to any older code.