### PR TITLE
TST: Verbose pytest and use capsys

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@8ffcd60
     - name: Run tests
-      run: pytest --pyargs ginga doc
+      run: pytest --pyargs ginga doc -sv
 
   older_deps_tests:
     runs-on: ubuntu-16.04
@@ -74,7 +74,7 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@8ffcd60
     - name: Run tests
-      run: pytest --pyargs ginga doc
+      run: pytest --pyargs ginga doc -sv
 
   dev_deps_tests:
     runs-on: ubuntu-latest
@@ -96,7 +96,7 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@8ffcd60
     - name: Run tests
-      run: pytest --pyargs ginga doc
+      run: pytest --pyargs ginga doc -sv
 
   conda_linux_tests:
     runs-on: ubuntu-latest
@@ -117,4 +117,4 @@ jobs:
         $CONDA/bin/conda install attrs astropy pytest-astropy -c conda-forge
         $CONDA/bin/pip install -e .
     - name: Run tests
-      run: $CONDA/bin/pytest --pyargs ginga doc
+      run: $CONDA/bin/pytest --pyargs ginga doc -sv

--- a/ginga/misc/tests/test_Callback.py
+++ b/ginga/misc/tests/test_Callback.py
@@ -381,7 +381,7 @@ class TestCallbacks(object):
         actual = test_callbacks.make_callback("test_name")
         assert expected == actual
 
-    def test_make_callback_raises_no_exception(self):
+    def test_make_callback_raises_no_exception(self, capsys):
         test_callbacks = Callback.Callbacks()
 
         # This function when used as a callback should raise a TypeError
@@ -397,7 +397,10 @@ class TestCallbacks(object):
         actual = test_callbacks.make_callback("test_name")
         assert expected == actual
 
-    def test_make_callback_raises_no_exception_completes_all_callbacks(self):
+        captured = capsys.readouterr()
+        assert 'Error making callback' in captured.out
+
+    def test_make_callback_raises_no_exception_completes_all_callbacks(self, capsys):
         test_callbacks = Callback.Callbacks()
 
         def test_callback_function():
@@ -415,5 +418,8 @@ class TestCallbacks(object):
         expected = True
         actual = test_callbacks.make_callback("test_name")
         assert expected == actual
+
+        captured = capsys.readouterr()
+        assert 'Error making callback' in captured.out
 
 # END


### PR DESCRIPTION
This PR makes pytest output more verbose, so we see exactly which test fails when failure happen. It also shows any screen output.

This PR also fixes the following screen output in the test log in the verbose mode set above (it currently does not fail the test but should be captured and tested anyway):

```
ginga/misc/tests/test_Callback.py::TestCallbacks::test_make_callback_raises_no_exception Error making callback 'test_name': test_callback_function() takes 0 positional arguments but 1 was given
Traceback:
  File ".../ginga/misc/Callback.py", line 156, in _do_callbacks
    res = method(*cb_args, **cb_kwargs)

PASSED
ginga/misc/tests/test_Callback.py::TestCallbacks::test_make_callback_raises_no_exception_completes_all_callbacks Error making callback 'test_name': test_callback_function() takes 0 positional arguments but 1 was given
Traceback:
  File ".../ginga/misc/Callback.py", line 156, in _do_callbacks
    res = method(*cb_args, **cb_kwargs)

```