### PR TITLE
Add copy() method to canvas objects

### DIFF
--- a/ginga/canvas/CanvasObject.py
+++ b/ginga/canvas/CanvasObject.py
@@ -6,6 +6,7 @@
 #
 import numpy as np
 from collections import namedtuple
+import copy
 
 from ginga.misc import Callback, Bunch
 from ginga import trcalc, colors
@@ -125,6 +126,13 @@ class CanvasObjectBase(Callback.Callbacks):
 
     def is_compound(self):
         return False
+
+    def copy(self, share=[]):
+        obj = copy.copy(self)
+        obj.viewer = None
+        if 'data' not in share:
+            obj.data = None
+        return obj
 
     def contains_pts(self, points):
         contains = np.asarray([False] * len(points))

--- a/ginga/canvas/CompoundMixin.py
+++ b/ginga/canvas/CompoundMixin.py
@@ -154,6 +154,11 @@ class CompoundMixin(object):
     def has_object(self, obj):
         return obj in self.objects
 
+    def copy(self, share=[]):
+        obj = super(CompoundMixin, self).copy(share=share)
+        obj.objects = [obj.copy(share=share) for obj in self.objects]
+        return obj
+
     def delete_object(self, obj):
         self.objects.remove(obj)
 

--- a/ginga/rv/plugins/Drawing.py
+++ b/ginga/rv/plugins/Drawing.py
@@ -435,8 +435,9 @@ class Drawing(GingaPlugin.LocalPlugin):
 
     def copy_object(self):
         obj = self.canvas._edit_obj.copy()
-        self.canvas.add(obj)
+        tag = self.canvas.add(obj)
         obj.move_delta_pt((20, 20))
+        self._drawn_tags.append(tag)
         self.canvas.redraw(whence=2)
 
     def rotate_object(self, w):

--- a/ginga/rv/plugins/Drawing.py
+++ b/ginga/rv/plugins/Drawing.py
@@ -141,7 +141,7 @@ class Drawing(GingaPlugin.LocalPlugin):
 
         captions = (("Rotate By:", 'label', 'Rotate By', 'entry',
                      "Scale By:", 'label', 'Scale By', 'entry'),
-                    ("Delete Obj", 'button', "sp1", 'spacer',
+                    ("Delete Obj", 'button', "Copy Obj", 'button',
                      "Create mask", 'button', "Clear canvas", 'button'),
                     )
         w, b = Widgets.build_info(captions)
@@ -149,6 +149,9 @@ class Drawing(GingaPlugin.LocalPlugin):
         b.delete_obj.add_callback('activated', lambda w: self.delete_object())
         b.delete_obj.set_tooltip("Delete selected object in edit mode")
         b.delete_obj.set_enabled(False)
+        b.copy_obj.add_callback('activated', lambda w: self.copy_object())
+        b.copy_obj.set_tooltip("Copy selected object in edit mode")
+        b.copy_obj.set_enabled(False)
         b.scale_by.add_callback('activated', self.scale_object)
         b.scale_by.set_text('0.9')
         b.scale_by.set_tooltip("Scale selected object in edit mode")
@@ -263,6 +266,7 @@ class Drawing(GingaPlugin.LocalPlugin):
 
         # disable edit-only controls
         self.w.delete_obj.set_enabled(False)
+        self.w.copy_obj.set_enabled(False)
         self.w.scale_by.set_enabled(False)
         self.w.rotate_by.set_enabled(False)
 
@@ -329,12 +333,14 @@ class Drawing(GingaPlugin.LocalPlugin):
 
             self.w.drawvbox.add_widget(w, stretch=1)
             self.w.delete_obj.set_enabled(True)
+            self.w.copy_obj.set_enabled(True)
             self.w.scale_by.set_enabled(True)
             self.w.rotate_by.set_enabled(True)
         else:
             self.w.attrlbl.set_text("")
 
             self.w.delete_obj.set_enabled(False)
+            self.w.copy_obj.set_enabled(False)
             self.w.scale_by.set_enabled(False)
             self.w.rotate_by.set_enabled(False)
 
@@ -425,6 +431,12 @@ class Drawing(GingaPlugin.LocalPlugin):
         self._drawn_tags.remove(tag)
         self.toggle_create_button()
         self.canvas.edit_delete()
+        self.canvas.redraw(whence=2)
+
+    def copy_object(self):
+        obj = self.canvas._edit_obj.copy()
+        self.canvas.add(obj)
+        obj.move_delta_pt((20, 20))
         self.canvas.redraw(whence=2)
 
     def rotate_object(self, w):

--- a/ginga/tests/test_canvas.py
+++ b/ginga/tests/test_canvas.py
@@ -1,0 +1,72 @@
+"""
+Tests of Ginga canvas objects.
+
+"""
+import logging
+
+from ginga.mockw.ImageViewMock import CanvasView
+from ginga.canvas.CanvasObject import get_canvas_types
+
+
+class TestCanvas(object):
+
+    def setup_class(self):
+        self.logger = logging.getLogger("TestCanvas")
+        self.viewer = CanvasView(logger=self.logger)
+        self.dc = get_canvas_types()
+        self.canvas = self.dc.DrawingCanvas()
+        # NOTE: canvas needs to be added to a viewer otherwise lots
+        # of operations do not work!
+        # add our canvas to the viewer's default canvas
+        self.viewer.get_canvas().add(self.canvas)
+
+    def test_add_to_canvas(self):
+        """Test adding an object to a canvas."""
+        o = self.dc.Line(10, 10, -200, -300)
+        self.canvas.add(o)
+        assert o in self.canvas
+
+    def test_delete_from_canvas(self):
+        """Test deleting an object from a canvas."""
+        o = self.dc.Line(10, 10, -200, -300)
+        self.canvas.add(o)
+        assert o in self.canvas
+        self.canvas.delete_object(o)
+        assert o not in self.canvas
+
+    def test_clear_canvas(self):
+        """Test clearing a canvas."""
+        o = self.dc.Line(10, 10, -200, -300)
+        self.canvas.add(o)
+        o2 = self.dc.Line(-10, -10, 200, 300)
+        self.canvas.add(o2)
+        self.canvas.delete_all_objects()
+        assert o not in self.canvas
+        assert o2 not in self.canvas
+
+    def test_copy_simple(self):
+        """Test copying a simple object on a canvas."""
+        r = self.dc.Rectangle(10, 20, 110, 210)
+        self.canvas.add(r)
+        r2 = r.copy()
+        assert isinstance(r2, self.dc.Rectangle)
+        assert r2 is not r
+
+    def test_copy_compound(self):
+        """Test copying a compound object on a canvas."""
+        a = self.dc.Annulus(100, 200, 10, width=5, atype='circle')
+        self.canvas.add(a)
+        a2 = a.copy()
+        assert isinstance(a2, self.dc.Annulus)
+        assert a2 is not a
+        # check that children are copied as well, and not shared
+        for o1, o2 in zip(a.get_objects(), a2.get_objects()):
+            assert o1 is not o2
+
+    def test_move_delta_pt(self):
+        """Test moving an object by a delta."""
+        o = self.dc.Box(50, 60, 100, 200)
+        self.canvas.add(o)
+        assert tuple(o.get_center_pt()) == (50, 60)
+        o.move_delta_pt((-10, 15))
+        assert tuple(o.get_center_pt()) == (40, 75)


### PR DESCRIPTION
Adds a `copy()` method to Ginga canvas objects.

This makes a shallow copy, which may not always work according to the intended purposes.  The `Drawing` plugin is modified to be able to use this to copy a selected object in edit mode.

In support of #874 