### PR TITLE
Add orientation setting to all plugins that are orientable

### DIFF
--- a/doc/WhatsNew.rst
+++ b/doc/WhatsNew.rst
@@ -32,6 +32,7 @@ Ver 3.2.0 (unreleased)
 - Fixed Pick plugin to autozoom the pick and contour images
 - Fixed an issue where Thumbs plugin might not show initial thumb(s)
   when main window is enlarged to certain sizes
+- Added "orientation" setting to orientable plugins
 
 Ver 3.1.0 (2020-07-20)
 ======================

--- a/ginga/gw/Widgets.py
+++ b/ginga/gw/Widgets.py
@@ -32,8 +32,9 @@ def get_orientation(container, aspect=1.0):
 
 
 def get_oriented_box(container, scrolled=True, fill=False,
-                     aspect=2.0):
-    orientation = get_orientation(container, aspect=aspect)
+                     aspect=2.0, orientation=None):
+    if orientation is None:
+        orientation = get_orientation(container, aspect=aspect)
 
     if orientation == 'vertical':
         box1 = VBox()  # noqa

--- a/ginga/rv/plugins/Blink.py
+++ b/ginga/rv/plugins/Blink.py
@@ -65,7 +65,8 @@ class Blink(GingaPlugin.LocalPlugin):
         top = Widgets.VBox()
         top.set_border_width(4)
 
-        vbox, sw, orientation = Widgets.get_oriented_box(container)
+        vbox, sw, orientation = Widgets.get_oriented_box(container,
+                                                         orientation=self.settings.get('orientation', None))
         vbox.set_border_width(4)
         vbox.set_spacing(2)
 

--- a/ginga/rv/plugins/ChangeHistory.py
+++ b/ginga/rv/plugins/ChangeHistory.py
@@ -81,7 +81,8 @@ class ChangeHistory(GingaPlugin.GlobalPlugin):
         and closed.
 
         """
-        vbox, sw, self.orientation = Widgets.get_oriented_box(container)
+        vbox, sw, self.orientation = Widgets.get_oriented_box(container,
+                                                              orientation=self.settings.get('orientation', None))
         vbox.set_border_width(4)
         vbox.set_spacing(2)
 

--- a/ginga/rv/plugins/Collage.py
+++ b/ginga/rv/plugins/Collage.py
@@ -113,7 +113,8 @@ class Collage(GingaPlugin.LocalPlugin):
         top = Widgets.VBox()
         top.set_border_width(4)
 
-        vbox, sw, orientation = Widgets.get_oriented_box(container)
+        vbox, sw, orientation = Widgets.get_oriented_box(container,
+                                                         orientation=self.settings.get('orientation', None))
         vbox.set_border_width(4)
         vbox.set_spacing(2)
 

--- a/ginga/rv/plugins/Crosshair.py
+++ b/ginga/rv/plugins/Crosshair.py
@@ -60,7 +60,8 @@ class Crosshair(GingaPlugin.LocalPlugin):
         top = Widgets.VBox()
         top.set_border_width(4)
 
-        vbox, sw, orientation = Widgets.get_oriented_box(container)
+        vbox, sw, orientation = Widgets.get_oriented_box(container,
+                                                         orientation=self.settings.get('orientation', None))
         vbox.set_border_width(4)
         vbox.set_spacing(2)
 

--- a/ginga/rv/plugins/Drawing.py
+++ b/ginga/rv/plugins/Drawing.py
@@ -85,7 +85,8 @@ class Drawing(GingaPlugin.LocalPlugin):
         top = Widgets.VBox()
         top.set_border_width(4)
 
-        vbox, sw, orientation = Widgets.get_oriented_box(container)
+        vbox, sw, orientation = Widgets.get_oriented_box(container,
+                                                         orientation=self.settings.get('orientation', None))
         self.orientation = orientation
         vbox.set_border_width(4)
         vbox.set_spacing(2)

--- a/ginga/rv/plugins/Histogram.py
+++ b/ginga/rv/plugins/Histogram.py
@@ -128,7 +128,8 @@ class Histogram(GingaPlugin.LocalPlugin):
         top.set_border_width(4)
 
         # Make the cuts plot
-        box, sw, orientation = Widgets.get_oriented_box(container)
+        box, sw, orientation = Widgets.get_oriented_box(container,
+                                                        orientation=self.settings.get('orientation', None))
         box.set_border_width(4)
         box.set_spacing(2)
 

--- a/ginga/rv/plugins/LineProfile.py
+++ b/ginga/rv/plugins/LineProfile.py
@@ -105,7 +105,8 @@ class LineProfile(GingaPlugin.LocalPlugin):
         top = Widgets.VBox()
         top.set_border_width(4)
 
-        box, sw, orientation = Widgets.get_oriented_box(container)
+        box, sw, orientation = Widgets.get_oriented_box(container,
+                                                        orientation=self.settings.get('orientation', None))
         box.set_border_width(4)
         box.set_spacing(2)
 

--- a/ginga/rv/plugins/Mosaic.py
+++ b/ginga/rv/plugins/Mosaic.py
@@ -112,7 +112,8 @@ class Mosaic(GingaPlugin.LocalPlugin):
         top = Widgets.VBox()
         top.set_border_width(4)
 
-        vbox, sw, orientation = Widgets.get_oriented_box(container)
+        vbox, sw, orientation = Widgets.get_oriented_box(container,
+                                                         orientation=self.settings.get('orientation', None))
         vbox.set_border_width(4)
         vbox.set_spacing(2)
 

--- a/ginga/rv/plugins/MultiDim.py
+++ b/ginga/rv/plugins/MultiDim.py
@@ -103,7 +103,8 @@ class MultiDim(GingaPlugin.LocalPlugin):
 
         vbox, sw, orientation = Widgets.get_oriented_box(container,
                                                          scrolled=True,
-                                                         aspect=3.0)
+                                                         aspect=3.0,
+                                                         orientation=self.settings.get('orientation', None))
         self.orientation = orientation
         vbox.set_border_width(4)
         vbox.set_spacing(2)

--- a/ginga/rv/plugins/Overlays.py
+++ b/ginga/rv/plugins/Overlays.py
@@ -65,7 +65,8 @@ class Overlays(GingaPlugin.LocalPlugin):
         top = Widgets.VBox()
         top.set_border_width(4)
 
-        vbox, sw, orientation = Widgets.get_oriented_box(container)
+        vbox, sw, orientation = Widgets.get_oriented_box(container,
+                                                         orientation=self.settings.get('orientation', None))
         vbox.set_border_width(4)
         vbox.set_spacing(2)
 

--- a/ginga/rv/plugins/Pick.py
+++ b/ginga/rv/plugins/Pick.py
@@ -476,7 +476,8 @@ class Pick(GingaPlugin.LocalPlugin):
         vtop = Widgets.VBox()
         vtop.set_border_width(4)
 
-        box, sw, orientation = Widgets.get_oriented_box(container)
+        box, sw, orientation = Widgets.get_oriented_box(container,
+                                                        orientation=self.settings.get('orientation', None))
         box.set_border_width(4)
         box.set_spacing(2)
 

--- a/ginga/rv/plugins/PixTable.py
+++ b/ginga/rv/plugins/PixTable.py
@@ -167,7 +167,8 @@ class PixTable(GingaPlugin.LocalPlugin):
         top = Widgets.VBox()
         top.set_border_width(4)
 
-        box, sw, orientation = Widgets.get_oriented_box(container)
+        box, sw, orientation = Widgets.get_oriented_box(container,
+                                                        orientation=self.settings.get('orientation', None))
         box.set_border_width(4)
         box.set_spacing(2)
 

--- a/ginga/rv/plugins/PlotTable.py
+++ b/ginga/rv/plugins/PlotTable.py
@@ -78,7 +78,8 @@ class PlotTable(LocalPlugin):
         top.set_border_width(4)
 
         # Make the plot
-        vbox, sw, orientation = Widgets.get_oriented_box(container)
+        vbox, sw, orientation = Widgets.get_oriented_box(container,
+                                                         orientation=self.settings.get('orientation', None))
         vbox.set_margins(4, 4, 4, 4)
         vbox.set_spacing(2)
 

--- a/ginga/rv/plugins/Preferences.py
+++ b/ginga/rv/plugins/Preferences.py
@@ -406,7 +406,8 @@ class Preferences(GingaPlugin.LocalPlugin):
         top = Widgets.VBox()
         top.set_border_width(4)
 
-        vbox, sw, orientation = Widgets.get_oriented_box(container)
+        vbox, sw, orientation = Widgets.get_oriented_box(container,
+                                                         orientation=self.settings.get('orientation', None))
         self.orientation = orientation
         #vbox.set_border_width(4)
         vbox.set_spacing(2)

--- a/ginga/rv/plugins/Ruler.py
+++ b/ginga/rv/plugins/Ruler.py
@@ -115,7 +115,8 @@ class Ruler(GingaPlugin.LocalPlugin):
         top = Widgets.VBox()
         top.set_border_width(4)
 
-        vbox, sw, orientation = Widgets.get_oriented_box(container)
+        vbox, sw, orientation = Widgets.get_oriented_box(container,
+                                                         orientation=self.settings.get('orientation', None))
         vbox.set_border_width(4)
         vbox.set_spacing(2)
 

--- a/ginga/rv/plugins/SaveImage.py
+++ b/ginga/rv/plugins/SaveImage.py
@@ -95,7 +95,8 @@ class SaveImage(GlobalPlugin):
     def build_gui(self, container):
         """Build GUI such that image list area is maximized."""
 
-        vbox, sw, orientation = Widgets.get_oriented_box(container)
+        vbox, sw, orientation = Widgets.get_oriented_box(container,
+                                                         orientation=self.settings.get('orientation', None))
 
         captions = (('Channel:', 'label', 'Channel Name', 'combobox',
                      'Modified only', 'checkbutton'), )

--- a/ginga/rv/plugins/TVMark.py
+++ b/ginga/rv/plugins/TVMark.py
@@ -167,7 +167,8 @@ class TVMark(LocalPlugin):
         return [c for c in colors.get_colors() if not re.search(r'\d', c)]
 
     def build_gui(self, container):
-        vbox, sw, self.orientation = Widgets.get_oriented_box(container)
+        vbox, sw, self.orientation = Widgets.get_oriented_box(container,
+                                                              orientation=self.settings.get('orientation', None))
 
         captions = (('Mark:', 'label', 'mark type', 'combobox'),
                     ('Color:', 'label', 'mark color', 'combobox'),

--- a/ginga/rv/plugins/TVMask.py
+++ b/ginga/rv/plugins/TVMask.py
@@ -134,7 +134,8 @@ class TVMask(LocalPlugin):
         return [c for c in colors.get_colors() if not re.search(r'\d', c)]
 
     def build_gui(self, container):
-        vbox, sw, self.orientation = Widgets.get_oriented_box(container)
+        vbox, sw, self.orientation = Widgets.get_oriented_box(container,
+                                                              orientation=self.settings.get('orientation', None))
 
         captions = (('Color:', 'label', 'mask color', 'combobox'),
                     ('Alpha:', 'label', 'mask alpha', 'entry'))

--- a/ginga/rv/plugins/Toolbar.py
+++ b/ginga/rv/plugins/Toolbar.py
@@ -51,7 +51,8 @@ class Toolbar(GingaPlugin.GlobalPlugin):
         top = Widgets.VBox()
         top.set_border_width(0)
 
-        vbox, sw, orientation = Widgets.get_oriented_box(container)
+        vbox, sw, orientation = Widgets.get_oriented_box(container,
+                                                         orientation=self.settings.get('orientation', None))
         self.orientation = orientation
         vbox.set_spacing(0)
         vbox.set_border_width(0)

--- a/ginga/rv/plugins/WCSAxes.py
+++ b/ginga/rv/plugins/WCSAxes.py
@@ -74,7 +74,8 @@ class WCSAxes(LocalPlugin):
         top = Widgets.VBox()
         top.set_border_width(4)
 
-        vbox, sw, orientation = Widgets.get_oriented_box(container)
+        vbox, sw, orientation = Widgets.get_oriented_box(container,
+                                                         orientation=self.settings.get('orientation', None))
         vbox.set_border_width(4)
         vbox.set_spacing(2)
 

--- a/ginga/rv/plugins/WCSMatch.py
+++ b/ginga/rv/plugins/WCSMatch.py
@@ -60,7 +60,8 @@ class WCSMatch(GingaPlugin.GlobalPlugin):
         top = Widgets.VBox()
         top.set_border_width(4)
 
-        vbox, sw, orientation = Widgets.get_oriented_box(container)
+        vbox, sw, orientation = Widgets.get_oriented_box(container,
+                                                         orientation=self.settings.get('orientation', None))
         vbox.set_border_width(4)
         vbox.set_spacing(2)
 

--- a/ginga/rv/plugins/Zoom.py
+++ b/ginga/rv/plugins/Zoom.py
@@ -100,7 +100,8 @@ class Zoom(GingaPlugin.GlobalPlugin):
         vtop = Widgets.VBox()
         vtop.set_border_width(4)
 
-        box, sw, orientation = Widgets.get_oriented_box(container)
+        box, sw, orientation = Widgets.get_oriented_box(container,
+                                                        orientation=self.settings.get('orientation', None))
         # Uncomment to debug; passing parent logger generates too
         # much noise in the main logger
         #zi = Viewers.CanvasView(logger=self.logger)


### PR DESCRIPTION
Adds an "orientation" setting to all plugins that use the "get_oriented_box" function.  It allows the user to fix (override) the auto-orientation.
