### PR TITLE
New iqcalc_astropy module to use astropy to fit FWHM

### DIFF
--- a/doc/WhatsNew.rst
+++ b/doc/WhatsNew.rst
@@ -10,6 +10,8 @@ Ver 3.2.0 (unreleased)
 - Added an option to make a copy of existing shape in Drawing plugin
 - Added an option to make a copy of existing cut in Cuts plugin
 - Added new iqcalc_astropy module to handle FWHM fitting using astropy
+- Added new calc_fwhm_lib configuration item to let Pick switch between
+  iqcalc and iqcalc_astropy
 - Fixed a bug where certain plots were not cleared in Pick plugin
 - Removed support for matplotlib versions < 2.1
 

--- a/doc/WhatsNew.rst
+++ b/doc/WhatsNew.rst
@@ -9,6 +9,7 @@ Ver 3.2.0 (unreleased)
 - Canvas shapes can now be copied
 - Added an option to make a copy of existing shape in Drawing plugin
 - Added an option to make a copy of existing cut in Cuts plugin
+- Added new iqcalc_astropy module to handle FWHM fitting using astropy
 - Fixed a bug where certain plots were not cleared in Pick plugin
 - Removed support for matplotlib versions < 2.1
 

--- a/doc/ref_api.rst
+++ b/doc/ref_api.rst
@@ -39,3 +39,9 @@ Reference/API
 
 .. automodapi:: ginga.util.ap_region
    :no-inheritance-diagram:
+
+.. automodapi:: ginga.util.iqcalc
+   :no-inheritance-diagram:
+
+.. automodapi:: ginga.util.iqcalc_astropy
+   :no-inheritance-diagram:

--- a/ginga/examples/configs/plugin_Pick.cfg
+++ b/ginga/examples/configs/plugin_Pick.cfg
@@ -50,6 +50,9 @@ show_candidates = False
 # calculation:
 calc_center_alg = 'centroid'
 
+# Library to use for FWHM fitting ("native" or "astropy")
+calc_fwhm_lib = 'native'
+
 # Fitting function to use for FWHM ("gaussian" or "moffat")
 calc_fwhm_alg = 'gaussian'
 
@@ -66,4 +69,3 @@ record_picks = True
 
 # Set this to a file name, if None a filename will be automatically chosen
 report_log_path = None
-

--- a/ginga/examples/configs/plugin_Pick.cfg
+++ b/ginga/examples/configs/plugin_Pick.cfg
@@ -37,7 +37,7 @@ radius = 10
 # Set threshold to None to auto calculate it
 threshold = None
 # Minimum and maximum fwhm to be considered a candidate
-min_fwhm = 2.0
+min_fwhm = 1.5
 max_fwhm = 50.0
 # Minimum ellipticity to be considered a candidate
 min_ellipse = 0.5

--- a/ginga/rv/plugins/Pick.py
+++ b/ginga/rv/plugins/Pick.py
@@ -262,7 +262,7 @@ The "Settings" tab controls aspects of the search within the pick area:
 * The "FWHM fitting" parameter is used to determine which function is
   is used for FWHM fitting ("gaussian" or "moffat"). The option to use
   "lorentz" is also available if "calc_fwhm_lib" is set to "astropy"
-  in `~/.ginga/plugin_Pick.cfg`.
+  in ``~/.ginga/plugin_Pick.cfg``.
 * The "Contour Interpolation" parameter is used to set the interpolation
   method used in rendering the background image in the "Contour" plot.
 

--- a/ginga/rv/plugins/Pick.py
+++ b/ginga/rv/plugins/Pick.py
@@ -429,7 +429,7 @@ class Pick(GingaPlugin.LocalPlugin):
         self.max_side = self.settings.get('max_side', 1024)
         self.radius = self.settings.get('radius', 10)
         self.threshold = self.settings.get('threshold', None)
-        self.min_fwhm = self.settings.get('min_fwhm', 2.0)
+        self.min_fwhm = self.settings.get('min_fwhm', 1.5)
         self.max_fwhm = self.settings.get('max_fwhm', 50.0)
         self.min_ellipse = self.settings.get('min_ellipse', 0.5)
         self.edgew = self.settings.get('edge_width', 0.01)

--- a/ginga/tests/test_iqcalc.py
+++ b/ginga/tests/test_iqcalc.py
@@ -3,6 +3,11 @@ import numpy as np
 import pytest
 
 from ginga.util import iqcalc, iqcalc_astropy
+try:
+    from scipy import optimize  # noqa
+    HAS_SCIPY = True
+except ImportError:
+    HAS_SCIPY = False
 
 try:
     from scipy import optimize  # noqa

--- a/ginga/tests/test_iqcalc.py
+++ b/ginga/tests/test_iqcalc.py
@@ -2,7 +2,7 @@ import logging
 import numpy as np
 import pytest
 
-from ginga.util import iqcalc
+from ginga.util import iqcalc, iqcalc_astropy
 
 try:
     from scipy import optimize  # noqa
@@ -43,31 +43,39 @@ def test_get_median_mask():
 
 @pytest.mark.skipif('not HAS_SCIPY')
 class TestIQCalc:
+    # Shared attributes that subclass can access.
+    logger = logging.getLogger("TestIQCalc")
+    input_arrays = (
+        np.array([0., 0., 11., 12., 8., 9., 37., 96., 289., 786.,
+                  1117., 795., 286., 86., 26., 18., 0., 8., 0., 0.]),
+        np.array([0., 9., 0., 0., 0., 34., 25., 60., 196., 602.,
+                  1117., 1003., 413., 135., 29., 0., 3., 0., 4., 3.]))
 
     def setup_class(self):
-        logger = logging.getLogger("TestIQCalc")
-        self.iqcalc = iqcalc.IQCalc(logger=logger)
+        self.iqcalc = iqcalc.IQCalc(logger=self.logger)
+        self.fwhm_funcs = (self.iqcalc.calc_fwhm_gaussian,
+                           self.iqcalc.calc_fwhm_moffat)
+        self.answers = ((2.8551, 2.7732),  # Gaussian
+                        (2.77949, 2.6735)  # Moffat
+                        )
 
-    def test_fwhm_gaussian(self):
-        """Test FHWM gaussian measuring function in 1D."""
-        x = np.array([0., 0., 11., 12., 8., 9., 37., 96., 289., 786.,
-                      1117., 795., 286., 86., 26., 18., 0., 8., 0., 0.])
-        y = np.array([0., 9., 0., 0., 0., 34., 25., 60., 196., 602.,
-                      1117., 1003., 413., 135., 29., 0., 3., 0., 4., 3.])
+    def test_fwhm(self):
+        """Test FWHM measuring function in 1D."""
+        for i, func in enumerate(self.fwhm_funcs):
+            for j, arr1d in enumerate(self.input_arrays):
+                res = func(arr1d)
+                np.testing.assert_allclose(
+                    res.fwhm, self.answers[i][j], atol=1e-4)
 
-        res = self.iqcalc.calc_fwhm_gaussian(x)
-        assert np.isclose(res.fwhm, 2.8551, atol=1e-04)
-        res = self.iqcalc.calc_fwhm_gaussian(y)
-        assert np.isclose(res.fwhm, 2.7732, atol=1e-04)
 
-    def test_fwhm_moffat(self):
-        """Test FWHM moffat measuring function in 1D."""
-        x = np.array([0., 0., 11., 12., 8., 9., 37., 96., 289., 786.,
-                      1117., 795., 286., 86., 26., 18., 0., 8., 0., 0.])
-        y = np.array([0., 9., 0., 0., 0., 34., 25., 60., 196., 602.,
-                      1117., 1003., 413., 135., 29., 0., 3., 0., 4., 3.])
-
-        res = self.iqcalc.calc_fwhm_moffat(x)
-        assert np.isclose(res.fwhm, 2.77949, atol=1e-04)
-        res = self.iqcalc.calc_fwhm_moffat(y)
-        assert np.isclose(res.fwhm, 2.6735, atol=1e-04)
+class TestIQCalcAstropy(TestIQCalc):
+    def setup_class(self):
+        """Customize for Astropy implementation."""
+        self.iqcalc = iqcalc_astropy.IQCalc(logger=self.logger)
+        self.fwhm_funcs = (self.iqcalc.calc_fwhm_gaussian,
+                           self.iqcalc.calc_fwhm_moffat,
+                           self.iqcalc.calc_fwhm_lorentz)
+        self.answers = ((2.8551, 2.7732),  # Gaussian
+                        (2.77949, 2.6735),  # Moffat
+                        (1.9570, 1.8113)  # Lorentz
+                        )

--- a/ginga/util/iqcalc_astropy.py
+++ b/ginga/util/iqcalc_astropy.py
@@ -1,0 +1,315 @@
+"""Module to handle image quality calculations using ``astropy``."""
+
+import numpy as np
+from astropy.modeling import models, fitting
+
+from ginga.misc import Bunch
+
+# Reuse shared items from the old module until we can merge old and new together.
+from ginga.util.iqcalc import IQCalcError, get_median, have_scipy
+from ginga.util.iqcalc import IQCalc as _IQCalc
+
+__all__ = ['IQCalc']
+
+
+# TODO: Use photutils for source finding.
+class IQCalc(_IQCalc):
+    """This is `ginga.util.iqcalc.IQCalc` that uses ``astropy``.
+
+    This subclass has an extra ``self.fitter`` attribute for ``astropy``
+    fitting.
+
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fitter = fitting.LevMarLSQFitter()
+
+    # FWHM CALCULATION
+
+    def _prep_for_fitting(self, arr1d, medv):
+        if not have_scipy:
+            raise IQCalcError("Please install the 'scipy' module "
+                              "to use this function")
+
+        N = len(arr1d)
+        X = np.array(list(range(N)))
+        Y = np.asarray(arr1d)
+
+        # Fitting works more reliably if we do the following
+        # a. subtract sky background
+        if medv is None:
+            medv = get_median(Y)
+        Y -= medv
+        maxv = Y.max()
+        # b. clamp to 0..max (of the sky subtracted field)
+        Y = Y.clip(0, maxv)
+
+        return N, X, Y, maxv
+
+    def gaussian(self, x, p):
+        """Evaluate Gaussian function in 1D.
+
+        Parameters
+        ----------
+        x : array-like
+            X values.
+
+        p : tuple of float
+            Parameters for Gaussian, i.e., ``(mean, stddev, amplitude)``.
+
+        Returns
+        -------
+        y : array-like
+            Y values.
+
+        """
+        g = models.Gaussian1D(amplitude=p[2], mean=p[0], stddev=p[1])
+        return g(x)
+
+    def calc_fwhm_gaussian(self, arr1d, medv=None, **kwargs):
+        """FWHM calculation on a 1D array by using least square fitting of
+        a Gaussian function on the data.
+
+        Parameters
+        ----------
+        arr1d : array-like
+            1D array cut in either X or Y direction on the object.
+
+        medv : float or `None`
+            Median of the data. If not given, it is calculated from ``arr1d``.
+
+        kwargs : dict
+            Not used; for backward-compatible API call only.
+
+        Returns
+        -------
+        res : `~ginga.misc.Bunch.Bunch`
+            Fitting results.
+
+        Raises
+        ------
+        IQCalcError
+            Fitting failed.
+
+        """
+        N, X, Y, maxv = self._prep_for_fitting(arr1d, medv)
+
+        # Gaussian model with initial guess
+        m_init = models.Gaussian1D(amplitude=maxv, mean=0, stddev=(N - 1))
+
+        # NOTE: without this mutex, optimize.leastsq causes a fatal error
+        # sometimes--it appears not to be thread safe.
+        # The error is:
+        # "SystemError: null argument to internal routine"
+        # "Fatal Python error: GC object already tracked"
+        with self.lock:
+            try:
+                m = self.fitter(m_init, X, Y)
+            except Exception:
+                raise IQCalcError("FWHM Gaussian fitting failed")
+
+        # Now that we have the sdev from fitting, we can calculate FWHM
+        fwhm = m.fwhm
+        # Some routines choke on numpy values and need "pure" Python floats
+        # e.g. when marshalling through a remote procedure interface
+        mu = m.mean.value
+        sdev = m.stddev.value
+        maxv = m.amplitude.value
+
+        self.logger.debug('mu={} sdev={} maxv={}'.format(mu, sdev, maxv))
+
+        res = Bunch.Bunch(fwhm=fwhm, mu=mu, sdev=sdev, maxv=maxv,
+                          fit_fn=self.gaussian, fit_args=[mu, sdev, maxv])
+        return res
+
+    def moffat(self, x, p):
+        """Evaluate Moffat function in 1D.
+
+        Parameters
+        ----------
+        x : array-like
+            X values.
+
+        p : tuple of float
+            Parameters for Moffat, i.e., ``(x_0, gamma, alpha, amplitude)``,
+            where ``x_0`` a.k.a. mean and ``gamma`` core width.
+
+        Returns
+        -------
+        y : array-like
+            Y values.
+
+        """
+        m = models.Moffat1D(amplitude=p[3], x_0=p[0], gamma=p[1], alpha=p[2])
+        return m(x)
+
+    def calc_fwhm_moffat(self, arr1d, medv=None, **kwargs):
+        """FWHM calculation on a 1D array by using least square fitting of
+        a Moffat function on the data.
+
+        Parameters
+        ----------
+        arr1d : array-like
+            1D array cut in either X or Y direction on the object.
+
+        medv : float or `None`
+            Median of the data. If not given, it is calculated from ``arr1d``.
+
+        kwargs : dict
+            Not used; for backward-compatible API call only.
+
+        Returns
+        -------
+        res : `~ginga.misc.Bunch.Bunch`
+            Fitting results.
+
+        Raises
+        ------
+        IQCalcError
+            Fitting failed.
+
+        """
+        N, X, Y, maxv = self._prep_for_fitting(arr1d, medv)
+
+        # Moffat model with initial guess
+        m_init = models.Moffat1D(amplitude=maxv, x_0=0, gamma=(N - 1), alpha=2)
+
+        # NOTE: without this mutex, optimize.leastsq causes a fatal error
+        # sometimes--it appears not to be thread safe.
+        # The error is:
+        # "SystemError: null argument to internal routine"
+        # "Fatal Python error: GC object already tracked"
+        with self.lock:
+            try:
+                m = self.fitter(m_init, X, Y)
+            except Exception:
+                raise IQCalcError("FWHM Moffat fitting failed")
+
+        fwhm = m.fwhm
+
+        # Some routines choke on numpy values and need "pure" Python floats
+        # e.g. when marshalling through a remote procedure interface
+        mu = m.x_0.value
+        width = np.abs(m.gamma.value)
+        power = m.alpha.value
+        maxv = m.amplitude.value
+
+        self.logger.debug('mu={} width={} power={} maxv={}'.format(
+            mu, width, power, maxv))
+
+        res = Bunch.Bunch(fwhm=fwhm, mu=mu, width=width, power=power,
+                          maxv=maxv, fit_fn=self.moffat,
+                          fit_args=[mu, width, power, maxv])
+        return res
+
+    def lorentz(self, x, p):
+        """Evaluate Lorentz function in 1D.
+
+        Parameters
+        ----------
+        x : array-like
+            X values.
+
+        p : tuple of float
+            Parameters for Lorentz, i.e., ``(x_0, fwhm, amplitude)``.
+
+        Returns
+        -------
+        y : array-like
+            Y values.
+
+        """
+        m = models.Lorentz1D(amplitude=p[2], x_0=p[0], fwhm=p[1])
+        return m(x)
+
+    def calc_fwhm_lorentz(self, arr1d, medv=None, **kwargs):
+        """FWHM calculation on a 1D array by using least square fitting of
+        a Lorentz function on the data.
+
+        Parameters
+        ----------
+        arr1d : array-like
+            1D array cut in either X or Y direction on the object.
+
+        medv : float or `None`
+            Median of the data. If not given, it is calculated from ``arr1d``.
+
+        kwargs : dict
+            Not used; for backward-compatible API call only.
+
+        Returns
+        -------
+        res : `~ginga.misc.Bunch.Bunch`
+            Fitting results.
+
+        Raises
+        ------
+        IQCalcError
+            Fitting failed.
+
+        """
+        N, X, Y, maxv = self._prep_for_fitting(arr1d, medv)
+
+        # Lorentz model with initial guess
+        m_init = models.Lorentz1D(amplitude=maxv, x_0=0, fwhm=(N - 1))
+
+        # NOTE: without this mutex, optimize.leastsq causes a fatal error
+        # sometimes--it appears not to be thread safe.
+        # The error is:
+        # "SystemError: null argument to internal routine"
+        # "Fatal Python error: GC object already tracked"
+        with self.lock:
+            try:
+                m = self.fitter(m_init, X, Y)
+            except Exception:
+                raise IQCalcError("FWHM Lorentz fitting failed")
+
+        # Some routines choke on numpy values and need "pure" Python floats
+        # e.g. when marshalling through a remote procedure interface
+        fwhm = m.fwhm.value
+        mu = m.x_0.value
+        maxv = m.amplitude.value
+
+        self.logger.debug('mu={} fwhm={} maxv={}'.format(mu, fwhm, maxv))
+
+        res = Bunch.Bunch(fwhm=fwhm, mu=mu, maxv=maxv, fit_fn=self.lorentz,
+                          fit_args=[mu, fwhm, maxv])
+        return res
+
+    def calc_fwhm(self, arr1d, medv=None, method_name='gaussian'):
+        """Calculate FWHM for the given input array.
+
+        Parameters
+        ----------
+        arr1d : array-like
+            1D array cut in either X or Y direction on the object.
+
+        medv : float or `None`
+            Median of the data. If not given, it is calculated from ``arr1d``.
+
+        method_name : {'gaussian', 'moffat', 'lorentz'}
+            Function to use for fitting.
+
+        Returns
+        -------
+        res : `~ginga.misc.Bunch.Bunch`
+            Fitting results.
+
+        Raises
+        ------
+        NotImplementedError
+            Given function is not supported.
+
+        """
+        if method_name == 'gaussian':
+            fwhm_fn = self.calc_fwhm_gaussian
+        elif method_name == 'moffat':
+            fwhm_fn = self.calc_fwhm_moffat
+        elif method_name == 'lorentz':
+            fwhm_fn = self.calc_fwhm_lorentz
+        else:
+            raise NotImplementedError(
+                'Fitting with {} is unsupported'.format(method_name))
+
+        return fwhm_fn(arr1d, medv=medv)

--- a/ginga/util/iqcalc_astropy.py
+++ b/ginga/util/iqcalc_astropy.py
@@ -43,7 +43,7 @@ class IQCalc(_IQCalc):
         # a. subtract sky background
         if medv is None:
             medv = get_median(Y)
-        Y -= medv
+        Y = Y - medv
         maxv = Y.max()
         # b. clamp to 0..max (of the sky subtracted field)
         Y = Y.clip(0, maxv)

--- a/ginga/util/iqcalc_astropy.py
+++ b/ginga/util/iqcalc_astropy.py
@@ -9,6 +9,9 @@ from ginga.misc import Bunch
 from ginga.util.iqcalc import IQCalcError, get_median, have_scipy
 from ginga.util.iqcalc import IQCalc as _IQCalc
 
+# Import the rest into namespace so we can use this module like iqcalc.
+from ginga.util.iqcalc import get_mean  # noqa
+
 __all__ = ['IQCalc']
 
 

--- a/ginga/util/iqcalc_astropy.py
+++ b/ginga/util/iqcalc_astropy.py
@@ -96,7 +96,8 @@ class IQCalc(_IQCalc):
         N, X, Y, maxv = self._prep_for_fitting(arr1d, medv)
 
         # Gaussian model with initial guess
-        m_init = models.Gaussian1D(amplitude=maxv, mean=0, stddev=(N - 1))
+        m_init = models.Gaussian1D(
+            amplitude=maxv, mean=N * 0.5, stddev=(N * 0.25))
 
         # NOTE: without this mutex, optimize.leastsq causes a fatal error
         # sometimes--it appears not to be thread safe.
@@ -173,7 +174,8 @@ class IQCalc(_IQCalc):
         N, X, Y, maxv = self._prep_for_fitting(arr1d, medv)
 
         # Moffat model with initial guess
-        m_init = models.Moffat1D(amplitude=maxv, x_0=0, gamma=(N - 1), alpha=2)
+        m_init = models.Moffat1D(
+            amplitude=maxv, x_0=(N * 0.5), gamma=(N * 0.25), alpha=2)
 
         # NOTE: without this mutex, optimize.leastsq causes a fatal error
         # sometimes--it appears not to be thread safe.
@@ -252,7 +254,8 @@ class IQCalc(_IQCalc):
         N, X, Y, maxv = self._prep_for_fitting(arr1d, medv)
 
         # Lorentz model with initial guess
-        m_init = models.Lorentz1D(amplitude=maxv, x_0=0, fwhm=(N - 1))
+        m_init = models.Lorentz1D(
+            amplitude=maxv, x_0=(N * 0.5), fwhm=(N * 0.25))
 
         # NOTE: without this mutex, optimize.leastsq causes a fatal error
         # sometimes--it appears not to be thread safe.

--- a/ginga/util/plots.py
+++ b/ginga/util/plots.py
@@ -9,7 +9,7 @@ import numpy as np
 import matplotlib as mpl
 from matplotlib.figure import Figure
 
-from ginga.util import iqcalc
+from ginga.util import iqcalc as _iqcalc  # Prevent namespace confusion below
 from ginga.misc import Callback, Bunch
 
 # fix issue of negative numbers rendering incorrectly with default font
@@ -405,7 +405,7 @@ class FWHMPlot(Plot):
     def __init__(self, *args, **kwargs):
         super(FWHMPlot, self).__init__(*args, **kwargs)
 
-        self.iqcalc = iqcalc.IQCalc(self.logger)
+        self.iqcalc = _iqcalc.IQCalc(self.logger)
 
     def _plot_fwhm_axis(self, arr, iqcalc, skybg, color1, color2, color3,
                         fwhm_method='gaussian'):


### PR DESCRIPTION
This fixes #754 by implementing Lorentz fitting, but it is only available if `iqcalc_astropy` is used over `iqcalc`.

**TODO**

- [x] Add tests for new stuff.
- [x] Compare results between `iqcalc` and `iqcalc_astropy`. (This can be part of the tests too.)
- [x] Rebase after #881 is merged.
- [x] Figure out a way for Ginga to swap between the two modules: New entry in ~`general.cfg`~ `plugin_Pick.cfg`?
- [x] See if `Pick` still works with both.
- [x] Update change log entry when more stuff above is complete.

**Screenshot**

![ginga_iqcalc_astropy](https://user-images.githubusercontent.com/2090236/90925912-06786180-e3c0-11ea-9d66-8f24266679ff.jpg)

```python
import matplotlib.pyplot as plt
import numpy as np           

from ginga.util.iqcalc_astropy import IQCalc

arr1d = np.array([0., 9., 0., 0., 0., 34., 25., 60., 196., 602., 
                  1117., 1003., 413., 135., 29., 0., 3., 0., 4., 3.])
x = list(range(arr1d.size))

iqcalc = IQCalc() 
res_gaussian = iqcalc.calc_fwhm_gaussian(arr1d)
res_moffat = iqcalc.calc_fwhm_moffat(arr1d)
res_lorentz = iqcalc.calc_fwhm_lorentz(arr1d)

fit_gaussian = res_gaussian.fit_fn(x, res_gaussian.fit_args)
fit_moffat = res_moffat.fit_fn(x, res_moffat.fit_args)
fit_lorentz = res_lorentz.fit_fn(x, res_lorentz.fit_args)

fig = plt.figure()
ax1 = fig.add_subplot(311)
ax2 = fig.add_subplot(312)
ax3 = fig.add_subplot(313)

ax1.plot(arr1d)
ax2.plot(arr1d)
ax3.plot(arr1d)

ax1.plot(fit_gaussian, 'r--')
ax2.plot(fit_moffat, 'r--')
ax3.plot(fit_lorentz, 'r--')

ax1.text(0.05, 0.95, f'Gaussian FWHM: {res_gaussian.fwhm:.4f}', transform=ax1.transAxes, verticalalignment='top')
ax2.text(0.05, 0.95, f'Moffat FWHM: {res_moffat.fwhm:.4f}', transform=ax2.transAxes, verticalalignment='top')
ax3.text(0.05, 0.95, f'Lorentz FWHM: {res_lorentz.fwhm:.4f}', transform=ax3.transAxes, verticalalignment='top')

plt.show()
```