### PR TITLE
Ignore icon thumbnail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ __pycache__
 htmlcov
 .coverage
 MANIFEST
+ginga/icons/.thumbs/
 
 # Sphinx
 doc/api


### PR DESCRIPTION
Not sure why but when `ginga` runs with the banner on, I get a residue `ginga/icons/.thumbs` directory in the source checkout.