### PR TITLE
MNT: Un-ignore datfix warning from astropy 4.3.dev

### DIFF
--- a/ginga/tests/test_aimg.py
+++ b/ginga/tests/test_aimg.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 
 from astropy import nddata
 from astropy.io import fits
@@ -11,7 +10,6 @@ from ginga.util import wcs, wcsmod
 wcsmod.use('astropy')
 
 
-@pytest.mark.filterwarnings("ignore:'datfix' made the change")
 class TestAstroImage(object):
     def setup_class(self):
         self.logger = log.get_logger("TestAstroImage", null=True)


### PR DESCRIPTION
Revert #938 as the `datfix` warning should no longer be issued because `astropy` updated bundled `wcslib`.

Also see astropy/astropy#11549