### PR TITLE
MNT: Drop Python 3.5 and 3.6

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - name: Install and build
       run: |
         python -m pip install --upgrade pip setuptools
@@ -65,7 +65,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.6'
+        python-version: '3.7'
     - name: Install and build
       run: |
         python -m pip install --upgrade pip setuptools

--- a/doc/FAQ.rst
+++ b/doc/FAQ.rst
@@ -20,7 +20,7 @@ Linux, Mac and Windows versions, all of these packages are available.
 
 Does Ginga work with Python 3?
 ------------------------------
-Yes, but only Python 3.5 or later. Just install with Python 3.
+Yes, but only Python 3.7 or later. Just install with Python 3.
 Of course, you need all the supporting modules for Python 3 (NumPy, SciPy, Qt 5, etc.).
 
 Does Ginga work with Python 2?

--- a/doc/WhatsNew.rst
+++ b/doc/WhatsNew.rst
@@ -4,6 +4,7 @@ What's New
 
 Ver 3.2.0 (unreleased)
 ======================
+- Minimum supported Python version is now 3.7
 - Fixed some numpy deprecation warnings with numpy 1.19.0
 - Canvas shapes can now be copied
 - Added an option to make a copy of existing shape in Drawing plugin

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -19,7 +19,7 @@ to compile anything, but as always, your mileage may vary.
 REQUIRED
 ========
 
-* python (v. 3.5 or higher)
+* python (v. 3.7 or higher)
 * setuptools-scm
 * numpy  (v. 1.13 or higher)
 * astropy

--- a/ginga/misc/ModuleManager.py
+++ b/ginga/misc/ModuleManager.py
@@ -21,9 +21,7 @@ def my_import(name, path=None):
 
     # Documentation for importlib says this may be needed to pick up
     # modules created after the program has started
-    if hasattr(importlib, 'invalidate_caches'):
-        # python 3.3+
-        importlib.invalidate_caches()
+    importlib.invalidate_caches()
 
     if path is not None:
         directory, src_file = os.path.split(path)

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,8 +28,6 @@ classifiers =
     Operating System :: Microsoft :: Windows
     Operating System :: POSIX
     Programming Language :: C
-    Programming Language :: Python :: 3.5
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3
@@ -40,7 +38,7 @@ classifiers =
 [options]
 zip_safe = False
 packages = find:
-python_requires = >=3.5
+python_requires = >=3.7
 install_requires = numpy>=1.13; qtpy>=1.1; astropy>=3.2
 setup_requires = setuptools_scm
 


### PR DESCRIPTION
Fix #879 

Note: https://github.com/conda-forge/ginga-feedstock/blob/master/recipe/meta.yaml needs to be updated too at release time.