### PR TITLE
Remove camel-case deprecated calls

### DIFF
--- a/doc/WhatsNew.rst
+++ b/doc/WhatsNew.rst
@@ -15,6 +15,8 @@ Ver 4.0.0 (unreleased)
   active canvas bindings.
 - Removed the "Quick Mode" and "From Peak" options in the Pick plugin
   to simplify operation.
+- Many deprecated camelcase (non-PEP8) methods were removed. Use the
+  "snake-case" names instead.
 
 Ver 3.4.0 (2022-06-28)
 ======================

--- a/ginga/AstroImage.py
+++ b/ginga/AstroImage.py
@@ -6,7 +6,6 @@
 #
 import sys
 import traceback
-import warnings
 from collections import OrderedDict
 
 import numpy as np

--- a/ginga/AstroImage.py
+++ b/ginga/AstroImage.py
@@ -108,8 +108,6 @@ class AstroImage(BaseImage):
             raise ImageError("No IO loader defined")
 
         self.io.load_hdu(hdu, dstobj=self, fobj=fobj, naxispath=naxispath,
-                         save_primary_header=save_primary_header,
-                         inherit_primary_header=inherit_primary_header,
                          **kwargs)
 
     def load_nddata(self, ndd, naxispath=None):

--- a/ginga/AstroImage.py
+++ b/ginga/AstroImage.py
@@ -61,23 +61,6 @@ class AstroImage(BaseImage):
 
         self.io = ioclass(self.logger)
 
-        # these attributes to be removed--DO NOT USE!!!
-        inherit_primary_header = False
-        if 'inherit_primary_header' in kwargs:
-            warnings.warn("inherit_primary_header kwarg has been deprecated--"
-                          "use inherit_primary_header in load_hdu() or load_file()",
-                          DeprecationWarning)
-            inherit_primary_header = kwargs['inherit_primary_header']
-        self.inherit_primary_header = inherit_primary_header
-
-        save_primary_header = True
-        if 'save_primary_header' in kwargs:
-            warnings.warn("save_primary_header kwarg has been deprecated--"
-                          "use save_primary_header in load_hdu() or load_file()",
-                          DeprecationWarning)
-            save_primary_header = kwargs['save_primary_header']
-        self.save_primary_header = save_primary_header
-
         if metadata is not None:
             header = self.get_header()
             self.wcs.load_header(header)
@@ -114,7 +97,6 @@ class AstroImage(BaseImage):
         self.set_naxispath(naxispath)
 
     def load_hdu(self, hdu, fobj=None, naxispath=None,
-                 save_primary_header=None, inherit_primary_header=None,
                  **kwargs):
         """NOTE: hdu type must be compatible with ioclass set in this
         AstroImage; for example:
@@ -124,12 +106,6 @@ class AstroImage(BaseImage):
 
         if self.io is None:
             raise ImageError("No IO loader defined")
-
-        # TO BE DEPRECATED--will just pass kwargs on through
-        if save_primary_header is None:
-            save_primary_header = self.save_primary_header
-        if inherit_primary_header is None:
-            inherit_primary_header = self.inherit_primary_header
 
         self.io.load_hdu(hdu, dstobj=self, fobj=fobj, naxispath=naxispath,
                          save_primary_header=save_primary_header,
@@ -162,12 +138,6 @@ class AstroImage(BaseImage):
 
         if self.io is None:
             raise ImageError("No IO loader defined")
-
-        # TO BE DEPRECATED--will just pass kwargs on through
-        if 'save_primary_header' not in kwargs:
-            kwargs['save_primary_header'] = self.save_primary_header
-        if 'inherit_primary_header' not in kwargs:
-            kwargs['inherit_primary_header'] = self.inherit_primary_header
 
         self.io.load_file(filespec, dstobj=self, **kwargs)
 
@@ -235,9 +205,7 @@ class AstroImage(BaseImage):
             hdr = self['header']
 
         if include_primary_header is None:
-            include_primary_header = (self.get('inherit_primary_header', False) or
-                                      # TO BE DEPRECATED
-                                      self.inherit_primary_header)
+            include_primary_header = self.get('inherit_primary_header', False)
 
         # If it was saved during loading, by convention, the primary fits
         # header is stored in a dictionary under the keyword 'primary_header'
@@ -287,12 +255,6 @@ class AstroImage(BaseImage):
     def set_keywords(self, **kwds):
         """Set an item in the fits header, if any."""
         return self.update_keywords(kwds)
-
-    def update_data(self, data_np, metadata=None, astype=None):
-        """DO NOT USE: this method will be deprecated!
-        """
-        self.set_data(data_np.copy(), metadata=metadata,
-                      astype=astype)
 
     def update_metadata(self, key_dict):
         self.update(key_dict)
@@ -394,86 +356,6 @@ class AstroImage(BaseImage):
             dec_deg = wcs.lat_to_deg(dec_deg)
         return self.wcs.radectopix(ra_deg, dec_deg, coords=coords,
                                    naxispath=self.revnaxis)
-
-    # -----> TODO:
-    #   This section has been merged into ginga.util.wcs or
-    #   ginga.util.mosaic .  Deprecate it here.
-    #
-    def get_starsep_XY(self, x1, y1, x2, y2):
-        warnings.warn("This function has been deprecated--"
-                      "use the version in ginga.util.wcs",
-                      DeprecationWarning)
-        return wcs.get_starsep_XY(self, x1, y1, x2, y2)
-
-    def calc_radius_xy(self, x, y, radius_deg):
-        warnings.warn("This function has been deprecated--"
-                      "use the version in ginga.util.wcs",
-                      DeprecationWarning)
-        return wcs.calc_radius_xy(self, x, y, radius_deg)
-
-    def calc_radius_deg2pix(self, ra_deg, dec_deg, delta_deg,
-                            equinox=None):
-        warnings.warn("This function has been deprecated--"
-                      "use the version in ginga.util.wcs",
-                      DeprecationWarning)
-        return wcs.calc_radius_deg2pix(self, ra_deg, dec_deg, delta_deg,
-                                       equinox=equinox)
-
-    def add_offset_xy(self, x, y, delta_deg_x, delta_deg_y):
-        warnings.warn("This function has been deprecated--"
-                      "use the version in ginga.util.wcs",
-                      DeprecationWarning)
-        return wcs.add_offset_xy(self, x, y, delta_deg_x, delta_deg_y)
-
-    def calc_radius_center(self, delta_deg):
-        warnings.warn("This function has been deprecated--"
-                      "use the version in ginga.util.wcs",
-                      DeprecationWarning)
-        return wcs.calc_radius_center(self, delta_deg)
-
-    def calc_compass(self, x, y, len_deg_e, len_deg_n):
-        warnings.warn("This function has been deprecated--"
-                      "use the version in ginga.util.wcs",
-                      DeprecationWarning)
-        return wcs.calc_compass(self, x, y, len_deg_e, len_deg_n)
-
-    def calc_compass_radius(self, x, y, radius_px):
-        warnings.warn("This function has been deprecated--"
-                      "use the version in ginga.util.wcs",
-                      DeprecationWarning)
-        return wcs.calc_compass_radius(self, x, y, radius_px)
-
-    def calc_compass_center(self):
-        warnings.warn("This function has been deprecated--"
-                      "use the version in ginga.util.wcs",
-                      DeprecationWarning)
-        return wcs.calc_compass_center(self)
-
-    def get_wcs_rotation_deg(self):
-        warnings.warn("This function has been deprecated--"
-                      "use get_rotation_and_scale in ginga.util.wcs",
-                      DeprecationWarning)
-        header = self.get_header()
-        (rot, cdelt1, cdelt2) = wcs.get_rotation_and_scale(header)
-        return rot
-
-    def mosaic_inline(self, imagelist, bg_ref=None, trim_px=None,
-                      merge=False, allow_expand=True, expand_pad_deg=0.01,
-                      max_expand_pct=None,
-                      update_minmax=True, suppress_callback=False):
-        warnings.warn("This function has been deprecated--"
-                      "use the version in ginga.util.mosaic",
-                      DeprecationWarning)
-        from ginga.util import mosaic
-        return mosaic.mosaic_inline(self, imagelist, bg_ref=bg_ref,
-                                    trim_px=trim_px, merge=merge,
-                                    allow_expand=allow_expand,
-                                    expand_pad_deg=expand_pad_deg,
-                                    max_expand_pct=max_expand_pct,
-                                    update_minmax=update_minmax,
-                                    suppress_callback=suppress_callback)
-    #
-    # <----- TODO: deprecate
 
     def info_xy(self, data_x, data_y, settings):
         info = super(AstroImage, self).info_xy(data_x, data_y, settings)

--- a/ginga/AutoCuts.py
+++ b/ginga/AutoCuts.py
@@ -5,7 +5,6 @@
 # Please see the file LICENSE.txt for details.
 #
 import numpy as np
-import warnings
 
 from ginga import trcalc
 from ginga.misc import Bunch

--- a/ginga/AutoCuts.py
+++ b/ginga/AutoCuts.py
@@ -446,11 +446,6 @@ class Histogram(AutoCutsBase):
         self.pct = pct
         self.numbins = numbins
 
-        if usecrop is not None:
-            warnings.warn("The usecrop parameter has been deprecated--"
-                          "use sample=crop inst",
-                          PendingDeprecationWarning)
-
     def calc_cut_levels(self, image):
         """See subclass documentation."""
         if self.sample == 'crop':
@@ -635,11 +630,6 @@ class StdDev(AutoCutsBase):
         # "stddev" algorithm (from the old SOSS fits viewer)
         self.hensa_lo = hensa_lo
         self.hensa_hi = hensa_hi
-
-        if usecrop is not None:
-            warnings.warn("The usecrop parameter has been deprecated--"
-                          "use sample=crop instead",
-                          PendingDeprecationWarning)
 
     def calc_cut_levels(self, image):
         """See subclass documentation."""

--- a/ginga/ImageView.py
+++ b/ginga/ImageView.py
@@ -1453,7 +1453,7 @@ class ImageViewBase(Callback.Callbacks):
         """
         return self.tform['mouse_to_data'].to_(win_pt)
 
-    def get_data_xy(self, win_x, win_y, center=None):
+    def get_data_xy(self, win_x, win_y):
         """Get the closest coordinates in the data array to those
         reported on the window.
 
@@ -1462,25 +1462,16 @@ class ImageViewBase(Callback.Callbacks):
         win_x, win_y : float or ndarray
             Window coordinates.
 
-        center : bool
-            If `True`, then the coordinates are mapped such that the
-            pixel is centered on the square when the image is zoomed in past
-            1X. This is the specification of the FITS image standard,
-            that the pixel is centered on the integer row/column.
-
         Returns
         -------
         coord : tuple
             Data coordinates in the form of ``(x, y)``.
 
         """
-        if center is not None:
-            self.logger.warning("`center` keyword is ignored and will be deprecated")
-
         arr_pts = np.asarray((win_x, win_y)).T
         return self.tform['mouse_to_data'].to_(arr_pts).T[:2]
 
-    def offset_to_data(self, off_x, off_y, center=None):
+    def offset_to_data(self, off_x, off_y):
         """Get the closest coordinates in the data array to those
         in cartesian fixed (non-scaled) canvas coordinates.
 
@@ -1495,9 +1486,6 @@ class ImageViewBase(Callback.Callbacks):
             Data coordinates in the form of ``(x, y)``.
 
         """
-        if center is not None:
-            self.logger.warning("`center` keyword is ignored and will be deprecated")
-
         arr_pts = np.asarray((off_x, off_y)).T
         return self.tform['data_to_cartesian'].from_(arr_pts).T[:2]
 
@@ -1508,23 +1496,17 @@ class ImageViewBase(Callback.Callbacks):
         """
         return self.tform['data_to_native'].to_(data_pt)
 
-    def get_canvas_xy(self, data_x, data_y, center=None):
+    def get_canvas_xy(self, data_x, data_y):
         """Reverse of :meth:`get_data_xy`.
 
         """
-        if center is not None:
-            self.logger.warning("`center` keyword is ignored and will be deprecated")
-
         arr_pts = np.asarray((data_x, data_y)).T
         return self.tform['data_to_native'].to_(arr_pts).T[:2]
 
-    def data_to_offset(self, data_x, data_y, center=None):
+    def data_to_offset(self, data_x, data_y):
         """Reverse of :meth:`offset_to_data`.
 
         """
-        if center is not None:
-            self.logger.warning("`center` keyword is ignored and will be deprecated")
-
         arr_pts = np.asarray((data_x, data_y)).T
         return self.tform['data_to_cartesian'].to_(arr_pts).T[:2]
 
@@ -1550,13 +1532,10 @@ class ImageViewBase(Callback.Callbacks):
         arr_pts = np.asarray((win_x, win_y)).T
         return self.tform['cartesian_to_native'].from_(arr_pts).T[:2]
 
-    def canvascoords(self, data_x, data_y, center=None):
+    def canvascoords(self, data_x, data_y):
         """Same as :meth:`get_canvas_xy`.
 
         """
-        if center is not None:
-            self.logger.warning("`center` keyword is ignored and will be deprecated")
-
         # data->canvas space coordinate conversion
         arr_pts = np.asarray((data_x, data_y)).T
         return self.tform['data_to_native'].to_(arr_pts).T[:2]
@@ -2952,10 +2931,6 @@ class ImageViewBase(Callback.Callbacks):
 
         """
         self.logger.warning("Subclass should override this abstract method!")
-
-    # TO BE DEPRECATED--please use update_widget
-    def update_image(self):
-        return self.update_widget()
 
     def reschedule_redraw(self, time_sec):
         """Reschedule redraw event.

--- a/ginga/Mixins.py
+++ b/ginga/Mixins.py
@@ -86,9 +86,3 @@ class UIMixin(object):
                 num -= 1
 
         return super(UIMixin, self).make_callback(name, *args, **kwargs)
-
-    ### NON-PEP8 EQUIVALENTS -- TO BE DEPRECATED ###
-    ui_isActive = ui_is_active
-    ui_setActive = ui_set_active
-
-# END

--- a/ginga/canvas/CanvasMixin.py
+++ b/ginga/canvas/CanvasMixin.py
@@ -150,20 +150,3 @@ class CanvasMixin(object):
 
         if redraw:
             self.update_canvas(whence=3)
-
-    ### NON-PEP8 EQUIVALENTS -- TO BE DEPRECATED ###
-
-    deleteObjectsByTag = delete_objects_by_tag
-    deleteObjectByTag = delete_object_by_tag
-    getObjectByTag = get_object_by_tag
-    getTagsByTagpfx = get_tags_by_tag_pfx
-    getObjectsByTagpfx = get_objects_by_tag_pfx
-    getObjectsByTagpfx = get_objects_by_tag_pfx
-    deleteAllObjects = delete_all_objects
-    deleteObjects = delete_objects
-    deleteObject = delete_object
-    raiseObjectByTag = raise_object_by_tag
-    lowerObjectByTag = lower_object_by_tag
-
-
-# END

--- a/ginga/canvas/CanvasObject.py
+++ b/ginga/canvas/CanvasObject.py
@@ -117,11 +117,7 @@ class CanvasObjectBase(Callback.Callbacks):
     def use_coordmap(self, mapobj):
         self.crdmap = mapobj
 
-    def canvascoords(self, viewer, data_x, data_y, center=None):
-        if center is not None:
-            self.logger.warn(
-                "`center` keyword is ignored and will be deprecated")
-
+    def canvascoords(self, viewer, data_x, data_y):
         return viewer.get_canvas_xy(data_x, data_y)
 
     def is_compound(self):

--- a/ginga/canvas/CompoundMixin.py
+++ b/ginga/canvas/CompoundMixin.py
@@ -250,17 +250,3 @@ class CompoundMixin(object):
         for obj in self.objects:
             res.extend(list(obj.get_points()))
         return res
-
-    ### NON-PEP8 EQUIVALENTS -- TO BE DEPRECATED ###
-
-    getItemsAt = get_items_at
-    getObjects = get_objects
-    deleteObject = delete_object
-    deleteObjects = delete_objects
-    deleteAllObjects = delete_all_objects
-    setAttrAll = set_attr_all
-    addObject = add_object
-    raiseObject = raise_object
-    lowerObject = lower_object
-
-# END

--- a/ginga/canvas/DrawingMixin.py
+++ b/ginga/canvas/DrawingMixin.py
@@ -731,11 +731,3 @@ class DrawingMixin(object):
             for obj in selected:
                 cr = viewer.renderer.setup_cr(obj)
                 obj.draw_edit(cr, viewer)
-
-    ### NON-PEP8 EQUIVALENTS -- TO BE DEPRECATED ###
-
-    setSurface = set_surface
-    getDrawClass = get_draw_class
-
-
-# END

--- a/ginga/canvas/coordmap.py
+++ b/ginga/canvas/coordmap.py
@@ -22,9 +22,6 @@ class BaseMapper(object):
     def __init__(self):
         super(BaseMapper, self).__init__()
 
-    def to_canvas(self, canvas_x, canvas_y):
-        raise CoordMapError("this method is deprecated")
-
     def to_data(self, pts):
         raise CoordMapError("subclass should override this method")
 

--- a/ginga/gw/PluginManager.py
+++ b/ginga/gw/PluginManager.py
@@ -495,14 +495,3 @@ class PluginManager(Callback.Callbacks):
         p_info.widget = None
         vbox.hide()
         vbox.delete()
-
-    ########################################################
-    ### NON-PEP8 PREDECESSORS: TO BE DEPRECATED
-
-    loadPlugin = load_plugin
-    reloadPlugin = reload_plugin
-    getPluginInfo = get_plugin_info
-    getPlugin = get_plugin
-    getNames = get_names
-
-# END

--- a/ginga/misc/CanvasTypes.py
+++ b/ginga/misc/CanvasTypes.py
@@ -1,3 +1,0 @@
-# THIS FILE TO BE DEPRECATED
-from ginga.gw.Viewers import *  # noqa
-from ginga.canvas.types.all import *  # noqa

--- a/ginga/misc/ModuleManager.py
+++ b/ginga/misc/ModuleManager.py
@@ -84,11 +84,3 @@ class ModuleManager(object):
 
         except KeyError:
             return sys.modules[module_name]
-
-    ########################################################
-    ### NON-PEP8 PREDECESSORS: TO BE DEPRECATED
-
-    loadModule = load_module
-    getModule = get_module
-
-# END

--- a/ginga/misc/Settings.py
+++ b/ginga/misc/Settings.py
@@ -277,18 +277,6 @@ class SettingGroup(object):
             errmsg = "Error writing settings output: %s" % (str(e))
             self.logger.error(errmsg)
 
-    ########################################################
-    ### NON-PEP8 PREDECESSORS: TO BE DEPRECATED
-
-    addSettings = add_settings
-    getSetting = get_setting
-    shareSettings = share_settings
-    copySettings = copy_settings
-    addDefaults = add_defaults
-    setDefaults = set_defaults
-    getDict = get_dict
-    setDict = set_dict
-
 
 class Preferences(object):
 
@@ -324,15 +312,6 @@ class Preferences(object):
     def get_dict(self):
         return dict([[name, self.settings[name].get_dict()] for name in
                      self.settings.keys()])
-
-    ########################################################
-    ### NON-PEP8 PREDECESSORS: TO BE DEPRECATED
-
-    setDefaults = set_defaults
-    getSettings = get_settings
-    createCategory = create_category
-    get_baseFolder = get_base_folder
-    getDict = get_dict
 
 
 def strip_comments(lines):

--- a/ginga/rv/Control.py
+++ b/ginga/rv/Control.py
@@ -2961,40 +2961,6 @@ class GingaShell(GwMain.GwMain, Widgets.Application):
             channel = self.get_channel(name)
             channel.fitsimage.onscreen_message(name, delay=2.5)
 
-    ########################################################
-    ### NON-PEP8 PREDECESSORS: TO BE DEPRECATED
-
-    def name_image_from_path(self, path, idx=None):
-        self.logger.warning("This function has moved to the"
-                            " 'ginga.util.iohelper' module,"
-                            " and will be deprecated soon.")
-        return iohelper.name_image_from_path(path, idx=idx)
-
-    def get_fileinfo(self, filespec, dldir=None):
-        self.logger.warning("This function has moved to the"
-                            " 'ginga.util.iohelper' module,"
-                            " and will be deprecated soon.")
-        return iohelper.get_fileinfo(filespec, cache_dir=dldir)
-
-    def stop_operation_channel(self, chname, opname):
-        self.logger.warning(
-            "Do not use this method name--it will be deprecated!")
-        return self.stop_local_plugin(chname, opname)
-
-    getDrawClass = get_draw_class
-    getDrawClasses = get_draw_classes
-    get_channelName = get_channel_name
-    get_channelInfo = get_channel_info
-    get_channelNames = get_channel_names
-    followFocus = follow_focus
-    showStatus = show_status
-    getfocus_fitsimage = getfocus_viewer
-    get_fitsimage = get_viewer
-    get_ServerBank = get_server_bank
-    getFont = get_font
-    getPluginManager = get_plugin_manager
-    statusMsg = status_msg
-
 
 class GuiLogHandler(logging.Handler):
     """Logs to a pane in the GUI."""

--- a/ginga/rv/main.py
+++ b/ginga/rv/main.py
@@ -272,9 +272,6 @@ class ReferenceViewer(object):
         add_argument("--numthreads", dest="numthreads", type=int,
                      default=30, metavar="NUM",
                      help="Start NUM threads in thread pool")
-        add_argument("--opencv", dest="opencv", default=False,
-                     action="store_true",
-                     help="Use OpenCv acceleration")
         add_argument("--opengl", dest="opengl", default=False,
                      action="store_true",
                      help="Use OpenGL acceleration")
@@ -455,11 +452,6 @@ class ReferenceViewer(object):
         except Exception as e:
             logger.warning(
                 "failed to set FITS package preference '{}': {}".format(fitspkg, e))
-
-        # Check whether user specified deprecated --opencv option
-        if options.opencv:
-            logger.warning("--opencv switch is deprecated; "
-                           "OpenCv will be used by default if installed")
 
         if options.opengl:
             settings.set(use_opengl=True)
@@ -711,32 +703,6 @@ class ReferenceViewer(object):
             ev_quit.set()
 
         sys.exit(0)
-
-    # TO BE DEPRECATED-- DO NOT USE!!!
-
-    def add_global_plugin_spec(self, spec):
-        if 'ptype' not in spec:
-            spec['ptype'] = 'global'
-        self.plugins.append(spec)
-
-    def add_local_plugin_spec(self, spec):
-        if 'ptype' not in spec:
-            spec['ptype'] = 'local'
-        self.plugins.append(spec)
-
-    def add_local_plugin(self, module_name, ws_name,
-                         path=None, klass=None, pfx=None, category=None):
-        self.add_plugin_spec(
-            Bunch(module=module_name, workspace=ws_name, category=category,
-                  ptype='local', path=path, klass=klass, pfx=pfx))
-
-    def add_global_plugin(self, module_name, ws_name,
-                          path=None, klass=None, category='Global',
-                          tab_name=None, start_plugin=True, pfx=None):
-        self.add_plugin_spec(
-            Bunch(module=module_name, workspace=ws_name, tab=tab_name,
-                  path=path, klass=klass, category=category,
-                  ptype='global', start=start_plugin, pfx=pfx))
 
 
 def reference_viewer(sys_argv):

--- a/ginga/table/TableView.py
+++ b/ginga/table/TableView.py
@@ -93,10 +93,6 @@ class TableViewBase(Callback.Callbacks):
     def get_table(self):
         return self._table
 
-    # TO BE DEPRECATED
-    get_image = get_table
-    set_image = set_table
-
     # for compatibility with other Ginga viewers
     get_dataobj = get_table
     set_dataobj = set_table

--- a/ginga/util/catalog.py
+++ b/ginga/util/catalog.py
@@ -671,15 +671,6 @@ class ServerBank(object):
 
         return obj.search(**params)
 
-    # TO BE DEPRECATED
-    addImageServer = add_image_server
-    addCatalogServer = add_catalog_server
-    getImageServer = get_image_server
-    getCatalogServer = get_catalog_server
-    getServerNames = get_server_names
-    getImage = get_image
-    getCatalog = get_catalog
-
 
 # ---- SET UP DEFAULT SOURCES ----
 

--- a/ginga/util/io_fits.py
+++ b/ginga/util/io_fits.py
@@ -80,12 +80,6 @@ def use(fitspkg, raise_err=True):
 
 class BaseFitsFileHandler(io_base.BaseIOHandler):
 
-    # TODO: remove in a future version
-    @classmethod
-    def register_type(cls, name, klass):
-        raise Exception("This method has been deprecated;"
-                        "you don't need to call it anymore.")
-
     def __init__(self, logger):
         super(BaseFitsFileHandler, self).__init__(logger)
 
@@ -531,16 +525,6 @@ class AstropyFitsFileHandler(BaseFitsFileHandler):
     def save_as_file(self, filepath, data, header, **kwargs):
         self.write_fits(filepath, data, header, **kwargs)
 
-    def fromHDU(self, hdu, ahdr):
-        warnings.warn("fromHDU will be deprecated in the next release--"
-                      "use copy_header instead",
-                      DeprecationWarning)
-        return self.copy_header(hdu, ahdr)
-
-
-# TO BE DEPRECATED
-PyFitsFileHandler = AstropyFitsFileHandler
-
 
 class FitsioFileHandler(BaseFitsFileHandler):
 
@@ -813,12 +797,6 @@ class FitsioFileHandler(BaseFitsFileHandler):
 
     def save_as_file(self, filepath, data, header, **kwargs):
         self.write_fits(filepath, data, header, **kwargs)
-
-    def fromHDU(self, hdu, ahdr):
-        warnings.warn("fromHDU will be deprecated in the next release--"
-                      "use copy_header instead",
-                      DeprecationWarning)
-        return self.copy_header(hdu, ahdr)
 
 
 if not fits_configured:

--- a/ginga/util/io_fits.py
+++ b/ginga/util/io_fits.py
@@ -18,7 +18,6 @@ any images.  Otherwise Ginga will try to pick one for you.
 """
 import re
 import numpy as np
-import warnings
 
 from ginga.AstroImage import AstroImage, AstroHeader
 from ginga.table.AstroTable import AstroTable

--- a/ginga/util/iqcalc.py
+++ b/ginga/util/iqcalc.py
@@ -719,7 +719,7 @@ class IQCalc(object):
 
     # EVALUATION ON A FIELD
 
-    def evaluate_peaks(self, peaks, data, bright_radius=2, fwhm_radius=15,
+    def evaluate_peaks(self, peaks, data, fwhm_radius=15,
                        fwhm_method='gaussian', ee_total_radius=10,
                        cb_fn=None, ev_intr=None):
         """Evaluate photometry for given peaks in data array.
@@ -731,9 +731,6 @@ class IQCalc(object):
 
         data : array-like
             Data array that goes with the given peaks.
-
-        bright_radius : int
-            **This is not used.**
 
         fwhm_radius, fwhm_method
             See :meth:`get_fwhm`.
@@ -749,6 +746,9 @@ class IQCalc(object):
 
         ev_intr : :py:class:`threading.Event` or `None`
             For threading, if applicable.
+
+        .. note:: unused parameter `bright_radius` was removed in
+                  release 4.0
 
         Returns
         -------
@@ -929,7 +929,7 @@ class IQCalc(object):
         results.sort(key=self._sortkey, reverse=True)
         return results
 
-    def pick_field(self, data, peak_radius=5, bright_radius=2, fwhm_radius=15,
+    def pick_field(self, data, peak_radius=5, fwhm_radius=15,
                    threshold=None,
                    minfwhm=2.0, maxfwhm=50.0, minelipse=0.5,
                    edgew=0.01, ee_total_radius=10):
@@ -943,11 +943,14 @@ class IQCalc(object):
         peak_radius, threshold
             See :meth:`find_bright_peaks`.
 
-        bright_radius, fwhm_radius, ee_total_radius
+        fwhm_radius, ee_total_radius
             See :meth:`evaluate_peaks`.
 
         minfwhm, maxfwhm, minelipse, edgew
             See :meth:`objlist_select`.
+
+        .. note:: unused parameter `bright_radius` was removed in
+                  release 4.0
 
         Returns
         -------
@@ -972,7 +975,6 @@ class IQCalc(object):
 
         # Evaluate those peaks
         objlist = self.evaluate_peaks(peaks, data,
-                                      bright_radius=bright_radius,
                                       fwhm_radius=fwhm_radius,
                                       ee_total_radius=ee_total_radius)
         if len(objlist) == 0:
@@ -987,7 +989,7 @@ class IQCalc(object):
         return results[0]
 
     def qualsize(self, image, x1=None, y1=None, x2=None, y2=None,
-                 radius=5, bright_radius=2, fwhm_radius=15, threshold=None,
+                 radius=5, fwhm_radius=15, threshold=None,
                  minfwhm=2.0, maxfwhm=50.0, minelipse=0.5,
                  edgew=0.01, ee_total_radius=10):
         """Run :meth:`pick_field` on the given image.
@@ -1003,11 +1005,14 @@ class IQCalc(object):
         radius, threshold
             See :meth:`find_bright_peaks`.
 
-        bright_radius, fwhm_radius, ee_total_radius
+        fwhm_radius, ee_total_radius
             See :meth:`evaluate_peaks`.
 
         minfwhm, maxfwhm, minelipse, edgew
             See :meth:`objlist_select`.
+
+        .. note:: unused parameter `bright_radius` was removed in
+                  release 4.0
 
         Returns
         -------
@@ -1029,7 +1034,6 @@ class IQCalc(object):
         data = image.cutout_data(x1, y1, x2, y2, astype=float)
 
         qs = self.pick_field(data, peak_radius=radius,
-                             bright_radius=bright_radius,
                              fwhm_radius=fwhm_radius,
                              threshold=threshold,
                              minfwhm=minfwhm, maxfwhm=maxfwhm,

--- a/ginga/util/wcs.py
+++ b/ginga/util/wcs.py
@@ -786,30 +786,3 @@ def calc_compass_center(image):
     radius_px = float(min(image.width, image.height)) / 4.0
 
     return calc_compass_radius(image, x, y, radius_px)
-
-
-# TO BE DEPRECATED
-
-def raDegToString(ra_deg, format=None):
-    warnings.warn("This function has been deprecated--"
-                  "use ra_deg_to_str instead", DeprecationWarning)
-    if format is None:
-        return ra_deg_to_str(ra_deg)
-    if ra_deg > 360.0:
-        ra_deg = math.fmod(ra_deg, 360.0)
-
-    ra_hour, ra_min, ra_sec = degToHms(ra_deg)
-    return format % (ra_hour, ra_min, ra_sec)
-
-
-def decDegToString(dec_deg, format=None):
-    warnings.warn("This function has been deprecated--"
-                  "use dec_deg_to_str instead", DeprecationWarning)
-    if format is None:
-        return dec_deg_to_str(dec_deg)
-    sign, dec_degree, dec_min, dec_sec = degToDms(dec_deg)
-    if sign > 0:
-        sign_sym = '+'
-    else:
-        sign_sym = '-'
-    return format % (sign_sym, int(dec_degree), int(dec_min), dec_sec)

--- a/ginga/util/wcs.py
+++ b/ginga/util/wcs.py
@@ -6,7 +6,6 @@
 #
 """This module handles calculations based on world coordinate system."""
 import math
-import warnings
 from collections import OrderedDict
 
 import numpy as np
@@ -20,7 +19,7 @@ __all__ = ['hmsToDeg', 'dmsToDeg', 'decTimeToDeg', 'degToHms', 'degToDms',
            'get_relative_orientation', 'simple_wcs', 'deg2fmt', 'dispos',
            'deltaStarsRaDecDeg1', 'deltaStarsRaDecDeg2', 'get_starsep_RaDecDeg',
            'add_offset_radec', 'get_RaDecOffsets', 'lon_to_deg', 'lat_to_deg',
-           'raDegToString', 'decDegToString',
+           'ra_deg_to_str', 'dec_deg_to_str',
            ]
 
 

--- a/ginga/web/pgw/ipg.py
+++ b/ginga/web/pgw/ipg.py
@@ -453,15 +453,11 @@ class WebServer(object):
 
 
 def make_server(logger=None, basedir='.', numthreads=5,
-                host='localhost', port=9909, viewer_class=None,
-                use_opencv=None):
+                host='localhost', port=9909, viewer_class=None):
 
     if logger is None:
         logger = log.get_logger("ipg", null=True)
     ev_quit = threading.Event()
-
-    if use_opencv is not None:
-        logger.warning("use_opencv parameter is deprecated, OpenCv will be used if installed")
 
     base_url = "http://%s:%d/app" % (host, port)
     app = Widgets.Application(logger=logger, base_url=base_url,


### PR DESCRIPTION
This removes a number of camel-case deprecated methods.  It is targeted for release 4.0.

There are a few other deprecated items also removed.

supercedes #990
fix #898