### PR TITLE
MNT: Remove deprecated mpl usage

### DIFF
--- a/ginga/cmap.py
+++ b/ginga/cmap.py
@@ -13306,6 +13306,7 @@ def add_matplotlib_cmap(cm, name=None):
 def add_matplotlib_cmaps(fail_on_import_error=True):
     """Add all matplotlib colormaps."""
     try:
+        import matplotlib.pyplot as plt
         from matplotlib import cm as _cm
         from matplotlib.cbook import mplDeprecation
     except ImportError:
@@ -13314,7 +13315,7 @@ def add_matplotlib_cmaps(fail_on_import_error=True):
         # silently fail
         return
 
-    for name in _cm.cmap_d:
+    for name in plt.colormaps():
         if not isinstance(name, str):
             continue
         try:

--- a/ginga/cmap.py
+++ b/ginga/cmap.py
@@ -13315,6 +13315,7 @@ def add_matplotlib_cmaps(fail_on_import_error=True):
         # silently fail
         return
 
+    # NOTE: Update if matplotlib has new public API for this.
     for name in plt.colormaps():
         if not isinstance(name, str):
             continue


### PR DESCRIPTION
Seems to work with matplotlib 2.1, so I don't think we need any version check.

Fix #890, fix spacetelescope/imexam#214 . Thanks to @jchavez1992 for reporting.

Caused by matplotlib/matplotlib#16991