### PR TITLE
MNT: Add auto PR labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,36 @@
+documentation:
+  - .readthedocs.yml
+  - CITATION
+  - doc/**/*
+  - ginga/doc/*
+  - licenses/*
+ - '*.md'
+ - '*.txt'
+  - any: ['*.rst', '!CHANGES.rst']
+
+maintenance:
+  - .bandit.yaml
+  - .github/**/*
+  - .gitignore
+  - conftest.py
+  - MANIFEST.in
+  - pyproject.toml
+  - setup.*
+
+plugin:
+  - doc/manual/plugins.rst
+  - doc/manual/plugins_global/**/*
+  - doc/manual/plugins_local/**/*
+  - experimental/plugins/*
+  - ginga/rv/plugins/*
+
+reference viewer:
+  - ginga/rv/**/*
+
+widget:
+  - doc/dev_manual/jupnotebooks.rst
+  - ginga/aggw/**/*
+  - ginga/gtk3w/**/*
+  - ginga/gw/**/*
+  - ginga/qtw/**/*
+  - ginga/web/**/*

--- a/.github/workflows/open_actions.yml
+++ b/.github/workflows/open_actions.yml
@@ -1,0 +1,15 @@
+name: When Opened
+
+on:
+  pull_request_target:
+    types:
+    - opened
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Label PR
+      uses: actions/labeler@main
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This pull request adds auto PR labeler using https://github.com/actions/labeler in GitHub Actions. I tried to map some existing labels to associated files that seem obvious to me, but feel free to suggest changes if I got things wrong.

The motivation is to have more consistency in how the labels are applied to pull requests. Issues are not affected.