### PR TITLE
Update autocuts algorithms 

### DIFF
--- a/doc/WhatsNew.rst
+++ b/doc/WhatsNew.rst
@@ -26,6 +26,7 @@ Ver 3.3.0 (unreleased)
 - Updated pg widgets web backend due to changes to Tornado asyncio handling
 - Changes to 'histogram' and 'stddev' autocuts algorithms:
   - choice of sampling by grid now; useful for mosaics and collages
+  - for previous parameter of usecrop=True, use sample=crop
 
 Ver 3.2.0 (2021-06-07)
 ======================

--- a/doc/WhatsNew.rst
+++ b/doc/WhatsNew.rst
@@ -24,6 +24,8 @@ Ver 3.3.0 (unreleased)
 - Fixed a bug where creating a new workspace did not set the correct
   workspace type that was selected in the drop down menu
 - Updated pg widgets web backend due to changes to Tornado asyncio handling
+- Changes to 'histogram' and 'stddev' autocuts algorithms:
+  - choice of sampling by grid now; useful for mosaics and collages
 
 Ver 3.2.0 (2021-06-07)
 ======================

--- a/doc/ref_api.rst
+++ b/doc/ref_api.rst
@@ -29,6 +29,9 @@ Reference/API
 
 .. automodapi:: ginga.colors
 
+.. automodapi:: ginga.AutoCuts
+   :no-inheritance-diagram:
+
 .. automodapi:: ginga.util.io.io_asdf
 
 .. automodapi:: ginga.util.wcsmod

--- a/ginga/AutoCuts.py
+++ b/ginga/AutoCuts.py
@@ -5,6 +5,7 @@
 # Please see the file LICENSE.txt for details.
 #
 import numpy as np
+import warnings
 
 from ginga import trcalc
 from ginga.misc import Bunch
@@ -18,6 +19,10 @@ try:
 except ImportError:
     have_scipy = False
     autocut_methods = ('minmax', 'histogram', 'stddev', 'zscale')
+
+
+__all__ = ['AutoCutsBase', 'Minmax', 'Histogram', 'StdDev', 'MedianFilter',
+           'ZScale', 'get_autocuts', 'get_autocuts_names']
 
 
 class Param(Bunch.Bunch):
@@ -417,7 +422,7 @@ class Histogram(AutoCutsBase):
 
     # NOTE: `usecrop` kwarg to be deprecated--accepted but not used
     # for backward compatibility with saved older settings
-    def __init__(self, logger, usecrop=False, sample='crop',
+    def __init__(self, logger, usecrop=None, sample='crop',
                  full_px_limit=None, num_points=None,
                  pct=0.999, numbins=2048):
         super(Histogram, self).__init__(logger)
@@ -428,6 +433,11 @@ class Histogram(AutoCutsBase):
         self.num_points = num_points
         self.pct = pct
         self.numbins = numbins
+
+        if usecrop is not None:
+            warnings.warn("The usecrop parameter has been deprecated--"
+                          "use sample=crop inst",
+                          PendingDeprecationWarning)
 
     def calc_cut_levels(self, image):
         """See subclass documentation."""
@@ -600,7 +610,7 @@ class StdDev(AutoCutsBase):
 
     # NOTE: `usecrop` kwarg to be deprecated--accepted but not used
     # for backward compatibility with saved older settings
-    def __init__(self, logger, usecrop=False, sample='grid',
+    def __init__(self, logger, usecrop=None, sample='grid',
                  full_px_limit=None, num_points=None,
                  hensa_lo=-1.5, hensa_hi=4.0):
         super(StdDev, self).__init__(logger)
@@ -613,6 +623,11 @@ class StdDev(AutoCutsBase):
         # "stddev" algorithm (from the old SOSS fits viewer)
         self.hensa_lo = hensa_lo
         self.hensa_hi = hensa_hi
+
+        if usecrop is not None:
+            warnings.warn("The usecrop parameter has been deprecated--"
+                          "use sample=crop instead",
+                          PendingDeprecationWarning)
 
     def calc_cut_levels(self, image):
         """See subclass documentation."""

--- a/ginga/AutoCuts.py
+++ b/ginga/AutoCuts.py
@@ -638,7 +638,7 @@ class StdDev(AutoCutsBase):
                 crop_radius = self.crop_radius
             else:
                 crop_radius = int(self.num_points // 2)
-            data = self.get_crop(image, crop_radius=crop_radius)
+            data = self.get_crop_data(data_np, crop_radius=crop_radius)
         elif self.sample == 'grid':
             data = self.get_sample_data(data_np, num_points=self.num_points)
         else:

--- a/ginga/Bindings.py
+++ b/ginga/Bindings.py
@@ -1849,7 +1849,7 @@ class ImageViewBindings(object):
 
         elif event.state == 'down':
             self._start_x, self._start_y = x, y
-            image = viewer.get_image()
+            image = viewer.get_vip()
             #self._loval, self._hival = viewer.get_cut_levels()
             self._loval, self._hival = viewer.autocuts.calc_cut_levels(image)
 

--- a/ginga/Bindings.py
+++ b/ginga/Bindings.py
@@ -772,7 +772,7 @@ class ImageViewBindings(object):
 
     def _cutlow_pct(self, viewer, pct, msg=True):
         msg = self.settings.get('msg_cuts', msg)
-        image = viewer.get_image()
+        image = viewer.get_vip()
         minval, maxval = image.get_minmax()
         spread = maxval - minval
         loval, hival = viewer.get_cut_levels()
@@ -785,7 +785,7 @@ class ImageViewBindings(object):
         msg = self.settings.get('msg_cuts', msg)
         win_wd, win_ht = viewer.get_window_size()
         pct = float(x) / float(win_wd)
-        image = viewer.get_image()
+        image = viewer.get_vip()
         minval, maxval = image.get_minmax()
         spread = maxval - minval
         loval, hival = viewer.get_cut_levels()
@@ -796,7 +796,7 @@ class ImageViewBindings(object):
 
     def _cuthigh_pct(self, viewer, pct, msg=True):
         msg = self.settings.get('msg_cuts', msg)
-        image = viewer.get_image()
+        image = viewer.get_vip()
         minval, maxval = image.get_minmax()
         spread = maxval - minval
         loval, hival = viewer.get_cut_levels()
@@ -809,7 +809,7 @@ class ImageViewBindings(object):
         msg = self.settings.get('msg_cuts', msg)
         win_wd, win_ht = viewer.get_window_size()
         pct = 1.0 - (float(x) / float(win_wd))
-        image = viewer.get_image()
+        image = viewer.get_vip()
         minval, maxval = image.get_minmax()
         spread = maxval - minval
         loval, hival = viewer.get_cut_levels()
@@ -1333,7 +1333,7 @@ class ImageViewBindings(object):
     def kp_cut_minmax(self, viewer, event, data_x, data_y, msg=True):
         if self.cancut:
             msg = self.settings.get('msg_cuts', msg)
-            image = viewer.get_image()
+            image = viewer.get_vip()
             mn, mx = image.get_minmax(noinf=True)
             viewer.cut_levels(mn, mx, no_reset=True)
         return True

--- a/ginga/ImageView.py
+++ b/ginga/ImageView.py
@@ -2385,7 +2385,7 @@ class ImageViewBase(Callback.Callbacks):
         if autocuts is None:
             autocuts = self.autocuts
 
-        image = self.get_image()
+        image = self.get_vip()
         if image is None:
             #image = self.vip
             return

--- a/ginga/ImageView.py
+++ b/ginga/ImageView.py
@@ -760,18 +760,19 @@ class ImageViewBase(Callback.Callbacks):
                        float(ht - self.data_off)))
             self.t_.set(limits=limits)
 
-            # this line should force the callback of _image_set_cb()
-            canvas_img.set_image(image)
-
             if add_to_canvas:
                 try:
                     self.canvas.get_object_by_tag(self._canvas_img_tag)
 
                 except KeyError:
-                    self.canvas.add(canvas_img, tag=self._canvas_img_tag)
+                    self.canvas.add(canvas_img, tag=self._canvas_img_tag,
+                                    redraw=False)
 
                 # move image to bottom of layers
                 self.canvas.lower_object(canvas_img)
+
+            # this line should force the callback of _image_set_cb()
+            canvas_img.set_image(image)
 
             self.canvas.update_canvas(whence=0)
 
@@ -784,15 +785,8 @@ class ImageViewBase(Callback.Callbacks):
             self.apply_profile_or_settings(image)
 
         except Exception as e:
-            self.logger.error("Failed to initialize image: %s" % (str(e)))
-            try:
-                # log traceback, if possible
-                (type, value, tb) = sys.exc_info()
-                tb_str = "".join(traceback.format_tb(tb))
-                self.logger.error("Traceback:\n%s" % (tb_str))
-            except Exception:
-                tb_str = "Traceback information unavailable."
-                self.logger.error(tb_str)
+            self.logger.error("Failed to initialize image: {}".format(e),
+                              exc_info=True)
 
         # update our display if the image changes underneath us
         image.add_callback('modified', self._image_modified_cb)

--- a/ginga/ImageView.py
+++ b/ginga/ImageView.py
@@ -406,6 +406,11 @@ class ImageViewBase(Callback.Callbacks):
         """Get the first two dimensions of Numpy array data.
         Data may have more dimensions, but they are not reported.
 
+        Parameter
+        ---------
+        data : ndarray
+            A numpy array with at least two dimensions
+
         Returns
         -------
         dims : tuple


### PR DESCRIPTION
This PR updates the auto cuts algorithms in the following ways:
- auto cuts features in the viewer can now work properly with images plotted on the canvas (not just a single loaded image); for example, the output of the `Collage` plugin
- the auto cuts algorithms that defaulted to taking a small crop sample from the center of the image ('histogram' and 'stddev') are expanded to include an option to sample the data in a grid pattern across the image. This is useful for large images (collages or large data frames such as mosaics), where a small crop from the center is not representative of the data across the image and the image is much too large to apply the algorithm to the full data.
- adds a `full_px_limit` parameter to 'histogram' and 'stddev' that specifies the number of pixels limit (in image size), beyond which the full image data calculation falls back to a crop image calculation. This prevents the viewer from accidentally attempting to calculate cut levels on a really large image, which can lock up the viewer.

Here is an example of the PR improvement.  First, a collage using the 'zscale' auto cuts (before PR)
![hsc_mosaic_before](https://user-images.githubusercontent.com/1305473/144767664-90092e9c-d994-4393-aaed-330493e19fe9.png)

and after PR:
![hsc_mosaic_after](https://user-images.githubusercontent.com/1305473/144767678-41633482-5fa8-4a0f-ae10-10f5c53db5ae.png)

The documentation has been greatly enhanced in the `AutoCuts` module and the user manual will be expanded to include it.
