### PR TITLE
Add docutils to dependency list

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -32,6 +32,7 @@ Highly recommended, because some features will not be available without it:
   depending on where you get it from)
 * piexif
 * beautifulsoup4
+* docutils (to display help for plugins)
 
 For opening `FITS <https://fits.gsfc.nasa.gov/>`_ files you will
 need one of the following packages:

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ install_requires = numpy>=1.13; qtpy>=1.1; astropy>=3
 setup_requires = setuptools_scm
 
 [options.extras_require]
-recommended = pillow>=3.2.0; scipy>=0.18.1; matplotlib>=1.5.1; opencv-python>=3.4.1; piexif>=1.0.13; beautifulsoup4>=4.3.2
+recommended = pillow>=3.2.0; scipy>=0.18.1; matplotlib>=1.5.1; opencv-python>=3.4.1; piexif>=1.0.13; beautifulsoup4>=4.3.2; docutils
 test = attrs>=19.2.0; pytest-astropy
 docs = sphinx-astropy; sphinx_rtd_theme
 gtk3 = pycairo; pygobject


### PR DESCRIPTION
Looks like it is needed by `WBrowser` plugin.