### PR TITLE
Eliminate warning message when layout file does not exist

### DIFF
--- a/ginga/gw/Desktop.py
+++ b/ginga/gw/Desktop.py
@@ -679,7 +679,7 @@ class Desktop(Callback.Callbacks):
         return layout
 
     def build_desktop(self, layout, lo_file=None, widget_dict=None):
-        if lo_file is not None:
+        if lo_file is not None and os.path.exists(lo_file):
             alt_layout = layout
             try:
                 layout = self.read_layout_conf(lo_file)


### PR DESCRIPTION
Alternative to #865

EDIT: Close #865. Direct follow up of #763 . 