### PR TITLE
Redraw plot after a clear operation

### DIFF
--- a/doc/WhatsNew.rst
+++ b/doc/WhatsNew.rst
@@ -9,6 +9,7 @@ Ver 3.2.0 (unreleased)
 - Canvas shapes can now be copied
 - Added an option to make a copy of existing shape in Drawing plugin
 - Added an option to make a copy of existing cut in Cuts plugin
+- Fixed a bug where certain plots were not cleared in Pick plugin
 
 Ver 3.1.0 (2020-07-20)
 ======================

--- a/ginga/util/plots.py
+++ b/ginga/util/plots.py
@@ -94,6 +94,7 @@ class Plot(Callback.Callbacks):
         self.ax.cla()
         self.xdata = []
         self.ydata = []
+        self.draw()
 
     def draw(self):
         self.fig.canvas.draw()


### PR DESCRIPTION
Fix #884 

Fixes an issue where a plot is not redrawn automatically when calling `clear()` on it.
