### PR TITLE
MNT: Ignore import error in pytest collection

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ minversion = 3
 testpaths = "ginga" "doc"
 norecursedirs = build doc/_build
 astropy_header = true
-addopts = -p no:warnings
+addopts = -p no:warnings --doctest-ignore-import-errors
 
 [bdist_wheel]
 universal = 1


### PR DESCRIPTION
This is an automated update made by the `batchpr` tool :robot: to future-proof test collection behavior `pytest-doctestplus` - feel free to close if it doesn't look good or isn't relevant! You can report issues to @pllim.