### PR TITLE
TST: Ignore WCS warning from astropy 4.3.dev

### DIFF
--- a/ginga/tests/test_aimg.py
+++ b/ginga/tests/test_aimg.py
@@ -1,5 +1,5 @@
-
 import numpy as np
+import pytest
 
 from astropy import nddata
 from astropy.io import fits
@@ -11,6 +11,7 @@ from ginga.util import wcs, wcsmod
 wcsmod.use('astropy')
 
 
+@pytest.mark.filterwarnings("ignore:'datfix' made the change")
 class TestAstroImage(object):
     def setup_class(self):
         self.logger = log.get_logger("TestAstroImage", null=True)


### PR DESCRIPTION
Ignore WCS warning from astropy 4.3.dev, possibly caused by WCSLIB 7.4 upgrade (astropy/astropy#11260).

This fixes the dev job failure in CI.