### PR TITLE
Make get_oriented_box() return more sane results

### DIFF
--- a/ginga/gw/Widgets.py
+++ b/ginga/gw/Widgets.py
@@ -16,20 +16,24 @@ elif tkname == 'pg':
 
 # MODULE FUNCTIONS
 
-def get_orientation(container):
+def get_orientation(container, aspect=1.0):
     if not hasattr(container, 'size'):
         return 'vertical'
     (wd, ht) = container.size
     # wd, ht = container.get_size()
     # print('container size is %dx%d' % (wd, ht))
-    if wd < ht:
+    if ht == 0:
+        return 'horizontal' if wd > 0 else 'vertical'
+    calc_aspect = wd / ht
+    if calc_aspect <= aspect:
         return 'vertical'
     else:
         return 'horizontal'
 
 
-def get_oriented_box(container, scrolled=True, fill=False):
-    orientation = get_orientation(container)
+def get_oriented_box(container, scrolled=True, fill=False,
+                     aspect=2.0):
+    orientation = get_orientation(container, aspect=aspect)
 
     if orientation == 'vertical':
         box1 = VBox()  # noqa

--- a/ginga/rv/plugins/MultiDim.py
+++ b/ginga/rv/plugins/MultiDim.py
@@ -102,7 +102,8 @@ class MultiDim(GingaPlugin.LocalPlugin):
         top.set_border_width(4)
 
         vbox, sw, orientation = Widgets.get_oriented_box(container,
-                                                         scrolled=True)
+                                                         scrolled=True,
+                                                         aspect=3.0)
         self.orientation = orientation
         vbox.set_border_width(4)
         vbox.set_spacing(2)


### PR DESCRIPTION
Fixes the `get_oriented_box()` function to take an `aspect` parameter which can be used to force it to make more sane decisions about vertical or horizontal orientation.

EDIT: Fix #849