### PR TITLE
Pick plugin: account for coadds and multiple readouts in calculations

### DIFF
--- a/ginga/examples/configs/plugin_Pick.cfg
+++ b/ginga/examples/configs/plugin_Pick.cfg
@@ -66,6 +66,12 @@ ee_total_radius = 10.0
 # b. Radius (pixel) to sample EE for reporting.
 ee_sampling_radius = 2.5
 
+# used to scale background, skylevel and brightness calculations
+# FITS metadata keyword indicating number of coadds in image
+coadds_keyword = 'COADDS'
+# FITS metadata keyword indicating number of detector readouts per coadd
+ndr_keyword = 'NDR'
+
 # use a different color/intensity map than channel image?
 pick_cmap_name = None
 pick_imap_name = None


### PR DESCRIPTION
This PR adds the ability to account for image coadds and number of detector readouts per coadd in `Pick`'s calculations of background, sky level and brightness.  The values for coadds and readouts are read from the FITS header, if available.  The keywords associated with these values can be set in the plugin settings.

This PR also moves the calculation of the star size into `iqcalc`, so that the star size (size adjusting for pixel pitch of the detector) is calculated for every pick candidate and not just the final one.