### PR TITLE
MNT: Use float instead of np.float, int instead of np.int

### DIFF
--- a/ginga/Bindings.py
+++ b/ginga/Bindings.py
@@ -580,14 +580,14 @@ class ImageViewBindings(object):
 
         arr = np.array([(mnwd, mnht), (mxwd, mnht),
                         (mxwd, mxht), (mnwd, mxht)],
-                       dtype=np.float)
+                       dtype=float)
         x, y = tr.to_(arr).T
 
         rx1, rx2 = np.min(x), np.max(x)
         ry1, ry2 = np.min(y), np.max(y)
 
         rect = viewer.get_pan_rect()
-        arr = np.array(rect, dtype=np.float)
+        arr = np.array(rect, dtype=float)
         x, y = tr.to_(arr).T
 
         qx1, qx2 = np.min(x), np.max(x)
@@ -633,7 +633,7 @@ class ImageViewBindings(object):
 
         arr = np.array([(mnwd, mnht), (mxwd, mnht),
                         (mxwd, mxht), (mnwd, mxht)],
-                       dtype=np.float)
+                       dtype=float)
         x, y = tr.to_(arr).T
 
         rx1, rx2 = np.min(x), np.max(x)

--- a/ginga/ColorDist.py
+++ b/ginga/ColorDist.py
@@ -98,7 +98,7 @@ class LinearDist(ColorDistBase):
         self.check_hash()
 
     def get_dist_pct(self, pct):
-        pct = np.asarray(pct, dtype=np.float)
+        pct = np.asarray(pct, dtype=float)
         val = np.clip(pct, 0.0, 1.0)
         return val
 
@@ -127,7 +127,7 @@ class LogDist(ColorDistBase):
         self.check_hash()
 
     def get_dist_pct(self, pct):
-        pct = np.asarray(pct, dtype=np.float)
+        pct = np.asarray(pct, dtype=float)
         val_inv = (np.exp(pct * np.log(self.exp)) - 1) / self.exp
         val = np.clip(val_inv, 0.0, 1.0)
         return val
@@ -157,7 +157,7 @@ class PowerDist(ColorDistBase):
         self.check_hash()
 
     def get_dist_pct(self, pct):
-        pct = np.asarray(pct, dtype=np.float)
+        pct = np.asarray(pct, dtype=float)
         val_inv = np.log(self.exp * pct + 1) / np.log(self.exp)
         val = np.clip(val_inv, 0.0, 1.0)
         return val
@@ -186,7 +186,7 @@ class SqrtDist(ColorDistBase):
         self.check_hash()
 
     def get_dist_pct(self, pct):
-        pct = np.asarray(pct, dtype=np.float)
+        pct = np.asarray(pct, dtype=float)
         val_inv = pct ** 2.0
         val = np.clip(val_inv, 0.0, 1.0)
         return val
@@ -214,7 +214,7 @@ class SquaredDist(ColorDistBase):
         self.check_hash()
 
     def get_dist_pct(self, pct):
-        pct = np.asarray(pct, dtype=np.float)
+        pct = np.asarray(pct, dtype=float)
         val_inv = np.sqrt(pct)
         val = np.clip(val_inv, 0.0, 1.0)
         return val
@@ -246,7 +246,7 @@ class AsinhDist(ColorDistBase):
         self.check_hash()
 
     def get_dist_pct(self, pct):
-        pct = np.asarray(pct, dtype=np.float)
+        pct = np.asarray(pct, dtype=float)
         # calculate inverse of dist fn
         val_inv = np.sinh(self.nonlinearity * pct) / self.factor
         val = np.clip(val_inv, 0.0, 1.0)
@@ -279,7 +279,7 @@ class SinhDist(ColorDistBase):
         self.check_hash()
 
     def get_dist_pct(self, pct):
-        pct = np.asarray(pct, dtype=np.float)
+        pct = np.asarray(pct, dtype=float)
         # calculate inverse of dist fn
         val_inv = np.arcsinh(self.nonlinearity * pct) / self.factor
         val = np.clip(val_inv, 0.0, 1.0)
@@ -328,7 +328,7 @@ class HistogramEqualizationDist(ColorDistBase):
         return arr
 
     def get_dist_pct(self, pct):
-        pct = np.asarray(pct, dtype=np.float)
+        pct = np.asarray(pct, dtype=float)
         # TODO: this is wrong but we need a way to invert the hash
         val = np.clip(pct, 0.0, 1.0)
         return pct
@@ -355,7 +355,7 @@ class CurveDist(ColorDistBase):
         self.check_hash()
 
     def get_dist_pct(self, pct):
-        pct = np.asarray(pct, dtype=np.float)
+        pct = np.asarray(pct, dtype=float)
         val = np.clip(pct, 0.0, 1.0)
         return val
 

--- a/ginga/canvas/CanvasObject.py
+++ b/ginga/canvas/CanvasObject.py
@@ -291,7 +291,7 @@ class CanvasObjectBase(Callback.Callbacks):
     def set_point_by_index(self, i, pt):
         #self.points[i] = self.crdmap.data_to(pt)
         # Can we eventually use something like the above?
-        points = np.asarray(self.points, dtype=np.float)
+        points = np.asarray(self.points, dtype=float)
         points[i] = self.crdmap.data_to(pt)
         self.points = points
 

--- a/ginga/canvas/transform.py
+++ b/ginga/canvas/transform.py
@@ -161,7 +161,7 @@ class WindowPercentageTransform(BaseTransform):
 
         # round to pixel units, if asked
         if self.as_int:
-            win_pts = np.rint(win_pts).astype(np.int, copy=False)
+            win_pts = np.rint(win_pts).astype(int, copy=False)
 
         return win_pts
 
@@ -197,7 +197,7 @@ class CartesianWindowTransform(BaseTransform):
 
         # round to pixel units, if asked
         if self.as_int:
-            win_pts = np.rint(win_pts).astype(np.int, copy=False)
+            win_pts = np.rint(win_pts).astype(int, copy=False)
 
         return win_pts
 
@@ -259,7 +259,7 @@ class CartesianNativeTransform(BaseTransform):
 
         # round to pixel units, if asked
         if self.as_int:
-            win_pts = np.rint(win_pts).astype(np.int, copy=False)
+            win_pts = np.rint(win_pts).astype(int, copy=False)
 
         return win_pts
 
@@ -299,7 +299,7 @@ class AsIntegerTransform(BaseTransform):
         self.viewer = viewer
 
     def to_(self, flt_pts):
-        int_pts = np.asarray(flt_pts, dtype=np.int)
+        int_pts = np.asarray(flt_pts, dtype=int)
         return int_pts
 
     def from_(self, int_pts):

--- a/ginga/canvas/transform.py
+++ b/ginga/canvas/transform.py
@@ -138,7 +138,7 @@ class WindowPercentageTransform(BaseTransform):
         self.as_int = as_int
 
     def to_(self, win_pts):
-        win_pts = np.asarray(win_pts, dtype=np.float)
+        win_pts = np.asarray(win_pts, dtype=float)
         has_z = (win_pts.shape[-1] > 2)
 
         max_pt = list(self.viewer.get_window_size())
@@ -150,7 +150,7 @@ class WindowPercentageTransform(BaseTransform):
 
     def from_(self, pct_pts):
         """Reverse of :meth:`to_`."""
-        pct_pts = np.asarray(pct_pts, dtype=np.float)
+        pct_pts = np.asarray(pct_pts, dtype=float)
         has_z = (pct_pts.shape[-1] > 2)
 
         max_pt = list(self.viewer.get_window_size())
@@ -180,7 +180,7 @@ class CartesianWindowTransform(BaseTransform):
     def to_(self, off_pts):
         # add center pixel to convert from X/Y coordinate space to
         # window graphics space
-        off_pts = np.asarray(off_pts, dtype=np.float)
+        off_pts = np.asarray(off_pts, dtype=float)
         has_z = (off_pts.shape[-1] > 2)
 
         ctr_pt = list(self.viewer.get_center())
@@ -205,7 +205,7 @@ class CartesianWindowTransform(BaseTransform):
         """Reverse of :meth:`to_`."""
         # make relative to center pixel to convert from window
         # graphics space to standard X/Y coordinate space
-        win_pts = np.asarray(win_pts, dtype=np.float)
+        win_pts = np.asarray(win_pts, dtype=float)
         has_z = (win_pts.shape[-1] > 2)
 
         ctr_pt = list(self.viewer.get_center())
@@ -240,7 +240,7 @@ class CartesianNativeTransform(BaseTransform):
     def to_(self, off_pts):
         # add center pixel to convert from X/Y coordinate space to
         # back end graphics space
-        off_pts = np.asarray(off_pts, dtype=np.float)
+        off_pts = np.asarray(off_pts, dtype=float)
         has_z = (off_pts.shape[-1] > 2)
 
         ctr_pt = list(self.viewer.get_center())
@@ -267,7 +267,7 @@ class CartesianNativeTransform(BaseTransform):
         """Reverse of :meth:`to_`."""
         # make relative to center pixel to convert from back end
         # graphics space to standard X/Y coordinate space
-        win_pts = np.asarray(win_pts, dtype=np.float)
+        win_pts = np.asarray(win_pts, dtype=float)
         has_z = (win_pts.shape[-1] > 2)
 
         ctr_pt = list(self.viewer.get_center())
@@ -304,7 +304,7 @@ class AsIntegerTransform(BaseTransform):
 
     def from_(self, int_pts):
         """Reverse of :meth:`to_`."""
-        flt_pts = np.asarray(int_pts, dtype=np.float)
+        flt_pts = np.asarray(int_pts, dtype=float)
         return flt_pts
 
 
@@ -319,7 +319,7 @@ class FlipSwapTransform(BaseTransform):
         self.viewer = viewer
 
     def to_(self, off_pts):
-        off_pts = np.asarray(off_pts, dtype=np.float)
+        off_pts = np.asarray(off_pts, dtype=float)
         has_z = (off_pts.shape[-1] > 2)
 
         t_ = self.viewer.t_
@@ -345,7 +345,7 @@ class FlipSwapTransform(BaseTransform):
 
     def from_(self, off_pts):
         """Reverse of :meth:`to_`."""
-        off_pts = np.asarray(off_pts, dtype=np.float)
+        off_pts = np.asarray(off_pts, dtype=float)
         has_z = (off_pts.shape[-1] > 2)
 
         t_ = self.viewer.t_
@@ -381,7 +381,7 @@ class RotationTransform(BaseTransform):
         self.viewer = viewer
 
     def to_(self, off_pts):
-        off_pts = np.asarray(off_pts, dtype=np.float)
+        off_pts = np.asarray(off_pts, dtype=float)
         has_z = (off_pts.shape[-1] > 2)
 
         t_ = self.viewer.t_
@@ -398,7 +398,7 @@ class RotationTransform(BaseTransform):
 
     def from_(self, off_pts):
         """Reverse of :meth:`to_`."""
-        off_pts = np.asarray(off_pts, dtype=np.float)
+        off_pts = np.asarray(off_pts, dtype=float)
         has_z = (off_pts.shape[-1] > 2)
 
         t_ = self.viewer.t_
@@ -425,7 +425,7 @@ class RotationFlipTransform(BaseTransform):
         self.viewer = viewer
 
     def to_(self, off_pts):
-        off_pts = np.asarray(off_pts, dtype=np.float)
+        off_pts = np.asarray(off_pts, dtype=float)
         has_z = (off_pts.shape[-1] > 2)
 
         t_ = self.viewer.t_
@@ -459,7 +459,7 @@ class RotationFlipTransform(BaseTransform):
 
     def from_(self, off_pts):
         """Reverse of :meth:`to_`."""
-        off_pts = np.asarray(off_pts, dtype=np.float)
+        off_pts = np.asarray(off_pts, dtype=float)
         has_z = (off_pts.shape[-1] > 2)
 
         t_ = self.viewer.t_
@@ -503,7 +503,7 @@ class ScaleTransform(BaseTransform):
 
     def to_(self, off_pts):
         """Reverse of :meth:`from_`."""
-        off_pts = np.asarray(off_pts, dtype=np.float)
+        off_pts = np.asarray(off_pts, dtype=float)
         has_z = (off_pts.shape[-1] > 2)
 
         # scale according to current settings
@@ -516,7 +516,7 @@ class ScaleTransform(BaseTransform):
         return off_pts
 
     def from_(self, off_pts):
-        off_pts = np.asarray(off_pts, dtype=np.float)
+        off_pts = np.asarray(off_pts, dtype=float)
         has_z = (off_pts.shape[-1] > 2)
 
         sc = self.viewer.renderer.get_scale()
@@ -546,7 +546,7 @@ class DataCartesianTransform(BaseTransform):
 
     def to_(self, data_pts):
         """Reverse of :meth:`from_`."""
-        data_pts = np.asarray(data_pts, dtype=np.float)
+        data_pts = np.asarray(data_pts, dtype=float)
         has_z = (data_pts.shape[-1] > 2)
 
         if self.use_center:
@@ -562,7 +562,7 @@ class DataCartesianTransform(BaseTransform):
         return off_pts
 
     def from_(self, off_pts):
-        off_pts = np.asarray(off_pts, dtype=np.float)
+        off_pts = np.asarray(off_pts, dtype=float)
         has_z = (off_pts.shape[-1] > 2)
 
         # Add data index at center to offset
@@ -591,13 +591,13 @@ class OffsetDataTransform(BaseTransform):
         self.pt = pt
 
     def to_(self, delta_pts):
-        delta_x, delta_y = np.asarray(delta_pts, dtype=np.float).T
+        delta_x, delta_y = np.asarray(delta_pts, dtype=float).T
         ref_x, ref_y = self.pt[:2]
         res_x, res_y = ref_x + delta_x, ref_y + delta_y
         return np.asarray((res_x, res_y)).T
 
     def from_(self, data_pts):
-        data_x, data_y = np.asarray(data_pts, dtype=np.float).T
+        data_x, data_y = np.asarray(data_pts, dtype=float).T
         ref_x, ref_y = self.pt[:2]
         res_x, res_y = data_x - ref_x, data_y - ref_y
         return np.asarray((res_x, res_y)).T

--- a/ginga/canvas/types/astro.py
+++ b/ginga/canvas/types/astro.py
@@ -92,7 +92,7 @@ class RulerP(TwoPointMixin, CanvasObjectBase):
                  showcap=True, showplumb=True, showends=False, units='arcmin',
                  font='Sans Serif', fontsize=None, **kwdargs):
         self.kind = 'ruler'
-        points = np.asarray([pt1, pt2], dtype=np.float)
+        points = np.asarray([pt1, pt2], dtype=float)
         CanvasObjectBase.__init__(self, color=color, color2=color2,
                                   alpha=alpha, units=units,
                                   showplumb=showplumb, showends=showends,
@@ -321,7 +321,7 @@ class CompassP(OnePointOneRadiusMixin, CanvasObjectBase):
                  linewidth=1, fontsize=None, font='Sans Serif',
                  alpha=1.0, linestyle='solid', showcap=True, **kwdargs):
         self.kind = 'compass'
-        points = np.asarray([pt], dtype=np.float)
+        points = np.asarray([pt], dtype=float)
         CanvasObjectBase.__init__(self, ctype=ctype, color=color, alpha=alpha,
                                   linewidth=linewidth, showcap=showcap,
                                   linestyle=linestyle,
@@ -532,7 +532,7 @@ class CrosshairP(OnePointMixin, CanvasObjectBase):
                  fontsize=10.0, font='Sans Serif', fontscale=True,
                  format='xy', **kwdargs):
         self.kind = 'crosshair'
-        points = np.asarray([pt], dtype=np.float)
+        points = np.asarray([pt], dtype=float)
         CanvasObjectBase.__init__(self, color=color, alpha=alpha,
                                   linewidth=linewidth, linestyle=linestyle,
                                   text=text, textcolor=textcolor,
@@ -720,7 +720,7 @@ class AnnulusP(AnnulusMixin, OnePointOneRadiusMixin, CompoundObject):
                      coord=coord)
         obj2.editable = False
 
-        points = np.asarray([pt], dtype=np.float)
+        points = np.asarray([pt], dtype=float)
 
         CompoundObject.__init__(self, obj1, obj2,
                                 points=points, radius=radius,
@@ -905,7 +905,7 @@ class Annulus2RP(AnnulusMixin, OnePointTwoRadiusMixin, CompoundObject):
                      coord=coord, rot_deg=rot_deg)
         obj2.editable = False
 
-        points = np.asarray([pt], dtype=np.float)
+        points = np.asarray([pt], dtype=float)
 
         CompoundObject.__init__(self, obj1, obj2,
                                 points=points, xradius=xradius, yradius=yradius,

--- a/ginga/canvas/types/basic.py
+++ b/ginga/canvas/types/basic.py
@@ -82,7 +82,7 @@ class TextP(OnePointMixin, CanvasObjectBase):
                  color='yellow', alpha=1.0, rot_deg=0.0,
                  showcap=False, **kwdargs):
         self.kind = 'text'
-        points = np.asarray([pt], dtype=np.float)
+        points = np.asarray([pt], dtype=float)
         super(TextP, self).__init__(points=points, color=color, alpha=alpha,
                                     font=font, fontsize=fontsize,
                                     fontscale=fontscale,
@@ -514,7 +514,7 @@ class BoxP(OnePointTwoRadiusMixin, CanvasObjectBase):
                  fill=False, fillcolor=None, alpha=1.0, fillalpha=1.0,
                  rot_deg=0.0, **kwdargs):
         xradius, yradius = radii[:2]
-        points = np.asarray([pt], dtype=np.float)
+        points = np.asarray([pt], dtype=float)
         CanvasObjectBase.__init__(self, points=points, color=color,
                                   linewidth=linewidth, showcap=showcap,
                                   linestyle=linestyle,
@@ -648,7 +648,7 @@ class SquareBoxP(OnePointOneRadiusMixin, CanvasObjectBase):
                  linewidth=1, linestyle='solid', showcap=False,
                  fill=False, fillcolor=None, alpha=1.0, fillalpha=1.0,
                  rot_deg=0.0, **kwdargs):
-        points = np.asarray([pt], dtype=np.float)
+        points = np.asarray([pt], dtype=float)
         CanvasObjectBase.__init__(self, points=points, color=color,
                                   linewidth=linewidth, showcap=showcap,
                                   linestyle=linestyle,
@@ -811,7 +811,7 @@ class EllipseP(OnePointTwoRadiusMixin, CanvasObjectBase):
                  fill=False, fillcolor=None, alpha=1.0, fillalpha=1.0,
                  rot_deg=0.0, **kwdargs):
         xradius, yradius = radii
-        points = np.asarray([pt], dtype=np.float)
+        points = np.asarray([pt], dtype=float)
         CanvasObjectBase.__init__(self, points=points, color=color,
                                   linewidth=linewidth, showcap=showcap,
                                   linestyle=linestyle,
@@ -836,8 +836,8 @@ class EllipseP(OnePointTwoRadiusMixin, CanvasObjectBase):
 
     def contains_pts(self, pts):
         x_arr, y_arr = np.asarray(pts).T
-        x_arr, y_arr = (x_arr.astype(np.float, copy=False),
-                        y_arr.astype(np.float, copy=False))
+        x_arr, y_arr = (x_arr.astype(float, copy=False),
+                        y_arr.astype(float, copy=False))
 
         points = self.get_points()
         # rotate point back to cartesian alignment for test
@@ -1014,7 +1014,7 @@ class TriangleP(OnePointTwoRadiusMixin, CanvasObjectBase):
                  rot_deg=0.0, **kwdargs):
         self.kind = 'triangle'
         xradius, yradius = radii[:2]
-        points = np.asarray([pt], dtype=np.float)
+        points = np.asarray([pt], dtype=float)
         CanvasObjectBase.__init__(self, points=points, color=color,
                                   linewidth=linewidth, showcap=showcap,
                                   linestyle=linestyle, alpha=alpha,
@@ -1037,7 +1037,7 @@ class TriangleP(OnePointTwoRadiusMixin, CanvasObjectBase):
 
     def get_llur(self):
         xd, yd = self.crdmap.to_data((self.x, self.y))
-        points = np.asarray(self.get_points(), dtype=np.float)
+        points = np.asarray(self.get_points(), dtype=float)
 
         mpts = trcalc.rotate_coord(points, [self.rot_deg], [xd, yd])
         t_ = mpts.T
@@ -1048,8 +1048,8 @@ class TriangleP(OnePointTwoRadiusMixin, CanvasObjectBase):
 
     def contains_pts(self, pts):
         x_arr, y_arr = np.asarray(pts).T
-        x_arr, y_arr = (x_arr.astype(np.float, copy=False),
-                        y_arr.astype(np.float, copy=False))
+        x_arr, y_arr = (x_arr.astype(float, copy=False),
+                        y_arr.astype(float, copy=False))
         # is this the same as self.x, self.y ?
         xd, yd = self.get_center_pt()
         # rotate point back to cartesian alignment for test
@@ -1158,7 +1158,7 @@ class CircleP(OnePointOneRadiusMixin, CanvasObjectBase):
                  linewidth=1, linestyle='solid', showcap=False,
                  fill=False, fillcolor=None, alpha=1.0, fillalpha=1.0,
                  **kwdargs):
-        points = np.asarray([pt], dtype=np.float)
+        points = np.asarray([pt], dtype=float)
         CanvasObjectBase.__init__(self, points=points, color=color,
                                   linewidth=linewidth, showcap=showcap,
                                   linestyle=linestyle,
@@ -1170,8 +1170,8 @@ class CircleP(OnePointOneRadiusMixin, CanvasObjectBase):
 
     def contains_pts(self, pts):
         x_arr, y_arr = np.asarray(pts).T
-        x_arr, y_arr = (x_arr.astype(np.float, copy=False),
-                        y_arr.astype(np.float, copy=False))
+        x_arr, y_arr = (x_arr.astype(float, copy=False),
+                        y_arr.astype(float, copy=False))
 
         xd, yd = self.crdmap.to_data((self.x, self.y))
 
@@ -1297,7 +1297,7 @@ class PointP(OnePointOneRadiusMixin, CanvasObjectBase):
                  linewidth=1, linestyle='solid', alpha=1.0, showcap=False,
                  **kwdargs):
         self.kind = 'point'
-        points = np.asarray([pt], dtype=np.float)
+        points = np.asarray([pt], dtype=float)
         CanvasObjectBase.__init__(self, points=points, color=color,
                                   linewidth=linewidth, alpha=alpha,
                                   linestyle=linestyle, radius=radius,
@@ -1455,7 +1455,7 @@ class RectangleP(TwoPointMixin, CanvasObjectBase):
                  drawdims=False, font='Sans Serif', fillalpha=1.0,
                  **kwdargs):
         self.kind = 'rectangle'
-        points = np.asarray([pt1, pt2], dtype=np.float)
+        points = np.asarray([pt1, pt2], dtype=float)
 
         CanvasObjectBase.__init__(self, points=points, color=color,
                                   linewidth=linewidth, showcap=showcap,
@@ -1593,7 +1593,7 @@ class LineP(TwoPointMixin, CanvasObjectBase):
                  linewidth=1, linestyle='solid', alpha=1.0,
                  arrow=None, showcap=False, **kwdargs):
         self.kind = 'line'
-        points = np.asarray([pt1, pt2], dtype=np.float)
+        points = np.asarray([pt1, pt2], dtype=float)
         CanvasObjectBase.__init__(self, points=points, color=color, alpha=alpha,
                                   linewidth=linewidth, showcap=showcap,
                                   linestyle=linestyle, arrow=arrow,
@@ -1715,7 +1715,7 @@ class RightTriangleP(TwoPointMixin, CanvasObjectBase):
                  fill=False, fillcolor=None, alpha=1.0, fillalpha=1.0,
                  **kwdargs):
         self.kind = 'righttriangle'
-        points = np.asarray([pt1, pt2], dtype=np.float)
+        points = np.asarray([pt1, pt2], dtype=float)
         CanvasObjectBase.__init__(self, points=points, color=color, alpha=alpha,
                                   linewidth=linewidth, showcap=showcap,
                                   linestyle=linestyle,
@@ -1732,8 +1732,8 @@ class RightTriangleP(TwoPointMixin, CanvasObjectBase):
 
     def contains_pts(self, pts):
         x_arr, y_arr = np.asarray(pts).T
-        x_arr, y_arr = (x_arr.astype(np.float, copy=False),
-                        y_arr.astype(np.float, copy=False))
+        x_arr, y_arr = (x_arr.astype(float, copy=False),
+                        y_arr.astype(float, copy=False))
         points = self.get_points()
         x1, y1 = points[0]
         x2, y2 = points[1]

--- a/ginga/canvas/types/image.py
+++ b/ginga/canvas/types/image.py
@@ -71,7 +71,7 @@ class ImageP(OnePointMixin, CanvasObjectBase):
                  showcap=False, flipy=False, optimize=True,
                  **kwdargs):
         self.kind = 'image'
-        points = np.asarray([pt], dtype=np.float)
+        points = np.asarray([pt], dtype=float)
         CanvasObjectBase.__init__(self, points=points, image=image, alpha=alpha,
                                   scale_x=scale_x, scale_y=scale_y,
                                   interpolation=interpolation,

--- a/ginga/canvas/types/mixins.py
+++ b/ginga/canvas/types/mixins.py
@@ -315,8 +315,8 @@ class PolygonMixin(object):
         # NOTE: we use a version of the ray casting algorithm
         # See: http://alienryderflex.com/polygon/
         x_arr, y_arr = np.asarray(pts).T
-        x_arr, y_arr = (x_arr.astype(np.float, copy=False),
-                        y_arr.astype(np.float, copy=False))
+        x_arr, y_arr = (x_arr.astype(float, copy=False),
+                        y_arr.astype(float, copy=False))
         xa, ya = x_arr, y_arr
 
         result = np.empty(y_arr.shape, dtype=np.bool)
@@ -339,7 +339,7 @@ class PolygonMixin(object):
             # NOTE postscript: warnings context manager causes this computation
             # to fail silently sometimes where it previously worked with a
             # warning--commenting out the warning manager for now
-            cross = ((xi + (ya - yi).astype(np.float, copy=False) /
+            cross = ((xi + (ya - yi).astype(float, copy=False) /
                       (yj - yi) * (xj - xi)) < xa)
 
             idx = np.nonzero(tf)

--- a/ginga/cmap.py
+++ b/ginga/cmap.py
@@ -13281,7 +13281,7 @@ def matplotlib_to_ginga_cmap(cm, name=None):
     """Convert matplotlib colormap to Ginga's."""
     if name is None:
         name = cm.name
-    arr = cm(np.arange(0, min_cmap_len) / np.float(min_cmap_len - 1))
+    arr = cm(np.arange(0, min_cmap_len) / float(min_cmap_len - 1))
     clst = arr[:, 0:3]
     return ColorMap(name, clst)
 

--- a/ginga/rv/plugins/RC.py
+++ b/ginga/rv/plugins/RC.py
@@ -381,7 +381,7 @@ class GingaWrapper(object):
 
             # dtype string works for most instances
             if dtype == '':
-                dtype = np.float
+                dtype = float
 
             byteswap = metadata.get('byteswap', False)
 

--- a/ginga/rv/plugins/RC.py
+++ b/ginga/rv/plugins/RC.py
@@ -186,8 +186,6 @@ import sys
 import bz2
 from io import BytesIO
 
-import numpy as np
-
 from ginga import GingaPlugin
 from ginga import AstroImage
 from ginga.gw import Widgets

--- a/ginga/tests/test_colordist.py
+++ b/ginga/tests/test_colordist.py
@@ -18,7 +18,7 @@ class TestColorDist(object):
         self.nonlinearity = 3.0
 
         # Input data
-        self.data = np.arange(self.hashsize, dtype=np.int)
+        self.data = np.arange(self.hashsize, dtype=int)
 
     def scale_and_rescale(self, disttype, data):
         """This is to generate expected scaled output."""
@@ -28,7 +28,7 @@ class TestColorDist(object):
                 idx.ravel(), self.hashsize, density=False)
             cdf = hist.cumsum()
             ohash = ((cdf - cdf.min()) * (self.colorlen - 1) /
-                     (cdf.max() - cdf.min())).astype(np.int)
+                     (cdf.max() - cdf.min())).astype(int)
             idx = idx.astype(np.uint)
             result = ohash[idx]
         else:
@@ -49,7 +49,7 @@ class TestColorDist(object):
             elif disttype == 'sinh':
                 out = np.sinh(self.nonlinearity * x) / self.factor
 
-            result = (out.clip(0.0, 1.0) * (self.colorlen - 1)).astype(np.int)
+            result = (out.clip(0.0, 1.0) * (self.colorlen - 1)).astype(int)
 
         return result
 

--- a/ginga/tests/test_trcalc.py
+++ b/ginga/tests/test_trcalc.py
@@ -7,14 +7,14 @@ from ginga import trcalc
 class TestTrcalc:
 
     def _2ddata(self):
-        data = np.zeros((10, 10), dtype=np.int)
+        data = np.zeros((10, 10), dtype=int)
         for i in range(10):
             for j in range(10):
                 data[i, j] = min(i, j)
         return data
 
     def _3ddata(self):
-        data = np.zeros((10, 10, 10), dtype=np.int)
+        data = np.zeros((10, 10, 10), dtype=int)
         for i in range(10):
             for j in range(10):
                 for k in range(10):

--- a/ginga/trcalc.py
+++ b/ginga/trcalc.py
@@ -232,14 +232,14 @@ def rotate_clip(data_np, theta_deg, rotctr_x=None, rotctr_y=None,
             ap = (xi * cos_t) - (yi * sin_t) + rotctr_x
             bp = (xi * sin_t) + (yi * cos_t) + rotctr_y
 
-        #ap = np.rint(ap).clip(0, wd-1).astype(np.int)
-        #bp = np.rint(bp).clip(0, ht-1).astype(np.int)
+        #ap = np.rint(ap).clip(0, wd-1).astype(int)
+        #bp = np.rint(bp).clip(0, ht-1).astype(int)
         # Optomizations to reuse existing intermediate arrays
         np.rint(ap, out=ap)
-        ap = ap.astype(np.int, copy=False)
+        ap = ap.astype(int, copy=False)
         ap.clip(0, wd - 1, out=ap)
         np.rint(bp, out=bp)
-        bp = bp.astype(np.int, copy=False)
+        bp = bp.astype(int, copy=False)
         bp.clip(0, ht - 1, out=bp)
 
         if out is not None:
@@ -323,9 +323,9 @@ def get_scaled_cutout_wdht_view(shp, x1, y1, x2, y2, new_wd, new_ht):
     # Make indexes and scale them
     # Is there a more efficient way to do this?
     xi = np.clip(x1 + np.arange(0, new_wd) * iscale_x,
-                 0, max_x).astype(np.int, copy=False)
+                 0, max_x).astype(int, copy=False)
     yi = np.clip(y1 + np.arange(0, new_ht) * iscale_y,
-                 0, max_y).astype(np.int, copy=False)
+                 0, max_y).astype(int, copy=False)
     wd, ht = xi.size, yi.size
 
     # bounds check against shape (to protect future data access)
@@ -384,11 +384,11 @@ def get_scaled_cutout_wdhtdp_view(shp, p1, p2, new_dims):
         iscale_z = float(old_dp) / float(new_dp)
 
     xi = np.clip(x1 + np.arange(0, new_wd) * iscale_x,
-                 0, max_x).astype(np.int, copy=False)
+                 0, max_x).astype(int, copy=False)
     yi = np.clip(y1 + np.arange(0, new_ht) * iscale_y,
-                 0, max_y).astype(np.int, copy=False)
+                 0, max_y).astype(int, copy=False)
     zi = np.clip(z1 + np.arange(0, new_dp) * iscale_z,
-                 0, max_z).astype(np.int, copy=False)
+                 0, max_z).astype(int, copy=False)
     wd, ht, dp = xi.size, yi.size, zi.size
 
     # bounds check against shape (to protect future data access)

--- a/ginga/util/iqcalc.py
+++ b/ginga/util/iqcalc.py
@@ -907,7 +907,7 @@ class IQCalc(object):
             y2 = image.height
 
         x1, y1, x2, y2 = int(x1), int(y1), int(x2), int(y2)
-        data = image.cutout_data(x1, y1, x2, y2, astype=np.float)
+        data = image.cutout_data(x1, y1, x2, y2, astype=float)
 
         qs = self.pick_field(data, peak_radius=radius,
                              bright_radius=bright_radius,

--- a/ginga/util/vip.py
+++ b/ginga/util/vip.py
@@ -182,7 +182,7 @@ class ViewerImageProxy:
     # ----- for compatibility with BaseImage objects -----
 
     def cutout_data(self, x1, y1, x2, y2, xstep=1, ystep=1, z=0,
-                    astype=np.float, fill_value=np.NaN):
+                    astype=float, fill_value=np.NaN):
         """Cut out data area based on rectangular coordinates.
 
         Parameters
@@ -220,7 +220,7 @@ class ViewerImageProxy:
         t1 = time.time()
 
         if astype is None:
-            astype = np.float
+            astype = float
         if fill_value is None:
             fill_value = np.NaN
 

--- a/ginga/util/zscale.py
+++ b/ginga/util/zscale.py
@@ -118,7 +118,7 @@ def zsc_fit_line(samples, npix, krej, ngrow, maxiter):
     last_ngoodpix = npix + 1
 
     # This is the mask used in k-sigma clipping.  0 is good, 1 is bad
-    badpix = np.zeros(npix, dtype=np.int)
+    badpix = np.zeros(npix, dtype=int)
 
     #
     #  Iterate
@@ -160,7 +160,7 @@ def zsc_fit_line(samples, npix, krej, ngrow, maxiter):
         badpix[above] = BAD_PIXEL
 
         # Convolve with a kernel of length ngrow
-        kernel = np.ones(ngrow, dtype=np.int)
+        kernel = np.ones(ngrow, dtype=int)
         badpix = np.convolve(badpix, kernel, mode='same')
 
         ngoodpix = len(np.where(badpix == GOOD_PIXEL)[0])

--- a/ginga/util/zscale.py
+++ b/ginga/util/zscale.py
@@ -73,7 +73,7 @@ def zsc_sample(image, maxpix, bpmask=None, zmask=None):
 
 
 def zscale_samples(samples, contrast=0.25):
-    samples = np.asarray(samples, dtype=np.float)
+    samples = np.asarray(samples, dtype=float)
     npix = len(samples)
     samples.sort()
     zmin = samples[0]


### PR DESCRIPTION
Numpy 1.20 is released and is causing warnings like this in Ginga:

```
E   DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`.
To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe.
If you specifically wanted the numpy scalar type, use `np.float64` here.
E   Deprecated in NumPy 1.20; for more details and guidance:
https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```

```
E DeprecationWarning: `np.int` is a deprecated alias for the builtin `int`.
To silence this warning, use `int` by itself. Doing this will not modify any behavior and is safe.
When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision.
If you wish to review your current use, check the release note link for additional information.
E Deprecated in NumPy 1.20; for more details and guidance:
https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```