### PR TITLE
Add interactive setting of cut levels within Histogram plugin

### DIFF
--- a/doc/WhatsNew.rst
+++ b/doc/WhatsNew.rst
@@ -33,6 +33,8 @@ Ver 3.2.0 (unreleased)
 - Fixed an issue where Thumbs plugin might not show initial thumb(s)
   when main window is enlarged to certain sizes
 - Added "orientation" setting to orientable plugins
+- Enhancements to Histogram plugin: ability to click in plot to set low
+  and high cuts levels, scroll plot to expand or contract cuts width
 
 Ver 3.1.0 (2020-07-20)
 ======================

--- a/ginga/Bindings.py
+++ b/ginga/Bindings.py
@@ -829,7 +829,7 @@ class ImageViewBindings(object):
                 loval, hival))
         viewer.cut_levels(loval, hival)
 
-    def _cut_pct(self, viewer, pct, msg=True):
+    def cut_pct(self, viewer, pct, msg=True):
         msg = self.settings.get('msg_cuts', msg)
         loval, hival = viewer.get_cut_levels()
         spread = hival - loval
@@ -843,9 +843,9 @@ class ImageViewBindings(object):
     def _adjust_cuts(self, viewer, direction, pct, msg=True):
         direction = self.get_direction(direction)
         if direction == 'up':
-            self._cut_pct(viewer, pct, msg=msg)
+            self.cut_pct(viewer, pct, msg=msg)
         elif direction == 'down':
-            self._cut_pct(viewer, -pct, msg=msg)
+            self.cut_pct(viewer, -pct, msg=msg)
 
     def _scale_image(self, viewer, direction, factor, msg=True):
         msg = self.settings.get('msg_zoom', msg)

--- a/ginga/examples/configs/plugin_Histogram.cfg
+++ b/ginga/examples/configs/plugin_Histogram.cfg
@@ -17,3 +17,6 @@ show_stats = True
 
 # Controls formatting (width) of statistics numbers
 maxdigits = 7
+
+# percentage to adjust cuts gap when scrolling in histogram
+scroll_pct = 0.10

--- a/ginga/rv/plugins/Histogram.py
+++ b/ginga/rv/plugins/Histogram.py
@@ -90,6 +90,8 @@ class Histogram(GingaPlugin.LocalPlugin):
         self.histtag = None
         # If True, limits X axis to lo/hi cut levels
         self.xlimbycuts = True
+        # percentage to adjust plotting X limits when xlimbycuts is True
+        self.lim_adj_pct = 0.03
         self._split_sizes = [400, 500]
 
         # get Histogram preferences
@@ -390,11 +392,15 @@ class Histogram(GingaPlugin.LocalPlugin):
         # show cut levels
         loval, hival = self.fitsimage.get_cut_levels()
         self.loline = self.plot.ax.axvline(loval, 0.0, 0.99,
-                                           linestyle='-', color='red')
+                                           linestyle='-', color='brown')
         self.hiline = self.plot.ax.axvline(hival, 0.0, 0.99,
                                            linestyle='-', color='green')
         if self.xlimbycuts:
-            self.plot.ax.set_xlim(loval, hival)
+            # user wants "plot by cuts"--adjust plot limits to show only area
+            # between locut and high cut "plus a little" so that lo and hi cut
+            # markers are shown
+            incr = np.log10(np.fabs(self.lim_adj_pct * (hival - loval))) * 10.0
+            self.plot.ax.set_xlim(loval - incr, hival + incr)
 
         # Make x axis labels a little more readable
         ## lbls = self.plot.ax.xaxis.get_ticklabels()

--- a/ginga/rv/plugins/Histogram.py
+++ b/ginga/rv/plugins/Histogram.py
@@ -399,7 +399,7 @@ class Histogram(GingaPlugin.LocalPlugin):
             # user wants "plot by cuts"--adjust plot limits to show only area
             # between locut and high cut "plus a little" so that lo and hi cut
             # markers are shown
-            incr = np.log10(np.fabs(self.lim_adj_pct * (hival - loval))) * 10.0
+            incr = np.fabs(self.lim_adj_pct * (hival - loval))
             self.plot.ax.set_xlim(loval - incr, hival + incr)
 
         # Make x axis labels a little more readable


### PR DESCRIPTION
Fix #942

You can set cut levels by clicking in the histogram plot:

* left click: set low cut
* middle click: reset (auto cut levels)
* right click: set high cut

In addition, you can dynamically adjust the gap between low and high cuts by scrolling the wheel in the plot (i.e. the "width" of the histogram plot curve).  This has the effect of increasing or decreasing the contrast within the image.  The amount that is changed for each wheel click is set by the plugin configuration file setting ``scroll_pct``.  The default is 10%.