### PR TITLE
MNT: Add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,61 @@
+---
+name: Bug report
+about: Create a report describing unexpected or incorrect behavior in ginga.
+labels: 'bug'
+---
+
+<!-- This comments are hidden when you submit the issue,
+so you do not need to remove them! -->
+
+<!-- Please be sure to check out our code of conduct,
+https://github.com/ejeschke/ginga/blob/master/CODE_OF_CONDUCT.md . -->
+
+<!-- Please have a search on our GitHub repository to see if a similar
+issue has already been posted.
+If a similar issue is closed, have a quick look to see if you are satisfied
+by the resolution.
+If not please go ahead and open an issue! -->
+
+<!-- Please check that the development version still produces the same bug.
+You can install development version with
+pip install git+https://github.com/ejeschke/ginga
+command. -->
+
+### Description
+<!-- Provide a general description of the bug. -->
+
+### Expected behavior
+<!-- What did you expect to happen. -->
+
+### Actual behavior
+<!-- What actually happened. -->
+<!-- Was the output confusing or poorly described? -->
+
+### Steps to Reproduce
+<!-- Ideally a code example could be provided so we can run it ourselves. -->
+<!-- If you are pasting code, use triple backticks (```) around
+your code snippet. -->
+<!-- If necessary, sanitize your screen output to be pasted so you do not
+reveal secrets like tokens and passwords. -->
+
+1. [First Step]
+2. [Second Step]
+3. [and so on...]
+
+```python
+# Put your Python code snippet here.
+```
+
+### System Details
+<!-- Even if you do not think this is necessary, it is useful information for the maintainers.
+Please run the following snippet and paste the output below:
+import platform; print(platform.platform())
+import sys; print("Python", sys.version)
+import numpy; print("Numpy", numpy.__version__)
+import astropy; print("astropy", astropy.__version__)
+import scipy; print("Scipy", scipy.__version__)
+import matplotlib; print("Matplotlib", matplotlib.__version__)
+import qtpy; print("QtPy", qtpy.__version__)
+import ginga; print("Ginga", ginga.__version__)
+# Add version info of any other relevant packages too.
+-->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: Feature request
+about: Suggest an idea to improve ginga
+label: 'Feature Request'
+---
+
+<!-- This comments are hidden when you submit the issue,
+so you do not need to remove them! -->
+
+<!-- Please be sure to check out our code of conduct,
+https://github.com/ejeschke/ginga/blob/master/CODE_OF_CONDUCT.md . -->
+
+<!-- Please have a search on our GitHub repository to see if a similar
+issue has already been posted.
+If a similar issue is closed, have a quick look to see if you are satisfied
+by the resolution.
+If not please go ahead and open an issue! -->
+
+### Description
+<!-- Provide a general description of the feature you would like. -->
+<!-- If you want to, you can suggest a draft design or API. -->
+<!-- This way we have a deeper discussion on the feature. -->
+
+
+### Additional context
+<!-- Add any other context or screenshots about the feature request here. -->
+<!-- This part is optional. -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,35 @@
+---
+name: Question
+about: Ask a question about ginga that is neither a bug report nor a feature request.
+labels: 'question'
+---
+
+<!-- WAIT! Try out our new Discussions tab instead of opening issue. -->
+
+<!-- This comments are hidden when you submit the issue,
+so you do not need to remove them! -->
+
+<!-- Please be sure to check out our code of conduct,
+https://github.com/ejeschke/ginga/blob/master/CODE_OF_CONDUCT.md . -->
+
+<!-- Please have a search on our GitHub repository to see if a similar
+issue has already been posted.
+If a similar issue is closed, have a quick look to see if you are satisfied
+by the resolution.
+If not please go ahead and open an issue! -->
+
+### Description
+<!-- Ask your question here. -->
+
+### System Details (optional)
+<!-- If you attempted to run stsynphot, please run the following snippet and paste the output below:
+import platform; print(platform.platform())
+import sys; print("Python", sys.version)
+import numpy; print("Numpy", numpy.__version__)
+import astropy; print("astropy", astropy.__version__)
+import scipy; print("Scipy", scipy.__version__)
+import matplotlib; print("Matplotlib", matplotlib.__version__)
+import qtpy; print("QtPy", qtpy.__version__)
+import ginga; print("Ginga", ginga.__version__)
+# Add version info of any other relevant packages too.
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+<!-- This comments are hidden when you submit the pull request,
+so you do not need to remove them! -->
+
+<!-- Please be sure to check out our code of conduct,
+https://github.com/ejeschke/ginga/blob/master/CODE_OF_CONDUCT.md . -->
+
+<!-- Please just have a quick search on GitHub to see if a similar
+pull request has already been posted.
+We have old closed pull requests that might provide useful code or ideas
+that directly tie in with your pull request. -->
+
+<!-- We have several automatic features that run when a pull request is open.
+They can appear daunting but do not worry because maintainers will help
+you navigate them, if necessary. -->
+
+### Description
+<!-- Provide a general description of what your pull request does.
+Complete the following sentence and add relevant details as you see fit. -->
+
+<!-- In addition please ensure that the pull request title is descriptive. -->
+
+This pull request is to address ...
+
+<!-- If the pull request closes any open issues you can add this.
+If you replace <Issue Number> with a number, GitHub will automatically link it.
+If this pull request is unrelated to any issues, please remove
+the following line. -->
+
+Fixes #<Issue Number>


### PR DESCRIPTION
This pull request adds templates for new issues and pull requests. For issues, they are separated into feature request, bug report, and question categories. Also see https://docs.github.com/en/free-pro-team@latest/github/building-a-strong-community/using-templates-to-encourage-useful-issues-and-pull-requests