### PR TITLE
MNT: Update astropy default branch

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -95,7 +95,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools
         python -m pip install PyQt5 matplotlib
-        python -m pip install git+https://github.com/astropy/astropy.git@master#egg=astropy
+        python -m pip install git+https://github.com/astropy/astropy.git@main#egg=astropy
         python -m pip install -e .[test]
     - name: Install Qt
       uses: jurplel/install-qt-action@88f3374475d094ce56ca6a7cc41cfda5a6ec093c  # v2.13.0


### PR DESCRIPTION
This is an automated update made by the `batchpr` tool :robot: to because `astropy` has changed its default branch! You can report issues to @pllim.