### PR TITLE
Add NoConvergence workaround for radectopix in wcs_astropy.py

### DIFF
--- a/ginga/util/wcsmod/wcs_astropy.py
+++ b/ginga/util/wcsmod/wcs_astropy.py
@@ -121,7 +121,11 @@ class AstropyWCS(common.BaseWCS):
         skycrd = np.array([args], np.float_)
 
         try:
-            pix = self.wcs.all_world2pix(skycrd, origin)
+            pix = self.wcs.all_world2pix(skycrd, origin, maxiter=20,
+                                         detect_divergence=True, quiet=False)
+
+        except pywcs.NoConvergence as e:
+            pix = e.best_solution
 
         except Exception as e:
             self.logger.error("Error calculating radectopix: %s" % (str(e)))
@@ -192,7 +196,12 @@ class AstropyWCS(common.BaseWCS):
             if n > 0:
                 wcspt = np.hstack((wcspt, np.zeros((len(wcspt), n))))
         try:
-            datapt = self.wcs.all_world2pix(wcspt, origin)
+            datapt = self.wcs.all_world2pix(wcspt, origin, maxiter=20,
+                                            detect_divergence=True, quiet=False)
+
+        except pywcs.NoConvergence as e:
+            datapt = e.best_solution
+
         except Exception as e:
             self.logger.error(
                 "Error calculating wcspt_to_datapt: %s" % (str(e)))


### PR DESCRIPTION
Fixes the routines ``radectopix`` and ``wcspt_to_datapt`` in the WCS wrapper for astropy so that if the convergence fails it falls back to the best solution (based on the information in [this issue](https://github.com/astropy/astropy/issues/3203)).

The rationale for this is that these routines are mainly used for routines like drawing a compass, etc and do not need extreme accuracy of solution.