### PR TITLE
MNT: Compatibility with astropy.coordinates

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -69,7 +69,7 @@ jobs:
     - name: Install and build
       run: |
         python -m pip install --upgrade pip setuptools
-        python -m pip install PyQt5 numpy==1.16
+        python -m pip install PyQt5 numpy==1.16 astropy==3.2
         python -m pip install -e .[test]
     - name: Install Qt
       uses: jurplel/install-qt-action@8ffcd60

--- a/ginga/util/wcsmod/common.py
+++ b/ginga/util/wcsmod/common.py
@@ -10,8 +10,14 @@ import numpy as np
 
 from ginga.misc import Bunch
 
+__all__ = ['WCSError', 'BaseWCS', 'register_wcs', 'choose_coord_units',
+           'get_coord_system_name', 'get_astropy_frame']
+
 # Holds custom WCSes that are registered
 custom_wcs = Bunch.caselessDict()
+
+# Cache Astropy coordinate frames
+astropy_coord_frames = {}
 
 
 class WCSError(Exception):
@@ -423,3 +429,15 @@ def get_coord_system_name(header):
 
     #raise WCSError("Cannot determine appropriate coordinate system from FITS header")  # noqa
     return 'icrs'
+
+
+def get_astropy_frame(to_class):
+    """Obtain and instance of requested Astropy coordinates frame class.
+    This instance is cached, if necessary.
+    """
+    global astropy_coord_frames
+
+    cname = to_class.__name__
+    if cname not in astropy_coord_frames:
+        astropy_coord_frames[cname] = to_class()
+    return astropy_coord_frames[cname]

--- a/ginga/util/wcsmod/wcs_astropy.py
+++ b/ginga/util/wcsmod/wcs_astropy.py
@@ -150,7 +150,7 @@ class AstropyWCS(common.BaseWCS):
         # Skip in input and output is the same (no realize_frame
         # call in astropy)
         if to_class != frame_class:
-            coord = coord.transform_to(to_class)
+            coord = coord.transform_to(to_class())
 
         return coord
 
@@ -243,7 +243,7 @@ class AstropyWCS(common.BaseWCS):
         # Skip if input and output is the same (no realize_frame
         # call in astropy)
         if to_class != frame_class:
-            coord = coord.transform_to(to_class)
+            coord = coord.transform_to(to_class())
 
         return coord
 

--- a/ginga/util/wcsmod/wcs_astropy.py
+++ b/ginga/util/wcsmod/wcs_astropy.py
@@ -150,7 +150,7 @@ class AstropyWCS(common.BaseWCS):
         # Skip in input and output is the same (no realize_frame
         # call in astropy)
         if to_class != frame_class:
-            coord = coord.transform_to(to_class())
+            coord = coord.transform_to(common.get_astropy_frame(to_class))
 
         return coord
 
@@ -243,7 +243,7 @@ class AstropyWCS(common.BaseWCS):
         # Skip if input and output is the same (no realize_frame
         # call in astropy)
         if to_class != frame_class:
-            coord = coord.transform_to(to_class())
+            coord = coord.transform_to(common.get_astropy_frame(to_class))
 
         return coord
 

--- a/ginga/util/wcsmod/wcs_astropy_ape14.py
+++ b/ginga/util/wcsmod/wcs_astropy_ape14.py
@@ -151,7 +151,7 @@ class AstropyWCS(common.BaseWCS):
         # Skip in input and output is the same (no realize_frame
         # call in astropy)
         if to_class != coord.name:
-            coord = coord.transform_to(to_class)
+            coord = coord.transform_to(to_class())
 
         return coord
 
@@ -246,7 +246,7 @@ class AstropyWCS(common.BaseWCS):
         # Skip in input and output is the same (no realize_frame
         # call in astropy)
         if to_class != frame_class:
-            coord = coord.transform_to(to_class)
+            coord = coord.transform_to(to_class())
 
         return coord
 

--- a/ginga/util/wcsmod/wcs_astropy_ape14.py
+++ b/ginga/util/wcsmod/wcs_astropy_ape14.py
@@ -151,7 +151,7 @@ class AstropyWCS(common.BaseWCS):
         # Skip in input and output is the same (no realize_frame
         # call in astropy)
         if to_class != coord.name:
-            coord = coord.transform_to(to_class())
+            coord = coord.transform_to(common.get_astropy_frame(to_class))
 
         return coord
 
@@ -246,7 +246,7 @@ class AstropyWCS(common.BaseWCS):
         # Skip in input and output is the same (no realize_frame
         # call in astropy)
         if to_class != frame_class:
-            coord = coord.transform_to(to_class())
+            coord = coord.transform_to(common.get_astropy_frame(to_class))
 
         return coord
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ classifiers =
 zip_safe = False
 packages = find:
 python_requires = >=3.5
-install_requires = numpy>=1.13; qtpy>=1.1; astropy>=3
+install_requires = numpy>=1.13; qtpy>=1.1; astropy>=3.2
 setup_requires = setuptools_scm
 
 [options.extras_require]


### PR DESCRIPTION
This deprecation warning started showing up and failing astropy-dev job:

```
E           astropy.utils.exceptions.AstropyDeprecationWarning: Transforming a frame instance to a frame class
(as opposed to another frame instance) will not be supported in the future.  Either explicitly instantiate the
target frame, or first convert the source frame instance to a `astropy.coordinates.SkyCoord` and
use its `transform_to()` method.
```

This is caused by astropy/astropy#10475 .

This PR proposes a fix for the astropy-dev job. It also clarifies that minimum version of `astropy` that we really support and added that to one of the jobs for testing.