### PR TITLE
Refactor handling of inherit_primary_header in AstroImage

### DIFF
--- a/doc/WhatsNew.rst
+++ b/doc/WhatsNew.rst
@@ -29,7 +29,8 @@ Ver 3.3.0 (unreleased)
   - for previous parameter of usecrop=True, use sample=crop
 - Moved loading of FITS HDUs from AstroImage to io_fits module,
   encapsulating the details of this file format into the module
-  responsible for loading those files
+  responsible for loading those files:
+
   - added loading of FITS tables via the fitsio package in io_fits
   - TableView can now view tables loaded with either astropy or fitsio
   - inherit_primary_header in general.cfg now defaults to True and

--- a/doc/WhatsNew.rst
+++ b/doc/WhatsNew.rst
@@ -27,6 +27,14 @@ Ver 3.3.0 (unreleased)
 - Changes to 'histogram' and 'stddev' autocuts algorithms:
   - choice of sampling by grid now; useful for mosaics and collages
   - for previous parameter of usecrop=True, use sample=crop
+- Moved loading of FITS HDUs from AstroImage to io_fits module,
+  encapsulating the details of this file format into the module
+  responsible for loading those files
+  - added loading of FITS tables via the fitsio package in io_fits
+  - TableView can now view tables loaded with either astropy or fitsio
+  - inherit_primary_header in general.cfg now defaults to True and
+    actually controls the behavior of always saving the primary header
+    if set to False
 
 Ver 3.2.0 (2021-06-07)
 ======================

--- a/doc/WhatsNew.rst
+++ b/doc/WhatsNew.rst
@@ -25,8 +25,10 @@ Ver 3.3.0 (unreleased)
   workspace type that was selected in the drop down menu
 - Updated pg widgets web backend due to changes to Tornado asyncio handling
 - Changes to 'histogram' and 'stddev' autocuts algorithms:
+  
   - choice of sampling by grid now; useful for mosaics and collages
   - for previous parameter of usecrop=True, use sample=crop
+    
 - Moved loading of FITS HDUs from AstroImage to io_fits module,
   encapsulating the details of this file format into the module
   responsible for loading those files:

--- a/ginga/AstroImage.py
+++ b/ginga/AstroImage.py
@@ -102,7 +102,8 @@ class AstroImage(BaseImage):
         if self.io is None:
             raise ImageError("No IO loader defined")
 
-        self.io.load_hdu(hdu, fobj=fobj, naxispath=naxispath)
+        self.io.load_hdu(hdu, dstobj=self, fobj=fobj, naxispath=naxispath,
+                         save_primary_header=False)
 
     def load_nddata(self, ndd, naxispath=None):
         """Load from an astropy.nddata.NDData object.

--- a/ginga/AstroImage.py
+++ b/ginga/AstroImage.py
@@ -277,7 +277,7 @@ class AstroImage(BaseImage):
 
     def has_primary_header(self):
         primary_hdr = self.metadata.get('primary_header', None)
-        return primary_hdr is not None
+        return isinstance(primary_hdr, AstroHeader)
 
     def clear_all(self):
         # clear metadata and data

--- a/ginga/BaseImage.py
+++ b/ginga/BaseImage.py
@@ -622,12 +622,13 @@ class Header(dict):
         except KeyError:
             return alt
 
-    def merge(self, hdr):
+    def merge(self, hdr, override_keywords=False):
         if not isinstance(hdr, Header):
             raise ValueError("need to pass a compatible header for merge")
         for key in hdr.keys():
-            card = hdr.get_card(key)
-            self.set_card(key, card.value, comment=card.comment)
+            if key not in self or override_keywords:
+                card = hdr.get_card(key)
+                self.set_card(key, card.value, comment=card.comment)
 
     def update(self, map_kind):
         for key, value in map_kind.items():

--- a/ginga/rv/Control.py
+++ b/ginga/rv/Control.py
@@ -93,8 +93,8 @@ class GingaShell(GwMain.GwMain, Widgets.Application):
                               numImages=10,
                               # Offset to add to numpy-based coords
                               pixel_coords_offset=1.0,
-                              # inherit from primary header
-                              inherit_primary_header=False,
+                              # save primary header when loading files
+                              inherit_primary_header=True,
                               cursor_interval=0.050,
                               download_folder=None,
                               save_layout=False,
@@ -572,12 +572,11 @@ class GingaShell(GwMain.GwMain, Widgets.Application):
         -------
         data_obj : data object named by filespec
         """
-        inherit_prihdr = self.settings.get('inherit_primary_header',
-                                           False)
+        save_prihdr = self.settings.get('inherit_primary_header', False)
         try:
             data_obj = loader.load_data(filespec, logger=self.logger,
                                         idx=idx,
-                                        inherit_primary_header=inherit_prihdr)
+                                        save_primary_header=save_prihdr)
         except Exception as e:
             errmsg = "Failed to load file '%s': %s" % (
                 filespec, str(e))
@@ -789,9 +788,9 @@ class GingaShell(GwMain.GwMain, Widgets.Application):
         def _open_file(opener_class):
             # kwd args to pass to opener
             kwargs = dict()
-            inherit_prihdr = self.settings.get('inherit_primary_header',
-                                               False)
-            kwargs['inherit_primary_header'] = inherit_prihdr
+            save_prihdr = self.settings.get('inherit_primary_header',
+                                            False)
+            kwargs['save_primary_header'] = save_prihdr
 
             # open the file and load the items named by the index
             opener = opener_class(self.logger)

--- a/ginga/rv/plugins/Header.py
+++ b/ginga/rv/plugins/Header.py
@@ -54,12 +54,12 @@ class Header(GingaPlugin.GlobalPlugin):
         self.settings.add_defaults(sortable=False,
                                    color_alternate_rows=True,
                                    max_rows_for_col_resize=5000,
+                                   include_primary_header=False,
                                    closeable=not spec.get('hidden', False))
         self.settings.load(onError='silent')
 
         self.flg_sort = self.settings.get('sortable', False)
-        prihdr = self.fv.settings.get('inherit_primary_header', False)
-        self.flg_prihdr = self.settings.get('include_primary_header', prihdr)
+        self.flg_prihdr = self.settings.get('include_primary_header', False)
         fv.add_callback('add-channel', self.add_channel)
         fv.add_callback('delete-channel', self.delete_channel)
         fv.add_callback('channel-change', self.focus_cb)

--- a/ginga/table/TableView.py
+++ b/ginga/table/TableView.py
@@ -136,30 +136,49 @@ class TableViewGw(TableViewBase):
         # Extract data as astropy table
         a_tab = table.get_data()
 
-        # Fill masked values, if applicable
-        try:
-            a_tab = a_tab.filled()
-        except Exception:  # Just use original table
-            pass
+        columns = [('Row', '_DISPLAY_ROW')]
 
         # This is to get around table widget not sorting numbers properly
-        i_fmt = '{{0:0{0}d}}'.format(len(str(len(a_tab))))
+        i_fmt = '{{0:0{0}d}}'.format(len(str(table.rows)))
 
-        # Table header with units
-        columns = [('Row', '_DISPLAY_ROW')]
-        for c in a_tab.columns.values():
-            col_str = '{0:^s}\n{1:^s}'.format(c.name, str(c.unit))
-            columns.append((col_str, c.name))
+        if table.kind == 'table-astropy':
+            # Fill masked values, if applicable
+            try:
+                a_tab = a_tab.filled()
+            except Exception:  # Just use original table
+                pass
+
+            # Table header with units
+            for c in a_tab.columns.values():
+                col_str = '{0:^s}\n{1:^s}'.format(c.name, str(c.unit))
+                columns.append((col_str, c.name))
+
+            # Table contents
+            for i, row in enumerate(a_tab, 1):
+                bnch = Bunch.Bunch(zip(row.colnames, row.as_void()))
+                i_str = i_fmt.format(i)
+                bnch['_DISPLAY_ROW'] = i_str
+                tree_dict[i_str] = bnch
+
+        elif table.kind == 'table-fitsio':
+            colnames = table.colnames
+
+            # Table header
+            for c_name in colnames:
+                col_str = '{0:^s}'.format(c_name)
+                columns.append((col_str, c_name))
+
+            # Table contents
+            for i, row in enumerate(a_tab, 1):
+                bnch = Bunch.Bunch(zip(colnames, row))
+                i_str = i_fmt.format(i)
+                bnch['_DISPLAY_ROW'] = i_str
+                tree_dict[i_str] = bnch
+
+        else:
+            raise ValueError(f"I don't know how to display tables of type '{table.kind}'")
 
         self.widget.setup_table(columns, 1, '_DISPLAY_ROW')
-
-        # Table contents
-        for i, row in enumerate(a_tab, 1):
-            bnch = Bunch.Bunch(zip(row.colnames, row.as_void()))
-            i_str = i_fmt.format(i)
-            bnch['_DISPLAY_ROW'] = i_str
-            tree_dict[i_str] = bnch
-
         self.widget.set_tree(tree_dict)
 
         # Resize column widths
@@ -178,5 +197,3 @@ class TableViewGw(TableViewBase):
         # no housekeeping to do (for now) on our part, just override to
         # suppress the logger warning
         pass
-
-# END

--- a/ginga/util/io_fits.py
+++ b/ginga/util/io_fits.py
@@ -31,6 +31,7 @@ fitsLoaderClass = None
 
 try:
     from astropy.io import fits as pyfits
+    from astropy.table import Table
     have_astropy = True
 except ImportError:
     have_astropy = False
@@ -219,7 +220,10 @@ class PyFitsFileHandler(BaseFitsFileHandler):
         super(PyFitsFileHandler, self).__init__(logger)
         self.kind = 'pyfits'
 
-    def fromHDU(self, hdu, ahdr):
+    def copy_header(self, hdu, ahdr):
+        """Copy a FITS header from an astropy.io.fits.PrimaryHDU object
+        into a ginga.AstroImage.AstroHeader object.
+        """
         header = hdu.header
         if hasattr(header, 'cards'):
             # newer astropy.io.fits don't have ascardlist()
@@ -246,18 +250,47 @@ class PyFitsFileHandler(BaseFitsFileHandler):
 
         return None
 
-    def load_hdu(self, hdu, dstobj=None, **kwargs):
+    def load_hdu(self, hdu, dstobj=None, fobj=None, naxispath=None,
+                 save_primary_header=True, **kwargs):
+        if fobj is None:
+            fobj = self.fits_f
+
+        # Set PRIMARY header
+        if save_primary_header and fobj is not None:
+            primary_hdr = AstroHeader()
+            self.copy_header(fobj[0], primary_hdr)
+        else:
+            primary_hdr = None
 
         typ = self.get_hdu_type(hdu)
         if typ == 'image':
 
             if dstobj is None:
                 dstobj = AstroImage(logger=self.logger)
-                dstobj.load_hdu(hdu, **kwargs)
-
             else:
-                # TODO: migrate code from AstroImage to here
-                dstobj.load_hdu(hdu, **kwargs)
+                if not isinstance(dstobj, AstroImage):
+                    raise ValueError("dstobj needs to be a type of AstroImage")
+                dstobj.clear_metadata()
+
+            # this seems to be necessary now for some fits files...
+            try:
+                hdu.verify('fix')
+
+            except Exception as e:
+                # Let's hope for the best!
+                self.logger.warning("Problem verifying fits HDU: {}".format(e))
+
+            # collect HDU header
+            ahdr = dstobj.get_header()
+            self.copy_header(hdu, ahdr)
+            dstobj.set(primary_header=primary_hdr)
+
+            dstobj.setup_data(hdu.data, naxispath=naxispath)
+
+            # Try to make a wcs object on the header
+            wcs = getattr(dstobj, 'wcs', None)
+            if wcs is not None:
+                wcs.load_header(hdu.header, fobj=fobj)
 
         elif typ == 'table':
             # <-- data may be a table
@@ -274,11 +307,30 @@ class PyFitsFileHandler(BaseFitsFileHandler):
 
             if dstobj is None:
                 dstobj = AstroTable(logger=self.logger)
+            else:
+                if not isinstance(dstobj, AstroTable):
+                    raise ValueError("dstobj needs to be a type of AstroTable")
+                dstobj.clear_metadata()
+
+            dstobj.kind = 'table-astropy'
 
             self.logger.debug('Attempting to load table from FITS')
 
-            # TODO: migrate code from AstroTable to here
-            dstobj.load_hdu(hdu, **kwargs)
+            ahdr = dstobj.get_header()
+            self.copy_header(hdu, ahdr)
+            dstobj.set(primary_header=primary_hdr)
+
+            if 'format' not in kwargs:
+                kwargs['format'] = 'fits'
+
+            try:
+                data = Table.read(hdu, **kwargs)
+                dstobj.set_data(data)
+                dstobj.colnames = list(data.colnames)
+
+            except Exception as e:
+                self.logger.error("Error reading table from hdu: {0}".format(e),
+                                  exc_info=True)
 
         else:
             raise FITSError("I don't know how to read this HDU")
@@ -288,14 +340,13 @@ class PyFitsFileHandler(BaseFitsFileHandler):
         return dstobj
 
     def load_file(self, filespec, numhdu=None, dstobj=None, memmap=None,
-                  **kwargs):
-        inherit_primary_header = kwargs.pop('inherit_primary_header', False)
+                  save_primary_header=True, **kwargs):
         opener = self.get_factory()
         opener.open_file(filespec, memmap=memmap, **kwargs)
         try:
             return opener.get_hdu(
                 numhdu, dstobj=dstobj,
-                inherit_primary_header=inherit_primary_header)
+                save_primary_header=save_primary_header)
         finally:
             opener.close()
 
@@ -491,7 +542,7 @@ class FitsioFileHandler(BaseFitsFileHandler):
         self.hdu_info = []
         self.hdu_db = {}
 
-    def fromHDU(self, hdu, ahdr):
+    def copy_header(self, hdu, ahdr):
         header = hdu.read_header()
         for d in header.records():
             if len(d['name']) == 0:
@@ -509,54 +560,74 @@ class FitsioFileHandler(BaseFitsFileHandler):
 
         return None
 
-    def load_hdu(self, hdu, dstobj=None, **kwargs):
+    def load_hdu(self, hdu, dstobj=None, fobj=None, naxispath=None,
+                 save_primary_header=True, **kwargs):
+        if fobj is None:
+            fobj = self.fits_f
+
+        # Set PRIMARY header
+        if save_primary_header and fobj is not None:
+            primary_hdr = AstroHeader()
+            self.copy_header(fobj[0], primary_hdr)
+        else:
+            primary_hdr = None
+
         typ = self.get_hdu_type(hdu)
 
         if typ == 'image':
             # <-- data is an image
             if dstobj is None:
                 dstobj = AstroImage(logger=self.logger)
+            else:
+                if not isinstance(dstobj, AstroImage):
+                    raise ValueError("dstobj needs to be a type of AstroImage")
+                dstobj.clear_metadata()
 
-            inherit_primary_header = (dstobj.inherit_primary_header or
-                                      kwargs.get('inherit_primary_header',
-                                                 False))
-            ahdr = AstroHeader()
-            if dstobj.save_primary_header or inherit_primary_header:
-                if self.fits_f is not None:
-                    primary_hdr = AstroHeader()
-                    if dstobj.save_primary_header:
-                        dstobj._primary_hdr = primary_hdr
-                    # load primary header
-                    self.fromHDU(self.fits_f[0], primary_hdr)
-
-                    if inherit_primary_header:
-                        ahdr.merge(primary_hdr)
-
-            self.fromHDU(hdu, ahdr)
-            metadata = dict(header=ahdr)
+            ahdr = dstobj.get_header()
+            self.copy_header(hdu, ahdr)
+            dstobj.set(primary_header=primary_hdr)
 
             data = hdu.read()
 
-            dstobj.load_data(data, metadata=metadata)
+            dstobj.setup_data(data, naxispath=naxispath)
+
+            # Try to make a wcs object on the header
+            wcs = getattr(dstobj, 'wcs', None)
+            if wcs is not None:
+                # NOTE: WCS packages don't know what to do with fitsio objects
+                wcs.load_header(ahdr.asdict(), fobj=None)
 
         elif typ == 'table':
             # <-- data is a table
-            raise FITSError(
-                "FITS tables are not yet readable using ginga/fitsio")
+            if dstobj is None:
+                dstobj = AstroTable(logger=self.logger)
+            else:
+                if not isinstance(dstobj, AstroTable):
+                    raise ValueError("dstobj needs to be a type of AstroTable")
+                dstobj.clear_metadata()
+
+            ahdr = dstobj.get_header()
+            self.copy_header(hdu, ahdr)
+            dstobj.set(primary_header=primary_hdr)
+
+            dstobj.kind = 'table-fitsio'
+
+            data = hdu.read()
+            dstobj.colnames = list(data.dtype.fields)
+            dstobj.set_data(data)
 
         dstobj.io = self
 
         return dstobj
 
     def load_file(self, filespec, numhdu=None, dstobj=None, memmap=None,
-                  **kwargs):
-        inherit_primary_header = kwargs.pop('inherit_primary_header', False)
+                  save_primary_header=True, **kwargs):
         opener = self.get_factory()
         opener.open_file(filespec, memmap=memmap, **kwargs)
         try:
             return opener.get_hdu(
                 numhdu, dstobj=dstobj,
-                inherit_primary_header=inherit_primary_header)
+                save_primary_header=save_primary_header)
         finally:
             opener.close()
 

--- a/ginga/util/io_fits.py
+++ b/ginga/util/io_fits.py
@@ -18,6 +18,7 @@ any images.  Otherwise Ginga will try to pick one for you.
 """
 import re
 import numpy as np
+import warnings
 
 from ginga.AstroImage import AstroImage, AstroHeader
 from ginga.table.AstroTable import AstroTable
@@ -342,6 +343,12 @@ class PyFitsFileHandler(BaseFitsFileHandler):
 
     def load_file(self, filespec, numhdu=None, dstobj=None, memmap=None,
                   save_primary_header=False, **kwargs):
+        if 'inherit_primary_header' in kwargs:
+            warnings.warn("inherit_primary_header kwarg will be deprecated in the next release--use save_primary_header instead",
+                          PendingDeprecationWarning)
+            save_primary_header = kwargs.pop('inherit_primary_header',
+                                             save_primary_header)
+
         opener = self.get_factory()
         opener.open_file(filespec, memmap=memmap, **kwargs)
         try:
@@ -524,6 +531,12 @@ class PyFitsFileHandler(BaseFitsFileHandler):
     def save_as_file(self, filepath, data, header, **kwargs):
         self.write_fits(filepath, data, header, **kwargs)
 
+    def fromHDU(self, hdu, ahdr):
+        warnings.warn("fromHDU will be deprecated in the next release--"
+                      "use copy_header instead",
+                      PendingDeprecationWarning)
+        return self.copy_header(hdu, ahdr)
+
 
 class FitsioFileHandler(BaseFitsFileHandler):
 
@@ -623,6 +636,11 @@ class FitsioFileHandler(BaseFitsFileHandler):
 
     def load_file(self, filespec, numhdu=None, dstobj=None, memmap=None,
                   save_primary_header=True, **kwargs):
+        if 'inherit_primary_header' in kwargs:
+            warnings.warn("inherit_primary_header kwarg will be deprecated in the next release--use save_primary_header instead",
+                          PendingDeprecationWarning)
+            save_primary_header = kwargs.pop('inherit_primary_header',
+                                             save_primary_header)
         opener = self.get_factory()
         opener.open_file(filespec, memmap=memmap, **kwargs)
         try:
@@ -787,6 +805,12 @@ class FitsioFileHandler(BaseFitsFileHandler):
     def save_as_file(self, filepath, data, header, **kwargs):
         self.write_fits(filepath, data, header, **kwargs)
 
+    def fromHDU(self, hdu, ahdr):
+        warnings.warn("fromHDU will be deprecated in the next release--"
+                      "use copy_header instead",
+                      PendingDeprecationWarning)
+        return self.copy_header(hdu, ahdr)
+
 
 if not fits_configured:
     if have_astropy:
@@ -814,6 +838,3 @@ def load_file(filepath, idx=None, logger=None, **kwargs):
     """
     opener = get_fitsloader(logger=logger)
     return opener.load_file(filepath, numhdu=idx, **kwargs)
-
-
-# END

--- a/ginga/util/io_fits.py
+++ b/ginga/util/io_fits.py
@@ -290,6 +290,7 @@ class PyFitsFileHandler(BaseFitsFileHandler):
             # Try to make a wcs object on the header
             wcs = getattr(dstobj, 'wcs', None)
             if wcs is not None:
+                print('loading header into WCS')
                 wcs.load_header(hdu.header, fobj=fobj)
 
         elif typ == 'table':

--- a/ginga/util/io_fits.py
+++ b/ginga/util/io_fits.py
@@ -251,7 +251,7 @@ class PyFitsFileHandler(BaseFitsFileHandler):
         return None
 
     def load_hdu(self, hdu, dstobj=None, fobj=None, naxispath=None,
-                 save_primary_header=True, **kwargs):
+                 save_primary_header=False, **kwargs):
         if fobj is None:
             fobj = self.fits_f
 
@@ -341,7 +341,7 @@ class PyFitsFileHandler(BaseFitsFileHandler):
         return dstobj
 
     def load_file(self, filespec, numhdu=None, dstobj=None, memmap=None,
-                  save_primary_header=True, **kwargs):
+                  save_primary_header=False, **kwargs):
         opener = self.get_factory()
         opener.open_file(filespec, memmap=memmap, **kwargs)
         try:


### PR DESCRIPTION
This PR refactors AstroImage, AstroTable and ginga.util.io_fits in the following ways:
- the primary header is saved as a metadata item called 'primary_header' (the header is already saved similarly as 'header'); this makes the handling of these two entities similar.
- the astropy/fitsio specific details for loading an HDU has been moved from AstroImage and AstroTable to ginga.util.io_fits. This encapsulates the details of the specific support package in io_fits
- added loading of FITS tables via the `fitsio` package in io_fits
- modified the TableView class to be able to view tables loaded with either astropy or fitsio