### PR TITLE
TST: Stop ignoring warnings

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,9 @@
 [tool:pytest]
-minversion = 3
+minversion = 5
 testpaths = "ginga" "doc"
 norecursedirs = build doc/_build
 astropy_header = true
-addopts = -p no:warnings --doctest-ignore-import-errors
+addopts = --doctest-ignore-import-errors
 
 [bdist_wheel]
 universal = 1

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,7 @@ addopts = --doctest-ignore-import-errors
 filterwarnings =
     error
     ignore:numpy.ndarray size changed:RuntimeWarning
+    ignore:numpy.ufunc size changed:RuntimeWarning
 
 [bdist_wheel]
 universal = 1

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,9 @@ testpaths = "ginga" "doc"
 norecursedirs = build doc/_build
 astropy_header = true
 addopts = --doctest-ignore-import-errors
+filterwarnings =
+    error
+    ignore:numpy.ndarray size changed:RuntimeWarning
 
 [bdist_wheel]
 universal = 1


### PR DESCRIPTION
I was wondering how #930 fell through the cracks and then I noticed that we have been ignoring warnings in `pytest`.

~I suspect this will smoke out a lot of warnings, so I still put this on draft status for now until we can figure out how to handle them.~

Well, that was easier than expected. This is ready for review now.