### PR TITLE
MNT: Do not use enable_deprecations_as_exceptions

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,7 +9,7 @@ sphinx:
 
 # Set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
+  version: 3.8
   system_packages: false
   install:
     - method: pip

--- a/conftest.py
+++ b/conftest.py
@@ -9,11 +9,6 @@ try:
 except ImportError:
     version = 'unknown'
 
-# Uncomment the following line to treat all DeprecationWarnings as
-# exceptions
-from astropy.tests.helper import enable_deprecations_as_exceptions
-enable_deprecations_as_exceptions()
-
 # Uncomment and customize the following lines to add/remove entries
 # from the list of packages for which version numbers are displayed
 # when running the tests.


### PR DESCRIPTION
This pull request is to remove soon to be deprecated code; also see astropy/astropy#12633 .

Also fix RTD build failure.