### PR TITLE
Restore the pipeline renderer as the default renderer

### DIFF
--- a/ginga/aggw/CanvasRenderAgg.py
+++ b/ginga/aggw/CanvasRenderAgg.py
@@ -163,10 +163,10 @@ class RenderContext(render.RenderContextBase):
         self.cr.canvas.path(path, self.pen, self.brush)
 
 
-class CanvasRenderer(render.StandardPixelRenderer):
+class CanvasRenderer(render.StandardPipelineRenderer):
 
     def __init__(self, viewer):
-        render.StandardPixelRenderer.__init__(self, viewer)
+        render.StandardPipelineRenderer.__init__(self, viewer)
 
         self.kind = 'agg'
         self.rgb_order = 'RGBA'

--- a/ginga/cairow/CanvasRenderCairo.py
+++ b/ginga/cairow/CanvasRenderCairo.py
@@ -200,10 +200,10 @@ class RenderContext(render.RenderContextBase):
         self.cr.new_path()
 
 
-class CanvasRenderer(render.StandardPixelRenderer):
+class CanvasRenderer(render.StandardPipelineRenderer):
 
     def __init__(self, viewer):
-        render.StandardPixelRenderer.__init__(self, viewer)
+        render.StandardPipelineRenderer.__init__(self, viewer)
 
         self.kind = 'cairo'
         if sys.byteorder == 'little':

--- a/ginga/cvw/CanvasRenderCv.py
+++ b/ginga/cvw/CanvasRenderCv.py
@@ -119,10 +119,10 @@ class RenderContext(render.RenderContextBase):
         self.cr.path(cpoints, self.pen)
 
 
-class CanvasRenderer(render.StandardPixelRenderer):
+class CanvasRenderer(render.StandardPipelineRenderer):
 
     def __init__(self, viewer):
-        render.StandardPixelRenderer.__init__(self, viewer)
+        render.StandardPipelineRenderer.__init__(self, viewer)
 
         self.kind = 'opencv'
         # According to OpenCV documentation:

--- a/ginga/mockw/CanvasRenderMock.py
+++ b/ginga/mockw/CanvasRenderMock.py
@@ -100,10 +100,10 @@ class RenderContext(render.RenderContextBase):
         pass
 
 
-class CanvasRenderer(render.StandardPixelRenderer):
+class CanvasRenderer(render.StandardPipelineRenderer):
 
     def __init__(self, viewer):
-        render.StandardPixelRenderer.__init__(self, viewer)
+        render.StandardPipelineRenderer.__init__(self, viewer)
 
         self.kind = 'mock'
         self.rgb_order = 'RGBA'

--- a/ginga/mplw/CanvasRenderMpl.py
+++ b/ginga/mplw/CanvasRenderMpl.py
@@ -171,10 +171,10 @@ class RenderContext(render.RenderContextBase):
         self.cr.axes.add_patch(p)
 
 
-class CanvasRenderer(render.StandardPixelRenderer):
+class CanvasRenderer(render.StandardPipelineRenderer):
 
     def __init__(self, viewer):
-        render.StandardPixelRenderer.__init__(self, viewer)
+        render.StandardPipelineRenderer.__init__(self, viewer)
 
         self.kind = 'mpl'
         self.rgb_order = viewer.rgb_order

--- a/ginga/opengl/CanvasRenderGL.py
+++ b/ginga/opengl/CanvasRenderGL.py
@@ -183,10 +183,10 @@ class RenderContext(render.RenderContextBase):
                                     self.brush, self.pen)
 
 
-class CanvasRenderer(vec.VectorRenderMixin, render.StandardPixelRenderer):
+class CanvasRenderer(vec.VectorRenderMixin, render.StandardPipelineRenderer):
 
     def __init__(self, viewer):
-        render.StandardPixelRenderer.__init__(self, viewer)
+        render.StandardPipelineRenderer.__init__(self, viewer)
         vec.VectorRenderMixin.__init__(self)
 
         self.kind = 'opengl'

--- a/ginga/pilw/CanvasRenderPil.py
+++ b/ginga/pilw/CanvasRenderPil.py
@@ -137,10 +137,10 @@ class RenderContext(render.RenderContextBase):
         self.cr.path(cpoints, self.pen)
 
 
-class CanvasRenderer(render.StandardPixelRenderer):
+class CanvasRenderer(render.StandardPipelineRenderer):
 
     def __init__(self, viewer):
-        render.StandardPixelRenderer.__init__(self, viewer)
+        render.StandardPipelineRenderer.__init__(self, viewer)
 
         self.kind = 'pil'
         self.rgb_order = 'RGBA'

--- a/ginga/qtw/CanvasRenderQt.py
+++ b/ginga/qtw/CanvasRenderQt.py
@@ -185,10 +185,10 @@ class RenderContext(render.RenderContextBase):
         self.cr.drawLines(pts)
 
 
-class CanvasRenderer(render.StandardPixelRenderer):
+class CanvasRenderer(render.StandardPipelineRenderer):
 
     def __init__(self, viewer, surface_type='qimage'):
-        render.StandardPixelRenderer.__init__(self, viewer)
+        render.StandardPipelineRenderer.__init__(self, viewer)
 
         self.kind = 'qt'
         # Qt needs this to be in BGRA


### PR DESCRIPTION
This was supposed to be the default renderer in release 3.2 but got reverted to some odd rendering that I noticed on one or two occasions.  This restores it to the default.  Need to confirm that it is working properly.