### PR TITLE
WIP: add Undistort plugin -- roughly correct for SIP distortion

### DIFF
--- a/ginga/rv/main.py
+++ b/ginga/rv/main.py
@@ -144,6 +144,8 @@ plugins = [
     Bunch(module='ChangeHistory', tab='History', workspace='right',
           menu="History [G]", start=False, category='Utils', ptype='global'),
     Bunch(module='Mosaic', workspace='dialogs', category='Utils', ptype='local'),
+    Bunch(module='Undistort', workspace='dialogs', category='Utils',
+          ptype='local'),
     Bunch(module='FBrowser', tab='Open File', workspace='right',
           menu="Open File [G]", start=False, category='Utils', ptype='global'),
     Bunch(module='Preferences', workspace='dialogs', category='Utils',

--- a/ginga/rv/plugins/Undistort.py
+++ b/ginga/rv/plugins/Undistort.py
@@ -1,0 +1,148 @@
+# This is open-source software licensed under a BSD license.
+# Please see the file LICENSE.txt for details.
+"""
+``Undistort`` is a simple plugin to roughly "undistort" an image based on
+it's SIP information a WCS.
+
+**Plugin Type: Local**
+
+``Undistort`` is a local plugin, which means it is associated with a channel.
+An instance can be opened for each channel.
+
+**Usage**
+
+Start the plugin on a channel.  Click "Undistort" to quickly correct the
+distortion for the image in the channel.
+"""
+import os.path
+from astropy.io import fits
+
+from ginga import GingaPlugin, AstroImage
+from ginga.misc import Future
+from ginga.gw import Widgets
+from ginga.util.undistort import quick_undistort_image
+
+__all__ = ['Undistort']
+
+
+class Undistort(GingaPlugin.LocalPlugin):
+
+    def __init__(self, fv, fitsimage):
+        # superclass defines some variables for us, like logger
+        super(Undistort, self).__init__(fv, fitsimage)
+
+        self.count = 1
+        self.cache_dir = "/tmp"
+
+    def build_gui(self, container):
+        vtop = Widgets.VBox()
+        vtop.set_border_width(4)
+
+        captions = (("Undistort", 'button', "_zzz", 'spacer'),
+                    ("status", "llabel")
+                    )
+        w, b = Widgets.build_info(captions, orientation='vertical')
+        self.w.update(b)
+        vtop.add_widget(w, stretch=0)
+
+        b.undistort.add_callback('activated', self.undistort_cb)
+        b.undistort.set_tooltip("Click to save channel image as undistorted image")
+        b.status.set_text("")
+
+        # stretch
+        spacer = Widgets.Label('')
+        vtop.add_widget(spacer, stretch=1)
+
+        btns = Widgets.HBox()
+        btns.set_border_width(4)
+        btns.set_spacing(4)
+
+        btn = Widgets.Button("Close")
+        btn.add_callback('activated', lambda w: self.close())
+        btns.add_widget(btn)
+        btn = Widgets.Button("Help")
+        btn.add_callback('activated', lambda w: self.help())
+        btns.add_widget(btn, stretch=0)
+        btns.add_widget(Widgets.Label(''), stretch=1)
+        vtop.add_widget(btns, stretch=0)
+
+        container.add_widget(vtop, stretch=5)
+        self.gui_up = True
+
+    def close(self):
+        self.fv.stop_local_plugin(self.chname, str(self))
+        return True
+
+    def redo(self):
+        pass
+
+    def undistort(self, image, name=None, cache_dir=None):
+        if image is None or image.wcs is None:
+            self.fv.show_error("Undistort: null target image or WCS")
+            return
+        wcs_in = image.wcs.wcs
+        data_in = image.get_data()
+
+        # do undistortion
+        data_out, wcs_out = quick_undistort_image(data_in, wcs_in)
+
+        # TODO: use mask (probably as alpha mask)
+        hdu = fits.PrimaryHDU(data_out)
+        # add conversion wcs keywords
+        hdu.header.update(wcs_out.to_header())
+        if name is None:
+            name = self.get_name(image.get('name'), cache_dir)
+
+        # Write image to cache directory, if one is defined
+        path = None
+        if cache_dir is not None:
+            path = os.path.join(cache_dir, name + '.fits')
+            hdulst = fits.HDUList([hdu])
+            hdulst.writeto(path)
+            self.logger.info("wrote {}".format(path))
+
+        img_out = AstroImage.AstroImage(logger=self.logger)
+        img_out.load_hdu(hdu)
+        img_out.set(name=name, path=path)
+
+        return img_out
+
+    def _undistort_cont(self, future):
+        self.fv.gui_call(self.w.status.set_text, "")
+        try:
+            img_out = future.get_value()
+
+        except Exception as e:
+            self.fv.show_error("undistort error: {}".format(e))
+            return
+
+        if img_out is not None:
+            self.fv.gui_do(self.channel.add_image, img_out)
+
+    def undistort_cb(self, w):
+        image = self.fitsimage.get_image()
+
+        future = Future.Future()
+        future.freeze(self.undistort, image, cache_dir=self.cache_dir)
+        future.add_callback('resolved', self._undistort_cont)
+
+        self.w.status.set_text("Working...")
+        self.fv.nongui_do_future(future)
+
+    def get_name(self, name_in, cache_dir):
+        found = False
+        while not found:
+            name = name_in + '-undst-{}'.format(self.count)
+            self.count += 1
+
+            # Write image to cache directory, if one is defined
+            path = None
+            if cache_dir is None:
+                return name
+
+            path = os.path.join(cache_dir, name + '.fits')
+            if not os.path.exists(path):
+                return name
+
+    def __str__(self):
+        return 'undistort'

--- a/ginga/util/undistort.py
+++ b/ginga/util/undistort.py
@@ -2,7 +2,9 @@
 # Please see the file LICENSE.txt for details.
 
 import copy
+
 import numpy as np
+from astropy.wcs import WCS
 
 
 # see https://github.com/astropy/astropy/issues/3675 for inspiration
@@ -32,34 +34,50 @@ def quick_undistort_image(data_in, wcs_in):
     # enumerate all pixels in input data
     ht, wd = data_in.shape
     yi, xi = np.mgrid[0:ht, 0:wd]
-    pts = np.array((yi.ravel(), xi.ravel())).T
+    pts = np.array((xi.ravel(), yi.ravel())).T
 
     # translate to world coordinates, taking into account all SIP
     # distortion corrections
     sky = wcs_in.all_pix2world(pts, 0, ra_dec_order=True)
 
+    n = len(sky) // 2
+    crval1, crval2 = sky[n]
+
     # translate back to pixel coordinates, *without* SIP corrections
     pts2 = wcs_in.wcs_world2pix(sky, 0)
+
+    crpix1, crpix2 = pts2[n]
 
     # round to integer pixels
     pts2 = np.round(pts2).astype(np.int)
 
     # determine size of new destination array
-    y_min, y_max = pts2[:, 0].min(), pts2[:, 0].max()
-    x_min, x_max = pts2[:, 1].min(), pts2[:, 1].max()
+    y_min, y_max = pts2[:, 1].min(), pts2[:, 1].max()
+    x_min, x_max = pts2[:, 0].min(), pts2[:, 0].max()
     new_ht, new_wd = y_max - y_min + 1, x_max - x_min + 1
 
     # create empty array holding NaNs
     out_arr = np.full((new_ht, new_wd), np.NaN)
 
     # deposit pixels in to output array
-    y2i, x2i = pts2[:, 0] - y_min, pts2[:, 1] - x_min
-    out_arr[y2i, x2i] = data_in[pts[:, 0], pts[:, 1]]
+    y2i, x2i = pts2[:, 1] - y_min, pts2[:, 0] - x_min
+    out_arr[y2i, x2i] = data_in[pts[:, 1], pts[:, 0]]
 
     # create a new WCS without the SIP info
     # TODO: need someone with knowledge of astropy.WCS to say if this
     # is sufficient
     new_wcs = copy.deepcopy(wcs_in)
     new_wcs.sip = None
+
+    # update CRPIX and CRVAL keywords to reflect new array
+    # TODO: this is not quite right, rounding error
+    header = new_wcs.to_header()
+
+    header['CRPIX1'] = crpix1 - x_min
+    header['CRPIX2'] = crpix2 - y_min
+    header['CRVAL1'] = crval1
+    header['CRVAL2'] = crval2
+
+    new_wcs = WCS(header)
 
     return out_arr, new_wcs

--- a/ginga/util/undistort.py
+++ b/ginga/util/undistort.py
@@ -1,0 +1,65 @@
+# This is open-source software licensed under a BSD license.
+# Please see the file LICENSE.txt for details.
+
+import copy
+import numpy as np
+
+
+# see https://github.com/astropy/astropy/issues/3675 for inspiration
+# for this function
+
+def quick_undistort_image(data_in, wcs_in):
+    """Perform a quick undistortion of an image based on a WCS with
+    SIP distortion correction.
+
+    Parameters
+    ----------
+    data_in : ndarray
+        2D image data
+
+    wcs_in : ~astropy.wcs.WCS object
+        The WCS object associated with the data.
+
+    Returns
+    -------
+    data_out : ndarray
+        Quickly undistorted 2D array
+
+    wcs_out : ~astropy.wcs.WCS object
+        A new WCS object without distortion correction.
+    """
+
+    # enumerate all pixels in input data
+    ht, wd = data_in.shape
+    yi, xi = np.mgrid[0:ht, 0:wd]
+    pts = np.array((yi.ravel(), xi.ravel())).T
+
+    # translate to world coordinates, taking into account all SIP
+    # distortion corrections
+    sky = wcs_in.all_pix2world(pts, 0, ra_dec_order=True)
+
+    # translate back to pixel coordinates, *without* SIP corrections
+    pts2 = wcs_in.wcs_world2pix(sky, 0)
+
+    # round to integer pixels
+    pts2 = np.round(pts2).astype(np.int)
+
+    # determine size of new destination array
+    y_min, y_max = pts2[:, 0].min(), pts2[:, 0].max()
+    x_min, x_max = pts2[:, 1].min(), pts2[:, 1].max()
+    new_ht, new_wd = y_max - y_min + 1, x_max - x_min + 1
+
+    # create empty array holding NaNs
+    out_arr = np.full((new_ht, new_wd), np.NaN)
+
+    # deposit pixels in to output array
+    y2i, x2i = pts2[:, 0] - y_min, pts2[:, 1] - x_min
+    out_arr[y2i, x2i] = data_in[pts[:, 0], pts[:, 1]]
+
+    # create a new WCS without the SIP info
+    # TODO: need someone with knowledge of astropy.WCS to say if this
+    # is sufficient
+    new_wcs = copy.deepcopy(wcs_in)
+    new_wcs.sip = None
+
+    return out_arr, new_wcs


### PR DESCRIPTION
Adds a plugin called "Undistort".

It does a quick image correction for distortion information contained in the SIP WCS.

Load an image that is distorted.  Open Utils->Undistort.  Click the "Undistort" button to quickly correct for distortion.

NOTE: in this implementation, `NaN`s are substituted for pixels that are not mapped in the distortion-corrected image.