### PR TITLE
Fix numpy deprecation warnings with numpy 1.19.0

### DIFF
--- a/doc/WhatsNew.rst
+++ b/doc/WhatsNew.rst
@@ -2,8 +2,8 @@
 What's New
 ++++++++++
 
-Ver 3.2.dev (unreleased)
-========================
+Ver 3.2.0 (unreleased)
+======================
 - Fixed some numpy deprecation warnings with numpy 1.19.0
 
 Ver 3.1.0 (2020-07-20)

--- a/doc/WhatsNew.rst
+++ b/doc/WhatsNew.rst
@@ -2,6 +2,10 @@
 What's New
 ++++++++++
 
+Ver 3.2.dev (unreleased)
+========================
+- Fixed some numpy deprecation warnings with numpy 1.19.0
+
 Ver 3.1.0 (2020-07-20)
 ======================
 - Zoom and Pan plugins refactored. Now shows graphical overlays.

--- a/ginga/BaseImage.py
+++ b/ginga/BaseImage.py
@@ -391,9 +391,8 @@ class BaseImage(ViewerObjectBase):
         Return full mask where True marks pixels within the given shape.
         """
         wd, ht = self.get_size()
-        yi = np.mgrid[:ht].reshape(-1, 1)
-        xi = np.mgrid[:wd].reshape(1, -1)
-        pts = np.asarray((xi, yi)).T
+        xi, yi = np.meshgrid(range(0, wd), range(0, ht))
+        pts = np.array((xi, yi)).T.reshape(-1, 2)
         contains = shape_obj.contains_pts(pts)
         return contains
 
@@ -415,9 +414,8 @@ class BaseImage(ViewerObjectBase):
             y1, y2 = max(0, y1), min(y2, ht - 1)
 
         # calculate pixel containment mask in bbox
-        yi = np.mgrid[y1:y2 + 1].reshape(-1, 1)
-        xi = np.mgrid[x1:x2 + 1].reshape(1, -1)
-        pts = np.asarray((xi, yi)).T
+        xi, yi = np.meshgrid(range(x1, x2 + 1), range(y1, y2 + 1))
+        pts = np.array((xi, yi)).T.reshape(-1, 2)
         contains = shape_obj.contains_pts(pts)
 
         view = np.s_[y1:y2 + 1, x1:x2 + 1]

--- a/ginga/BaseImage.py
+++ b/ginga/BaseImage.py
@@ -392,7 +392,7 @@ class BaseImage(ViewerObjectBase):
         """
         wd, ht = self.get_size()
         xi, yi = np.meshgrid(range(0, wd), range(0, ht))
-        pts = np.array((xi, yi)).T.reshape(-1, 2)
+        pts = np.array((xi, yi)).T
         contains = shape_obj.contains_pts(pts)
         return contains
 
@@ -415,7 +415,7 @@ class BaseImage(ViewerObjectBase):
 
         # calculate pixel containment mask in bbox
         xi, yi = np.meshgrid(range(x1, x2 + 1), range(y1, y2 + 1))
-        pts = np.array((xi, yi)).T.reshape(-1, 2)
+        pts = np.array((xi, yi)).T
         contains = shape_obj.contains_pts(pts)
 
         view = np.s_[y1:y2 + 1, x1:x2 + 1]

--- a/ginga/canvas/types/mixins.py
+++ b/ginga/canvas/types/mixins.py
@@ -319,16 +319,7 @@ class PolygonMixin(object):
                         y_arr.astype(np.float, copy=False))
         xa, ya = x_arr, y_arr
 
-        # promote input arrays dimension cardinality, if necessary
-        promoted = False
-        if len(xa.shape) == 1:
-            xa = xa.reshape(1, -1)
-            promoted = True
-        if len(ya.shape) == 1:
-            ya = ya.reshape(-1, 1)
-            promoted = True
-
-        result = np.empty((ya.size, xa.size), dtype=np.bool)
+        result = np.empty(y_arr.shape, dtype=np.bool)
         result.fill(False)
 
         points = self.get_data_points()
@@ -354,10 +345,6 @@ class PolygonMixin(object):
             idx = np.nonzero(tf)
             result[idx] ^= cross[idx]
             xj, yj = xi, yi
-
-        if promoted:
-            # de-promote result
-            result = result[np.eye(len(y_arr), len(x_arr), dtype=np.bool)]
 
         return result
 

--- a/ginga/util/iqcalc.py
+++ b/ginga/util/iqcalc.py
@@ -40,7 +40,7 @@ def get_mean(data_np):
     i = np.isfinite(data_np)
     if not np.any(i):
         return np.nan
-    return np.mean(data_np[i])
+    return np.ma.mean(data_np[i])
 
 
 def get_median(data_np):
@@ -48,7 +48,7 @@ def get_median(data_np):
     i = np.isfinite(data_np)
     if not np.any(i):
         return np.nan
-    return np.median(data_np[i])
+    return np.ma.median(data_np[i])
 
 
 class IQCalcError(Exception):

--- a/ginga/util/plots.py
+++ b/ginga/util/plots.py
@@ -461,7 +461,7 @@ class FWHMPlot(Plot):
             if cutout_data is None:
                 cutout_data, x1, y1, x2, y2 = image.cutout_radius(x, y, radius)
 
-            skybg = np.median(cutout_data)
+            skybg = np.ma.median(cutout_data)
             self.logger.debug("cutting x=%d y=%d r=%d med=%f" % (
                 x, y, radius, skybg))
 

--- a/ginga/util/vip.py
+++ b/ginga/util/vip.py
@@ -379,9 +379,9 @@ class ViewerImageProxy:
             y1, y2 = max(xy_mn[1], y1), min(y2, xy_mx[1] - 1)
 
         # calculate pixel containment mask in bbox
-        yi = np.mgrid[y1:y2 + 1].reshape(-1, 1)
-        xi = np.mgrid[x1:x2 + 1].reshape(1, -1)
-        pts = np.asarray((xi, yi)).T
+        xi, yi = np.meshgrid(range(x1, x2 + 1), range(y1, y2 + 1))
+        pts = np.array((xi, yi)).T.reshape(-1, 2)
+
         contains = shape_obj.contains_pts(pts)
 
         view = np.s_[y1:y2 + 1, x1:x2 + 1]

--- a/ginga/util/vip.py
+++ b/ginga/util/vip.py
@@ -380,7 +380,7 @@ class ViewerImageProxy:
 
         # calculate pixel containment mask in bbox
         xi, yi = np.meshgrid(range(x1, x2 + 1), range(y1, y2 + 1))
-        pts = np.array((xi, yi)).T.reshape(-1, 2)
+        pts = np.array((xi, yi)).T
 
         contains = shape_obj.contains_pts(pts)
 


### PR DESCRIPTION
(Close #868)

Eliminates:
- VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray
  return array(a, dtype, copy=False, order=order)

- Warning: 'partition' will ignore the 'mask' of the MaskedArray.
    a.partition(kth, axis=axis, kind=kind, order=order)