### PR TITLE
Fixes for Gtk Splitter widget

### DIFF
--- a/ginga/gtk3w/Widgets.py
+++ b/ginga/gtk3w/Widgets.py
@@ -1682,11 +1682,12 @@ class ScrollArea(ContainerBase):
 
 
 class Splitter(ContainerBase):
-    def __init__(self, orientation='horizontal'):
+    def __init__(self, orientation='horizontal', thumb_px=8):
         super(Splitter, self).__init__()
 
         self.orientation = orientation
-        self.widget = GtkHelp.Splitter(orientation=self.orientation)
+        self.widget = GtkHelp.Splitter(orientation=self.orientation,
+                                       thumb_px=thumb_px)
 
     def add_widget(self, child):
         self.add_ref(child)

--- a/ginga/qtw/Widgets.py
+++ b/ginga/qtw/Widgets.py
@@ -1508,8 +1508,10 @@ class ScrollArea(ContainerBase):
 
 
 class Splitter(ContainerBase):
-    def __init__(self, orientation='horizontal'):
+    def __init__(self, orientation='horizontal', thumb_px=8):
         super(Splitter, self).__init__()
+
+        self.thumb_px = thumb_px
 
         w = QtGui.QSplitter()
         self.orientation = orientation
@@ -1517,19 +1519,21 @@ class Splitter(ContainerBase):
         # indicator on Linux and Windows
         if self.orientation == 'horizontal':
             w.setOrientation(QtCore.Qt.Horizontal)
-            iconfile = pathlib.Path(icondir) / 'vdots.png'
-            w.setStyleSheet(
-                """
-                QSplitter::handle { width: 8px; height: 8px;
-                                    image: url(%s); }
-                """ % (iconfile))
+            if thumb_px is not None:
+                iconfile = pathlib.Path(icondir) / 'vdots.png'
+                w.setStyleSheet(
+                    """
+                    QSplitter::handle { width: %spx; height: %spx;
+                                        image: url(%s); }
+                    """ % (self.thumb_px, self.thumb_px, iconfile))
         else:
             w.setOrientation(QtCore.Qt.Vertical)
-            iconfile = pathlib.Path(icondir) / 'hdots.png'
-            w.setStyleSheet(
-                """
-                QSplitter::handle { height: 8px; image: url(%s); }
-                """ % (iconfile))
+            if thumb_px is not None:
+                iconfile = pathlib.Path(icondir) / 'hdots.png'
+                w.setStyleSheet(
+                    """
+                    QSplitter::handle { height: %spx; image: url(%s); }
+                    """ % (self.thumb_px, iconfile))
         self.widget = w
         w.setChildrenCollapsible(True)
 

--- a/ginga/web/pgw/Widgets.py
+++ b/ginga/web/pgw/Widgets.py
@@ -1822,11 +1822,12 @@ class Splitter(ContainerBase):
     </script>
     """
 
-    def __init__(self, orientation='horizontal'):
+    def __init__(self, orientation='horizontal', thumb_px=8):
         super(Splitter, self).__init__()
 
         self.orientation = orientation
         self.widget = None
+        self.thumb_px = thumb_px
         self.sizes = []
 
         self.enable_callback('activated')


### PR DESCRIPTION
Fixes some event handling for the Gtk version of Splitter widget and also provides a way to specify a size for the divider (splitter handle) image.