### PR TITLE
Downgrade rgb_cms warnings to info

### DIFF
--- a/ginga/util/rgb_cms.py
+++ b/ginga/util/rgb_cms.py
@@ -55,19 +55,19 @@ class ColorManager(object):
         # If we have a working color profile then handle any embedded
         # profile or color space information, if possible
         if not have_cms:
-            self.logger.warning(
+            self.logger.info(
                 "No CMS is installed; leaving image unprofiled.")
             return image
 
         if not have_profile(working_profile):
-            self.logger.warning(
+            self.logger.info(
                 "No working profile defined; leaving image unprofiled.")
             return image
 
         out_profile = profile[working_profile].name
 
         if not os.path.exists(profile[out_profile].path):
-            self.logger.warning(
+            self.logger.info(
                 "Working profile '%s' (%s) not found; leaving image "
                 "unprofiled." % (out_profile, profile[out_profile].path))
             return image


### PR DESCRIPTION
I keep seeing this warning when I start Ginga but I don't think I need to do anything about it, so I think info would have been more appropriate.
```
2020-07-09 13:50:47,065 | W | rgb_cms.py:63 (profile_to_working_pil) | No working profile defined; leaving image unprofiled.
```