### PR TITLE
Remove support for matplotlib < 2.0

### DIFF
--- a/doc/WhatsNew.rst
+++ b/doc/WhatsNew.rst
@@ -10,6 +10,7 @@ Ver 3.2.0 (unreleased)
 - Added an option to make a copy of existing shape in Drawing plugin
 - Added an option to make a copy of existing cut in Cuts plugin
 - Fixed a bug where certain plots were not cleared in Pick plugin
+- Removed support for matplotlib versions < 2.1
 
 Ver 3.1.0 (2020-07-20)
 ======================

--- a/ginga/gw/PlotView.py
+++ b/ginga/gw/PlotView.py
@@ -66,11 +66,7 @@ class PlotViewGw(Callback.Callbacks):
         self.line_plot = plots.Plot(logger=self.logger,
                                     width=400, height=400)
         bg = self.settings.get('plot_bg', 'white')
-        if plots.MPL_GE_2_0:
-            kwargs = {'facecolor': bg}
-        else:
-            kwargs = {'axisbg': bg}
-        self.line_plot.add_axis(**kwargs)
+        self.line_plot.add_axis(facecolor=bg)
         self.plot_w = Plot.PlotWidget(self.line_plot)
         self.plot_w.resize(400, 400)
 

--- a/ginga/rv/plugins/Cuts.py
+++ b/ginga/rv/plugins/Cuts.py
@@ -206,11 +206,7 @@ class Cuts(GingaPlugin.LocalPlugin):
 
         self.slit_plot = plots.Plot(logger=self.logger,
                                     width=400, height=400)
-        if plots.MPL_GE_2_0:
-            kwargs = {'facecolor': 'black'}
-        else:
-            kwargs = {'axisbg': 'black'}
-        self.slit_plot.add_axis(**kwargs)
+        self.slit_plot.add_axis(facecolor='black')
         self.plot2 = Plot.PlotWidget(self.slit_plot)
         self.plot2.resize(400, 400)
 

--- a/ginga/rv/plugins/Pick.py
+++ b/ginga/rv/plugins/Pick.py
@@ -571,11 +571,7 @@ class Pick(GingaPlugin.LocalPlugin):
                 # Contour plot
                 self.contour_plot = plots.ContourPlot(
                     logger=self.logger, width=width, height=height)
-                if plots.MPL_GE_2_0:
-                    kwargs = {'facecolor': 'black'}
-                else:
-                    kwargs = {'axisbg': 'black'}
-                self.contour_plot.add_axis(**kwargs)
+                self.contour_plot.add_axis(facecolor='black')
                 self.contour_plot.enable(pan=True, zoom=True)
                 pw = Plot.PlotWidget(self.contour_plot)
                 pw.resize(width, height)
@@ -591,11 +587,7 @@ class Pick(GingaPlugin.LocalPlugin):
             # FWHM gaussians plot
             self.fwhm_plot = plots.FWHMPlot(logger=self.logger,
                                             width=width, height=height)
-            if plots.MPL_GE_2_0:
-                kwargs = {'facecolor': 'white'}
-            else:
-                kwargs = {'axisbg': 'white'}
-            self.fwhm_plot.add_axis(**kwargs)
+            self.fwhm_plot.add_axis(facecolor='white')
             pw = Plot.PlotWidget(self.fwhm_plot)
             pw.resize(width, height)
             nb.add_widget(pw, title="FWHM")
@@ -603,7 +595,7 @@ class Pick(GingaPlugin.LocalPlugin):
             # Radial profile plot
             self.radial_plot = plots.RadialPlot(logger=self.logger,
                                                 width=width, height=height)
-            self.radial_plot.add_axis(**kwargs)
+            self.radial_plot.add_axis(facecolor='white')
             pw = Plot.PlotWidget(self.radial_plot)
             pw.resize(width, height)
             nb.add_widget(pw, title="Radial")

--- a/ginga/util/plots.py
+++ b/ginga/util/plots.py
@@ -15,8 +15,6 @@ from ginga.misc import Callback, Bunch
 # fix issue of negative numbers rendering incorrectly with default font
 mpl.rcParams['axes.unicode_minus'] = False
 
-MPL_GE_2_0 = mpl.__version__[0] not in ('0', '1')
-
 
 class Plot(Callback.Callbacks):
 
@@ -84,10 +82,7 @@ class Plot(Callback.Callbacks):
     def set_bg(self, color, ax=None):
         if ax is None:
             ax = self.ax
-        if MPL_GE_2_0:
-            ax.set_facecolor(color)
-        else:
-            ax.set_axis_bgcolor(color)
+        ax.set_facecolor(color)
 
     def clear(self):
         self.logger.debug('clearing canvas...')
@@ -303,10 +298,7 @@ class ContourPlot(Plot):
         ##     self.cbar.remove()
 
         self.ax.cla()
-        if MPL_GE_2_0:
-            self.ax.set_facecolor('#303030')
-        else:
-            self.ax.set_axis_bgcolor('#303030')
+        self.ax.set_facecolor('#303030')
 
         try:
             im = self.ax.imshow(data, interpolation=self.interpolation,
@@ -512,12 +504,7 @@ class SurfacePlot(Plot):
             from mpl_toolkits.mplot3d import Axes3D  # noqa
             from matplotlib.ticker import LinearLocator, FormatStrFormatter
 
-            if MPL_GE_2_0:
-                kwargs = {'facecolor': '#808080'}
-            else:
-                kwargs = {'axisbg': '#808080'}
-
-            self.ax = self.fig.gca(projection='3d', **kwargs)
+            self.ax = self.fig.gca(projection='3d', facecolor='#808080')
 
             self.set_titles(ytitle='Y', xtitle='X',
                             title='Surface Plot')

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ install_requires = numpy>=1.13; qtpy>=1.1; astropy>=3.2
 setup_requires = setuptools_scm
 
 [options.extras_require]
-recommended = pillow>=3.2.0; scipy>=0.18.1; matplotlib>=1.5.1; opencv-python>=3.4.1; piexif>=1.0.13; beautifulsoup4>=4.3.2; docutils
+recommended = pillow>=3.2.0; scipy>=0.18.1; matplotlib>=2.1; opencv-python>=3.4.1; piexif>=1.0.13; beautifulsoup4>=4.3.2; docutils
 test = attrs>=19.2.0; pytest-astropy
 docs = sphinx-astropy; sphinx_rtd_theme
 gtk3 = pycairo; pygobject


### PR DESCRIPTION
This removes support for matplotlib versions < 2.0. 

Since the "current" version of matplotlib seems to be 3.x I think this is reasonable.
