### PR TITLE
Modify Pick to use ginga plot for the Cuts plot

### DIFF
--- a/ginga/examples/configs/plugin_Pick.cfg
+++ b/ginga/examples/configs/plugin_Pick.cfg
@@ -26,7 +26,7 @@ quick_mode = False
 quick_from_peak = True
 # for future use
 quick_update_interval = 0.25
-quick_drag_only = True
+quick_drag_only = False
 
 # should the pick shape recenter on the found object center, if any?
 # useful for "tracking" an object that is moving from image to image

--- a/ginga/rv/plugins/Pick.py
+++ b/ginga/rv/plugins/Pick.py
@@ -673,14 +673,12 @@ class Pick(GingaPlugin.LocalPlugin):
 
         # add X and Y data sources. Hereafter, we can just update the data
         # sources and call update_plots() whenever we have new X and Y arms
-        x_acc = np.mean if gplots.have_npi else None
-        y_acc = np.nanmax if x_acc else None
         cname1 = self.settings.get('quick_h_cross_color', '#7570b3')
         self.cuts_xsrc = gplots.XYPlot(name='X', color=cname1, linewidth=2,
-                                       x_acc=x_acc, y_acc=y_acc)
+                                       x_acc=np.mean, y_acc=np.nanmax)
         cname2 = self.settings.get('quick_v_cross_color', '#1b9e77')
         self.cuts_ysrc = gplots.XYPlot(name='Y', color=cname2, linewidth=2,
-                                       x_acc=x_acc, y_acc=y_acc)
+                                       x_acc=np.mean, y_acc=np.nanmax)
         self.cuts_view.add_plot(self.cuts_xsrc)
         self.cuts_view.add_plot(self.cuts_ysrc)
 


### PR DESCRIPTION
This modifies `Pick` to use the new Ginga `XYPlot` for the Cuts plot used in `Pick`.

This plot has better performance for updating rapidly when moved around the image (matplotlib plot could be quite sluggish).
Also, the plugin is modified a bit to better reflect the way that "Quick mode" is supposed to operate. (explanation TBA)

Depends on merge of #941