### PR TITLE
Expand user dir for basedir

### DIFF
--- a/ginga/rv/main.py
+++ b/ginga/rv/main.py
@@ -305,7 +305,7 @@ class ReferenceViewer(object):
         logger = log.get_logger(name='ginga', options=options)
 
         if options.basedir is not None:
-            paths.ginga_home = options.basedir
+            paths.ginga_home = os.path.expanduser(options.basedir)
 
         # Get settings (preferences)
         basedir = paths.ginga_home


### PR DESCRIPTION
Direct follow-up of #763 . With this, I now can do this without expanding `~` manually:

```
ginga --basedir=~/.ginga_twofer/
```