### PR TITLE
Use np instead of np.ma for iqcalc

### DIFF
--- a/ginga/util/iqcalc.py
+++ b/ginga/util/iqcalc.py
@@ -40,7 +40,7 @@ def get_mean(data_np):
     i = np.isfinite(data_np)
     if not np.any(i):
         return np.nan
-    return np.ma.mean(data_np[i])
+    return np.mean(data_np[i])
 
 
 def get_median(data_np):
@@ -48,7 +48,7 @@ def get_median(data_np):
     i = np.isfinite(data_np)
     if not np.any(i):
         return np.nan
-    return np.ma.median(data_np[i])
+    return np.median(data_np[i])
 
 
 class IQCalcError(Exception):


### PR DESCRIPTION
Is there a reason to use `np.ma.` functions instead of `np.` ones? Do you pass in masked arrays?