### PR TITLE
TST: Ignore older_deps deprecation warning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,7 @@ filterwarnings =
     error
     ignore:numpy.ndarray size changed:RuntimeWarning
     ignore:numpy.ufunc size changed:RuntimeWarning
+    ignore:distutils Version classes are deprecated:DeprecationWarning
 
 [bdist_wheel]
 universal = 1


### PR DESCRIPTION
While newer stable releases upstream have fixed this problem, the `astropy` pulled by `older_deps` job does not have this fix because `astropy` itself dropped support for Python 3.7. So, we still need to ignore this warning.

Fix #980