### PR TITLE
MNT: Replace fromstring with frombuffer, bump numpy minversion

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -21,7 +21,7 @@ REQUIRED
 
 * python (v. 3.7 or higher)
 * setuptools-scm
-* numpy  (v. 1.13 or higher)
+* numpy  (v. 1.14 or higher)
 * astropy
 
 Highly recommended, because some features will not be available without it:

--- a/ginga/AstroImage.py
+++ b/ginga/AstroImage.py
@@ -182,7 +182,7 @@ class AstroImage(BaseImage):
 
     def load_buffer(self, buf, dims, dtype, byteswap=False,
                     naxispath=None, metadata=None):
-        data = np.fromstring(buf, dtype=dtype)
+        data = np.frombuffer(buf, dtype=dtype)
         if byteswap:
             data.byteswap(True)
         data = data.reshape(dims)

--- a/ginga/aggw/CanvasRenderAgg.py
+++ b/ginga/aggw/CanvasRenderAgg.py
@@ -212,7 +212,7 @@ class CanvasRenderer(render.StandardPixelRenderer):
         wd, ht = self.dims
 
         # Get agg surface as a numpy array
-        arr8 = np.fromstring(self.surface.tobytes(), dtype=np.uint8)
+        arr8 = np.frombuffer(self.surface.tobytes(), dtype=np.uint8)
         arr8 = arr8.reshape((ht, wd, len(self.rgb_order)))
 
         # adjust according to viewer's needed order

--- a/ginga/pilw/CanvasRenderPil.py
+++ b/ginga/pilw/CanvasRenderPil.py
@@ -197,7 +197,7 @@ class CanvasRenderer(render.StandardPixelRenderer):
         wd, ht = self.dims[:2]
 
         # Get PIL surface as a numpy array
-        arr8 = np.fromstring(self.surface.tobytes(), dtype=np.uint8)
+        arr8 = np.frombuffer(self.surface.tobytes(), dtype=np.uint8)
         arr8 = arr8.reshape((ht, wd, 3))
 
         # adjust according to viewer's needed order

--- a/ginga/pilw/PilHelp.py
+++ b/ginga/pilw/PilHelp.py
@@ -47,7 +47,7 @@ def text_to_array(text, font, rot_deg=0.0):
     d = ImageDraw.Draw(i, 'RGBA')
     d.text((0, 0), text, font=f, fill=color)
     i.rotate(rot_deg, expand=1)
-    arr8 = np.fromstring(i.tobytes(), dtype=np.uint8)
+    arr8 = np.frombuffer(i.tobytes(), dtype=np.uint8)
     arr8 = arr8.reshape((ht, wd, 4))
     return arr8
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ classifiers =
 zip_safe = False
 packages = find:
 python_requires = >=3.7
-install_requires = numpy>=1.13; qtpy>=1.1; astropy>=3.2
+install_requires = numpy>=1.14; qtpy>=1.1; astropy>=3.2
 setup_requires = setuptools_scm
 
 [options.extras_require]


### PR DESCRIPTION
I see this warning while working on astropy/astrowidgets#125

```
.../ginga/aggw/CanvasRenderAgg.py:215: DeprecationWarning: The binary mode of fromstring is deprecated,
as it behaves surprisingly on unicode inputs. Use frombuffer instead
    arr8 = np.fromstring(self.surface.tobytes(), dtype=np.uint8)
```