### PR TITLE
Downgrade channel_Image.cfg not found from warning to info

### DIFF
--- a/ginga/rv/Control.py
+++ b/ginga/rv/Control.py
@@ -1426,8 +1426,8 @@ class GingaShell(GwMain.GwMain, Widgets.Application):
                     settings.load(onError='raise')
 
                 except Exception as e:
-                    self.logger.warning("no saved preferences found for channel "
-                                        "'%s': %s" % (name, str(e)))
+                    self.logger.info("no saved preferences found for channel "
+                                     "'%s', using default: %s" % (name, str(e)))
 
                     # copy template settings to new channel
                     if settings_template is not None:


### PR DESCRIPTION
I don't like the warning because even if I am okay with defaults (in the even of that file missing), I have to create the file to silence the warning. Therefore, I propose to downgrade it from warning to info. What do you think?

*Before* this patch:
```
2020-07-18 15:37:57,505 | W | Control.py:1429 (add_channel) |
    no saved preferences found for channel 'Image':
    Error opening settings file (/home/username/.ginga/channel_Image.cfg):
    [Errno 2] No such file or directory: '/home/username/.ginga/channel_Image.cfg'
```

With this patch:
```
2020-07-18 15:59:25,384 | I | Control.py:1429 (add_channel) |
    no saved preferences found for channel 'Image', using default:
    Error opening settings file (/home/username/.ginga/channel_Image.cfg):
    [Errno 2] No such file or directory: '/home/username/.ginga/channel_Image.cfg'
```