### PR TITLE
Change Pick plot of FWHM to match rest of UI report

### DIFF
--- a/ginga/rv/plugins/Pick.py
+++ b/ginga/rv/plugins/Pick.py
@@ -1235,13 +1235,13 @@ class Pick(GingaPlugin.LocalPlugin):
 
     def plot_fwhm(self, qs, image):
         # Make a FWHM plot
-        x, y, radius = qs.x, qs.y, qs.fwhm_radius
+        x, y = qs.x - self.pick_x1, qs.y - self.pick_y1
+        radius = qs.fwhm_radius
 
         try:
-            self.fwhm_plot.plot_fwhm(x, y, radius, image,
-                                     cutout_data=self.pick_data,
-                                     iqcalc=self.iqcalc,
-                                     fwhm_method=self.fwhm_alg)
+            self.fwhm_plot.plot_fwhm_data(x, y, radius, self.pick_data,
+                                          iqcalc=self.iqcalc,
+                                          fwhm_method=self.fwhm_alg)
 
         except Exception as e:
             self.logger.error("Error making fwhm plot: %s" % (

--- a/ginga/util/iqcalc.py
+++ b/ginga/util/iqcalc.py
@@ -796,18 +796,15 @@ class IQCalc(object):
             oid_x, oid_y = None, None
             try:
                 oid_x, oid_y = self.centroid(data, x, y, fwhm_radius)
-                _x, _y = int(round(oid_x)), int(round(oid_y))
 
             except Exception as e:
                 # Error doing centroid
-                _x, _y = x, y
                 self.logger.debug("Error doing centroid on object at %.2f,%.2f: %s" % (
                     x, y, str(e)))
 
-            # Find the fwhm in x and y, using rounded centroid center, if
-            # known, otherwise using the local peak
+            # Find the fwhm in x and y, using local peak
             try:
-                res = self.fwhm_data(_x, _y, data, radius=fwhm_radius,
+                res = self.fwhm_data(x, y, data, radius=fwhm_radius,
                                      method_name=fwhm_method)
                 fwhm_x, fwhm_y, ctr_x, ctr_y, x_res, y_res = res
 

--- a/ginga/util/iqcalc.py
+++ b/ginga/util/iqcalc.py
@@ -792,9 +792,22 @@ class IQCalc(object):
             if ev_intr and ev_intr.is_set():
                 raise IQCalcError("Evaluation interrupted!")
 
-            # Find the fwhm in x and y
+            # centroid calculation on local peak
+            oid_x, oid_y = None, None
             try:
-                res = self.fwhm_data(x, y, data, radius=fwhm_radius,
+                oid_x, oid_y = self.centroid(data, x, y, fwhm_radius)
+                _x, _y = int(round(oid_x)), int(round(oid_y))
+
+            except Exception as e:
+                # Error doing centroid
+                _x, _y = x, y
+                self.logger.debug("Error doing centroid on object at %.2f,%.2f: %s" % (
+                    x, y, str(e)))
+
+            # Find the fwhm in x and y, using rounded centroid center, if
+            # known, otherwise using the local peak
+            try:
+                res = self.fwhm_data(_x, _y, data, radius=fwhm_radius,
                                      method_name=fwhm_method)
                 fwhm_x, fwhm_y, ctr_x, ctr_y, x_res, y_res = res
 
@@ -809,15 +822,6 @@ class IQCalc(object):
                 self.logger.debug("Error doing FWHM on object at %.2f,%.2f: %s" % (
                     x, y, str(e)))
                 continue
-
-            oid_x, oid_y = None, None
-            try:
-                oid_x, oid_y = self.centroid(data, x, y, fwhm_radius)
-
-            except Exception as e:
-                # Error doing centroid
-                self.logger.debug("Error doing centroid on object at %.2f,%.2f: %s" % (
-                    x, y, str(e)))
 
             self.logger.debug("orig=%f,%f  ctr=%f,%f  fwhm=%f,%f bright=%f" % (
                 x, y, ctr_x, ctr_y, fwhm_x, fwhm_y, bright))

--- a/ginga/util/plots.py
+++ b/ginga/util/plots.py
@@ -504,6 +504,49 @@ class FWHMPlot(Plot):
             self.logger.error("Error making fwhm plot: %s" % (
                 str(e)))
 
+    def plot_fwhm_data(self, x, y, radius, arr_data,
+                       iqcalc=None, fwhm_method='gaussian'):
+
+        x, y, radius = int(round(x)), int(round(y)), int(round(radius))
+
+        if iqcalc is None:
+            iqcalc = self.iqcalc
+
+        x0, y0, xarr, yarr = iqcalc.cut_cross(x, y, radius, arr_data)
+
+        self.ax.cla()
+
+        self.set_titles(ytitle='Brightness', xtitle='Pixels', title='FWHM')
+        self.ax.grid(True)
+
+        # Make a FWHM plot
+        try:
+            # get median value from the cutout area
+            skybg = np.ma.median(arr_data)
+            self.logger.debug("cutting x=%d y=%d r=%d med=%f" % (
+                x, y, radius, skybg))
+
+            self.logger.debug("xarr=%s" % (str(xarr)))
+            fwhm_x = self._plot_fwhm_axis(xarr, iqcalc, skybg,
+                                          '#7570b3', '#7570b3', 'purple',
+                                          fwhm_method=fwhm_method)
+
+            self.logger.debug("yarr=%s" % (str(yarr)))
+            fwhm_y = self._plot_fwhm_axis(yarr, iqcalc, skybg,
+                                          '#1b9e77', '#1b9e77', 'seagreen',
+                                          fwhm_method=fwhm_method)
+
+            falg = fwhm_method
+            self.ax.legend(('data x', '%s x' % falg, 'data y', '%s y' % falg),
+                           loc='upper right', shadow=False, fancybox=False,
+                           prop={'size': 8}, labelspacing=0.2)
+            self.set_titles(title="FWHM X: %.2f  Y: %.2f" % (fwhm_x, fwhm_y))
+
+            self.draw()
+
+        except Exception as e:
+            self.logger.error("Error making fwhm plot: {}".format(e))
+
 
 class EEPlot(Plot):
     """Class to handle plotting of encircled and ensquared energy (EE) values."""


### PR DESCRIPTION
Changes the center point of FWHM calculation in `evaluate_peaks` from the local peak to the center-of-mass centroid of the local peak, if it can be calculated.

This may result in a slightly more accurate FWHM in the `evaluate_peaks` pass that can be used to solve the problem outlined in #969

Fix #969