### PR TITLE
TST: Use latest Python for dev tests

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -80,7 +80,6 @@ jobs:
     - name: Run tests
       run: pytest --pyargs ginga doc -sv
 
-  # TODO: Lift Python 3.8 pin when numpy and scipy have wheels for Python 3.9
   dev_deps_tests:
     runs-on: ubuntu-latest
     steps:
@@ -91,7 +90,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.8'
+        python-version: '3.x'
     - name: Install and build
       run: |
         python -m pip install --upgrade pip setuptools


### PR DESCRIPTION
Numpy and Scipy have builds in Python 3.9 now.