### PR TITLE
MNT: Silence numpy deprecation warning

### DIFF
--- a/ginga/BaseImage.py
+++ b/ginga/BaseImage.py
@@ -417,7 +417,7 @@ class BaseImage(ViewerObjectBase):
         # calculate pixel containment mask in bbox
         yi = np.mgrid[y1:y2 + 1].reshape(-1, 1)
         xi = np.mgrid[x1:x2 + 1].reshape(1, -1)
-        pts = np.asarray((xi, yi)).T
+        pts = np.asarray((xi, yi), dtype=object).T
         contains = shape_obj.contains_pts(pts)
 
         view = np.s_[y1:y2 + 1, x1:x2 + 1]


### PR DESCRIPTION
I saw this warning over at spacetelescope/stginga#192. When I force numpy to turn warning into error, I get this traceback. With this patch, the warning is gone (at least for that workflow I was doing when I saw it).

```
Error making callback 'draw-event': Creating an ndarray from ragged nested sequences
(which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated.
If you meant to do this, you must specify 'dtype=object' when creating the ndarray

Traceback:
  File ".../ginga/misc/Callback.py", line 156, in _do_callbacks
    res = method(*cb_args, **cb_kwargs)

  File ".../stginga/plugins/BackgroundSub.py", line 384, in draw_cb
    return self.redo()

  File ".../stginga/plugins/BackgroundSub.py", line 256, in redo
    bg_masked = image.cutout_shape(bg_obj)

  File ".../ginga/BaseImage.py", line 433, in cutout_shape
    view, mask = self.get_shape_view(shape_obj)

  File ".../ginga/BaseImage.py", line 420, in get_shape_view
    pts = np.asarray((xi, yi)).T

  File ".../numpy/core/_asarray.py", line 86, in asarray
    a = array(a, dtype, copy=False, order=order)
```