### PR TITLE
Remove cursor-changed callback from canvases (fix #848)

### DIFF
--- a/doc/WhatsNew.rst
+++ b/doc/WhatsNew.rst
@@ -23,6 +23,8 @@ Ver 3.1.0 (unreleased)
 - Fixed an issue with Mosaic plugin where images with a PC matrix were
   not always oriented correctly
 - New Collage plugin offers an efficient alternative way to view mosaics
+- Fix for a bug where using Zoom and PixTable at the same time can cause
+  wrong results to be displayed in PixTable
 
 Ver 3.0.0 (2019-09-20)
 ======================

--- a/ginga/canvas/DrawingMixin.py
+++ b/ginga/canvas/DrawingMixin.py
@@ -86,7 +86,7 @@ class DrawingMixin(object):
                      'cursor-down', 'cursor-up', 'cursor-move',
                      'draw-scroll', 'keydown-poly_add', 'keydown-poly_del',
                      'keydown-edit_del', 'edit-event',
-                     'edit-select', 'drag-drop', 'cursor-changed'):
+                     'edit-select', 'drag-drop'):
             self.enable_callback(name)
 
         for name in ['key-down', 'key-up', 'btn-down', 'btn-move', 'btn-up',


### PR DESCRIPTION
- removes the cursor-changed callback from canvases. It only works correctly as coded when invoked from a viewer.

EDIT: Fix #848 