### PR TITLE
TST: Update CI workflow

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -9,8 +9,31 @@ on:
     - cron: '0 6 * * 1'
 
 jobs:
+  cancel_ci:
+    name: Mandatory checks before CI
+    runs-on: ubuntu-latest
+    steps:
+    # Base branch check should run whether we skip CI or not
+    - name: Check base branch
+      uses: pllim/action-check_pr_basebranch@main
+      with:
+        BASEBRANCH_NAME: master
+        SKIP_BASEBRANCH_CHECK_LABEL: skip-basebranch-check
+    - name: Failure means CI is skipped on purpose
+      uses: pllim/action-skip-ci@main
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    # This should only run if we did not skip CI
+    - name: Cancel Previous Runs
+      uses: styfle/cancel-workflow-action@ce17749
+      with:
+        access_token: ${{ secrets.GITHUB_TOKEN }}
+
+  # The rest only run if above are done
+
   pep_and_audit:
     runs-on: ubuntu-latest
+    needs: cancel_ci
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
@@ -27,9 +50,9 @@ jobs:
     # Make sure that packaging will work
     - name: PEP 517 build
       run: |
-        python -m pip install --upgrade setuptools build twine
+        python -m pip install --upgrade setuptools build "twine>=3.3"
         python -m build --sdist .
-        twine check dist/*
+        twine check --strict dist/*
     - name: Security audit
       run: |
         python -m pip install --upgrade bandit
@@ -37,6 +60,7 @@ jobs:
 
   multi_oses:
     runs-on: ${{ matrix.os }}
+    needs: cancel_ci
     strategy:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
@@ -61,6 +85,7 @@ jobs:
 
   older_deps_tests:
     runs-on: ubuntu-16.04
+    needs: cancel_ci
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
@@ -80,9 +105,9 @@ jobs:
     - name: Run tests
       run: pytest --pyargs ginga doc -sv
 
-  # TODO: Lift Python 3.8 pin when numpy and scipy have wheels for Python 3.9
   dev_deps_tests:
     runs-on: ubuntu-latest
+    needs: cancel_ci
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
@@ -91,7 +116,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.8'
+        python-version: '3.x'
     - name: Install and build
       run: |
         python -m pip install --upgrade pip setuptools
@@ -105,6 +130,7 @@ jobs:
 
   conda_linux_tests:
     runs-on: ubuntu-latest
+    needs: cancel_ci
     steps:
     - name: Checkout code
       uses: actions/checkout@v2

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -12,6 +12,8 @@ jobs:
   cancel_ci:
     name: Mandatory checks before CI
     runs-on: ubuntu-latest
+    outputs:
+      run_next: ${{ steps.skip_ci_step.outputs.run_next }}
     steps:
     # Base branch check should run whether we skip CI or not
     - name: Check base branch
@@ -19,13 +21,16 @@ jobs:
       with:
         BASEBRANCH_NAME: master
         SKIP_BASEBRANCH_CHECK_LABEL: skip-basebranch-check
-    - name: Failure means CI is skipped on purpose
+    - name: Check skip CI
       uses: pllim/action-skip-ci@main
+      id: skip_ci_step
       with:
+        NO_FAIL: true
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     # This should only run if we did not skip CI
     - name: Cancel Previous Runs
       uses: styfle/cancel-workflow-action@ce17749
+      if: steps.skip_ci_step.outputs.run_next == 'true'
       with:
         access_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -34,6 +39,7 @@ jobs:
   pep_and_audit:
     runs-on: ubuntu-latest
     needs: cancel_ci
+    if: needs.cancel_ci.outputs.run_next == 'true'
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
@@ -61,6 +67,7 @@ jobs:
   multi_oses:
     runs-on: ${{ matrix.os }}
     needs: cancel_ci
+    if: needs.cancel_ci.outputs.run_next == 'true'
     strategy:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
@@ -86,6 +93,7 @@ jobs:
   older_deps_tests:
     runs-on: ubuntu-16.04
     needs: cancel_ci
+    if: needs.cancel_ci.outputs.run_next == 'true'
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
@@ -108,6 +116,7 @@ jobs:
   dev_deps_tests:
     runs-on: ubuntu-latest
     needs: cancel_ci
+    if: needs.cancel_ci.outputs.run_next == 'true'
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
@@ -131,6 +140,7 @@ jobs:
   conda_linux_tests:
     runs-on: ubuntu-latest
     needs: cancel_ci
+    if: needs.cancel_ci.outputs.run_next == 'true'
     steps:
     - name: Checkout code
       uses: actions/checkout@v2

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -22,14 +22,14 @@ jobs:
         BASEBRANCH_NAME: master
         SKIP_BASEBRANCH_CHECK_LABEL: skip-basebranch-check
     - name: Check skip CI
-      uses: pllim/action-skip-ci@main
+      uses: OpenAstronomy/action-skip-ci@main
       id: skip_ci_step
       with:
         NO_FAIL: true
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     # This should only run if we did not skip CI
     - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@ce17749
+      uses: styfle/cancel-workflow-action@ce177499ccf9fd2aded3b0426c97e5434c2e8a73
       if: steps.skip_ci_step.outputs.run_next == 'true'
       with:
         access_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request updates the CI workflow in the following ways:

* ~Change `pull_request:` to `pull_request_target:`, which according to https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#pull_request_target, "prevents executing unsafe workflow code from the head of the pull request that could alter your repository or steal any secrets you use in your workflow."~ I reverted this so the CI runs on this PR. I am also confused by the documentation on GitHub and awaiting their clarification. UPDATE: No, should not use `pull_request_target`.
* Use https://github.com/pllim/action-check_pr_basebranch to ensure that PR is always opened against `master` branch. In the rare event where we need to push to `gh-pages`, we could use the `skip-basebranch-check` label to skip the check (apply it at the same time as you open the PR).
* Use https://github.com/pllim/action-skip-ci to allow `[ci skip]` to work in a PR.
* Use https://github.com/styfle/cancel-workflow-action to allow cancelling duplicate workflow runs.
* Use `twine check --strict` option to have it fail when the check finds warning. This is only available for `twine>=3.3`.
* Let dev job run on Python 3.9 now that we can do it.