### PR TITLE
Fixed Pick plugin to autozoom the pick and contour images

### DIFF
--- a/doc/WhatsNew.rst
+++ b/doc/WhatsNew.rst
@@ -29,6 +29,7 @@ Ver 3.2.0 (unreleased)
 - Changed splitter widget so that the "thumbs" have a visual indicator
 - Fixed an issue with cursor warp in free panning with Gtk3 backend
 - Fixed an issue where the cursor was not changed from the default
+- Fixed Pick plugin to autozoom the pick and contour images
 
 Ver 3.1.0 (2020-07-20)
 ======================

--- a/ginga/rv/plugins/Pick.py
+++ b/ginga/rv/plugins/Pick.py
@@ -489,14 +489,14 @@ class Pick(GingaPlugin.LocalPlugin):
 
         cm, im = self.fv.cm, self.fv.im
 
+        # Set up "Image" tab viewer
         di = Viewers.CanvasView(logger=self.logger)
         width, height = self._wd, self._ht
         di.set_desired_size(width, height)
-        di.enable_autozoom('off')
+        di.enable_autozoom('override')
         di.enable_autocuts('off')
         di.set_zoom_algorithm('rate')
         di.set_zoomrate(1.6)
-        di.zoom_to(2)
         settings = di.get_settings()
         settings.get_setting('zoomlevel').add_callback('set', self.zoomset, di)
 
@@ -534,16 +534,16 @@ class Pick(GingaPlugin.LocalPlugin):
         iw.resize(width, height)
         nb.add_widget(iw, title="Image")
 
+        # Set up "Contour" tab viewer
         if contour.have_skimage:
             # Contour plot, Ginga-style
             ci = Viewers.CanvasView(logger=self.logger)
             width, height = 400, 300
             ci.set_desired_size(width, height)
-            ci.enable_autozoom('once')
+            ci.enable_autozoom('override')
             ci.enable_autocuts('override')
             ci.set_zoom_algorithm('rate')
             ci.set_zoomrate(1.6)
-            ci.zoom_to(3)
             ci.set_autocut_params('histogram')
 
             t_ = ci.get_settings()


### PR DESCRIPTION
The Pick plugin is supposed to autozoom the pick and contour images in the plugin GUI, at least until the user overrides the zoom level.  This change makes it work correctly.