### PR TITLE
Clarify that opencv acceleration is used by default

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -125,7 +125,7 @@ Tk
 ==
 
 Ginga's Tk support is limited to the viewing widget itself.  For
-overplotting (graphics) support, you will also need:
+overplotting (graphics) support, you will also need one of:
 
 * Pillow
 * opencv-python

--- a/doc/optimizing.rst
+++ b/doc/optimizing.rst
@@ -48,24 +48,10 @@ Alternatively, you can add the following line to your Ginga general options conf
 OpenCv Acceleration
 -------------------
 Ginga includes support for OpenCv accelerated operations (e.g. rotation
-and rescaling).  *This support is not enabled by default*.
+and rescaling).  *This support is used by default if the package is installed*.
 
 To enable OpenCv support, install the python `opencv` module (you can
 find it `here <https://pypi.python.org/pypi/opencv-python>`_).
-
-If you are building your own program using a ginga viewer widget, simply
-enable the support by::
-
-    from ginga import trcalc
-    trcalc.use('opencv')
-
-If you are using the reference viewer, you can add the command line
-option `--opencv` to enable support.
-
-Alternatively, you can add the following line to your Ginga general options configuration file
-(`$HOME/.ginga/general.cfg`)::
-
-    use_opencv = True
 
 
 numexpr Acceleration

--- a/ginga/examples/configs/general.cfg
+++ b/ginga/examples/configs/general.cfg
@@ -59,11 +59,6 @@ cursor_interval = 0.050
 widgetSet = 'choose'
 #widgetSet = 'qt4'
 
-# Speeds up rotation a lot if you have python OpenCv module!
-# Enable this if you have it installed and can import "cv2" without problems.
-# NOTE: OpenCv is now used by default if it is installed
-#use_opencv = True
-
 # Enables the "opengl" renderer for backends Qt and Gtk
 # NOTE: some minor features are not supported well under OpenGL yet
 use_opengl = False

--- a/ginga/examples/gtk3/example2.py
+++ b/ginga/examples/gtk3/example2.py
@@ -213,16 +213,8 @@ def main(options, args):
 
     logger = log.get_logger("example2", options=options)
 
-    # Check whether user wants to use OpenCv
-    if options.opencv:
-        from ginga import trcalc
-        try:
-            trcalc.use('opencv')
-        except Exception as e:
-            logger.warning("failed to set OpenCv preference: %s" % (str(e)))
-
     # Check whether user wants to use OpenCL
-    elif options.opencl:
+    if options.opencl:
         from ginga import trcalc
         try:
             trcalc.use('opencl')
@@ -249,9 +241,6 @@ if __name__ == "__main__":
     argprs.add_argument("--debug", dest="debug", default=False,
                         action="store_true",
                         help="Enter the pdb debugger on main()")
-    argprs.add_argument("--opencv", dest="opencv", default=False,
-                        action="store_true",
-                        help="Use OpenCv acceleration")
     argprs.add_argument("--opencl", dest="opencl", default=False,
                         action="store_true",
                         help="Use OpenCL acceleration")

--- a/ginga/examples/gw/example1_video.py
+++ b/ginga/examples/gw/example1_video.py
@@ -51,9 +51,6 @@ except ImportError:
     print("You need to install the OpenCV python module to run this example")
     sys.exit(1)
 
-from ginga import trcalc
-# this should be the default if OpenCv is installed anyway
-trcalc.use('opencv')
 
 STD_FORMAT = '%(asctime)s | %(levelname)1.1s | %(filename)s:%(lineno)d (%(funcName)s) | %(message)s'
 

--- a/ginga/examples/pg/example2_pg.py
+++ b/ginga/examples/pg/example2_pg.py
@@ -266,13 +266,6 @@ def main(options, args):
 
     logger = log.get_logger("example2", options=options)
 
-    if options.use_opencv:
-        from ginga import trcalc
-        try:
-            trcalc.use('opencv')
-        except Exception as e:
-            logger.warning("Error using OpenCv: %s" % str(e))
-
     if options.use_opencl:
         from ginga import trcalc
         try:
@@ -330,9 +323,6 @@ if __name__ == "__main__":
     argprs.add_argument("--loglevel", dest="loglevel", metavar="LEVEL",
                         type=int, default=logging.INFO,
                         help="Set logging level to LEVEL")
-    argprs.add_argument("--opencv", dest="use_opencv", default=False,
-                        action="store_true",
-                        help="Use OpenCv acceleration")
     argprs.add_argument("--opencl", dest="use_opencl", default=False,
                         action="store_true",
                         help="Use OpenCL acceleration")

--- a/ginga/examples/qt/example2_qt.py
+++ b/ginga/examples/qt/example2_qt.py
@@ -275,16 +275,8 @@ def main(options, args):
 
     logger = log.get_logger("example2", options=options)
 
-    # Check whether user wants to use OpenCv
-    if options.opencv:
-        from ginga import trcalc
-        try:
-            trcalc.use('opencv')
-        except Exception as e:
-            logger.warning("failed to set OpenCv preference: %s" % (str(e)))
-
     # Check whether user wants to use OpenCL
-    elif options.opencl:
+    if options.opencl:
         from ginga import trcalc
         try:
             trcalc.use('opencl')
@@ -314,9 +306,6 @@ if __name__ == "__main__":
     argprs.add_argument("--debug", dest="debug", default=False,
                         action="store_true",
                         help="Enter the pdb debugger on main()")
-    argprs.add_argument("--opencv", dest="opencv", default=False,
-                        action="store_true",
-                        help="Use OpenCv acceleration")
     argprs.add_argument("--opencl", dest="opencl", default=False,
                         action="store_true",
                         help="Use OpenCL acceleration")

--- a/ginga/examples/qt/example_asdf.py
+++ b/ginga/examples/qt/example_asdf.py
@@ -278,16 +278,8 @@ def main(options, args):
 
     logger = log.get_logger("example2", options=options)
 
-    # Check whether user wants to use OpenCv
-    if options.opencv:
-        from ginga import trcalc
-        try:
-            trcalc.use('opencv')
-        except Exception as e:
-            logger.warning("failed to set OpenCv preference: %s" % (str(e)))
-
     # Check whether user wants to use OpenCL
-    elif options.opencl:
+    if options.opencl:
         from ginga import trcalc
         try:
             trcalc.use('opencl')
@@ -317,9 +309,6 @@ if __name__ == "__main__":
     argprs.add_argument("--debug", dest="debug", default=False,
                         action="store_true",
                         help="Enter the pdb debugger on main()")
-    argprs.add_argument("--opencv", dest="opencv", default=False,
-                        action="store_true",
-                        help="Use OpenCv acceleration")
     argprs.add_argument("--opencl", dest="opencl", default=False,
                         action="store_true",
                         help="Use OpenCL acceleration")

--- a/ginga/rv/main.py
+++ b/ginga/rv/main.py
@@ -439,15 +439,10 @@ class ReferenceViewer(object):
             logger.warning(
                 "failed to set FITS package preference: %s" % (str(e)))
 
-        # Check whether user wants to use OpenCv
-        use_opencv = settings.get('use_opencv', False)
-        if use_opencv or options.opencv:
-            from ginga import trcalc
-            try:
-                trcalc.use('opencv')
-            except Exception as e:
-                logger.warning(
-                    "failed to set OpenCv preference: %s" % (str(e)))
+        # Check whether user specified deprecated --opencv option
+        if options.opencv:
+            logger.warning("--opencv switch is deprecated; "
+                           "OpenCv will be used by default if installed")
 
         # Check whether user wants to use OpenCL
         use_opencl = settings.get('use_opencl', False)

--- a/ginga/trcalc.py
+++ b/ginga/trcalc.py
@@ -16,13 +16,7 @@ def use(pkgname):
     global have_opencl, trcalc_cl
     global _use
 
-    if pkgname == 'opencv':
-        _use = 'opencv'
-
-    elif pkgname == 'pillow':
-        _use = 'pillow'
-
-    elif pkgname == 'opencl':
+    if pkgname == 'opencl':
         try:
             from ginga.opencl import CL
             have_opencl = True

--- a/ginga/web/pgw/ipg.py
+++ b/ginga/web/pgw/ipg.py
@@ -461,18 +461,14 @@ class WebServer(object):
 
 def make_server(logger=None, basedir='.', numthreads=5,
                 host='localhost', port=9909, viewer_class=None,
-                use_opencv=False):
+                use_opencv=None):
 
     if logger is None:
         logger = log.get_logger("ipg", null=True)
     ev_quit = threading.Event()
 
-    if use_opencv:
-        from ginga import trcalc
-        try:
-            trcalc.use('opencv')
-        except Exception as e:
-            logger.warning("Error using opencv: %s" % str(e))
+    if use_opencv is not None:
+        logger.warning("use_opencv parameter is deprecated")
 
     thread_pool = Task.ThreadPool(numthreads, logger,
                                   ev_quit=ev_quit)
@@ -495,7 +491,7 @@ def main(options, args):
 
     server = make_server(logger=logger, basedir=options.basedir,
                          numthreads=options.numthreads, host=options.host,
-                         port=options.port, use_opencv=options.use_opencv)
+                         port=options.port)
     viewer = server.get_viewer('v1')
 
     logger.info("Starting server with one viewer, connect at %s" % viewer.url)
@@ -535,9 +531,6 @@ if __name__ == "__main__":
     argprs.add_argument("--stderr", dest="logstderr", default=False,
                         action="store_true",
                         help="Copy logging also to stderr")
-    argprs.add_argument("--opencv", dest="use_opencv", default=False,
-                        action="store_true",
-                        help="Use OpenCv acceleration")
     argprs.add_argument("-p", "--port", dest="port",
                         type=int, default=9909, metavar="PORT",
                         help="Default PORT to use for the web socket")

--- a/ginga/web/pgw/ipg.py
+++ b/ginga/web/pgw/ipg.py
@@ -468,7 +468,7 @@ def make_server(logger=None, basedir='.', numthreads=5,
     ev_quit = threading.Event()
 
     if use_opencv is not None:
-        logger.warning("use_opencv parameter is deprecated")
+        logger.warning("use_opencv parameter is deprecated, OpenCv will be used if installed")
 
     thread_pool = Task.ThreadPool(numthreads, logger,
                                   ev_quit=ev_quit)


### PR DESCRIPTION
Previously, OpenCv support had to be explicitly enabled via a command line switch or option in a configuration file.  This was due to a problem importing `cv2` that could crash the application on some platforms.  The `OpenCv` project has fixed that bug some time ago and for quite a while now, Ginga has been quietly enabling OpenCv support by default.

This PR removes the `--opencv` switch from example programs and updates the documentation to indicate that it is used by default if installed.  The option is retained on the reference viewer, however it will generate a logger warning that the option has been deprecated.