### PR TITLE
Make pillow a required package, change piexif to exifread

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -23,14 +23,14 @@ REQUIRED
 * setuptools-scm
 * numpy  (v. 1.14 or higher)
 * astropy
+* pillow
 
 Strongly recommended, because some features will not be available without it:
 
 * scipy
-* pillow
 * opencv-python (also distributed as opencv or python-opencv,
   depending on where you get it from)
-* piexif
+* exifread
 * beautifulsoup4
 * docutils (to display help for plugins)
 

--- a/ginga/canvas/render.py
+++ b/ginga/canvas/render.py
@@ -7,14 +7,7 @@
 from io import BytesIO
 
 import numpy as np
-
-
-try:
-    import PIL.Image as PILimage
-    have_PIL = True
-
-except ImportError:
-    have_PIL = False
+from PIL import Image
 
 from ginga import trcalc, RGBMap
 from ginga.fonts import font_asst
@@ -138,9 +131,6 @@ class RendererBase(object):
 
     def get_surface_as_rgb_format_buffer(self, output=None, format='png',
                                          quality=90):
-        if not have_PIL:
-            raise RenderError("Please install PIL to use this method")
-
         if self.surface is None:
             raise RenderError("No surface defined")
 
@@ -154,7 +144,7 @@ class RendererBase(object):
             obuf = BytesIO()
 
         # make a PIL image
-        image = PILimage.fromarray(arr8)
+        image = Image.fromarray(arr8)
 
         image.save(obuf, format=format, quality=quality)
         if output is not None:
@@ -168,9 +158,6 @@ class RendererBase(object):
 
     def save_surface_as_rgb_format_file(self, filepath, format='png',
                                         quality=90):
-        if not have_PIL:
-            raise RenderError("Please install PIL to use this method")
-
         if self.surface is None:
             raise RenderError("No surface defined")
 

--- a/ginga/rv/plugins/Compose.py
+++ b/ginga/rv/plugins/Compose.py
@@ -85,11 +85,7 @@ from ginga.misc import Bunch
 from ginga import RGBImage, LayerImage, AstroImage
 from ginga import GingaPlugin
 
-try:
-    from PIL import Image
-    have_PIL = True
-except ImportError:
-    have_PIL = False
+from PIL import Image
 
 __all__ = ['Compose']
 
@@ -392,9 +388,6 @@ class Compose(GingaPlugin.LocalPlugin):
         fimage.save_as_file(path)
 
     def save_rgb_as_file(self, path):
-        if not have_PIL:
-            raise Exception("You need to install PIL or pillow to save images")
-
         fimage = self.create_image()
         data = fimage.get_data()
         # Save image using PIL

--- a/ginga/tkw/ImageViewTk.py
+++ b/ginga/tkw/ImageViewTk.py
@@ -4,7 +4,7 @@
 # This is open-source software licensed under a BSD license.
 # Please see the file LICENSE.txt for details.
 #
-import PIL.Image as PILimage
+from PIL import Image
 
 have_pil_imagetk = False
 try:
@@ -113,7 +113,7 @@ class ImageViewTk(ImageView.ImageViewBase):
         if have_pil_imagetk:
             # Get surface as a numpy array
             arr8 = self.renderer.get_surface_as_array(order='RGB')
-            image = PILimage.fromarray(arr8)
+            image = Image.fromarray(arr8)
             photo = PhotoImage(image)
 
         else:

--- a/ginga/trcalc.py
+++ b/ginga/trcalc.py
@@ -29,8 +29,7 @@ pil_resize = dict(nearest=Image.NEAREST,
                   bicubic=Image.BICUBIC,
                   lanczos=Image.LANCZOS)
 
-interpolation_methods = list(set(['basic'] + list(pil_resize.keys())))
-interpolation_methods.sort()
+interpolation_methods = sorted(set(['basic'] + list(pil_resize.keys())))
 
 have_opencv = False
 try:
@@ -44,8 +43,7 @@ try:
                       lanczos=cv2.INTER_LANCZOS4)
     have_opencv = True
 
-    interpolation_methods = list(set(['basic'] + list(cv2_resize.keys())))
-    interpolation_methods.sort()
+    interpolation_methods = sorted(set(['basic'] + list(cv2_resize.keys())))
 
 except ImportError:
     pass

--- a/ginga/trcalc.py
+++ b/ginga/trcalc.py
@@ -8,7 +8,6 @@ import sys
 import math
 import numpy as np
 
-interpolation_methods = ['basic']
 _use = None
 
 
@@ -22,52 +21,37 @@ def use(pkgname):
         _use = 'pillow'
 
 
+# Python Imaging Library
+from PIL import Image
+pil_resize = dict(nearest=Image.NEAREST,
+                  linear=Image.BILINEAR,
+                  area=Image.HAMMING,
+                  bicubic=Image.BICUBIC,
+                  lanczos=Image.LANCZOS)
+
+interpolation_methods = list(set(['basic'] + list(pil_resize.keys())))
+interpolation_methods.sort()
+
 have_opencv = False
 try:
     # optional opencv package speeds up certain operations, especially
     # rotation
     import cv2
-    cv2_resize = {
-        'nearest': cv2.INTER_NEAREST,
-        'linear': cv2.INTER_LINEAR,
-        'area': cv2.INTER_AREA,
-        'bicubic': cv2.INTER_CUBIC,
-        'lanczos': cv2.INTER_LANCZOS4,
-    }
+    cv2_resize = dict(nearest=cv2.INTER_NEAREST,
+                      linear=cv2.INTER_LINEAR,
+                      area=cv2.INTER_AREA,
+                      bicubic=cv2.INTER_CUBIC,
+                      lanczos=cv2.INTER_LANCZOS4)
     have_opencv = True
 
-    if 'nearest' not in interpolation_methods:
-        interpolation_methods = list(set(['basic'] +
-                                         list(cv2_resize.keys())))
-        interpolation_methods.sort()
-
-except ImportError:
-    pass
-
-have_pillow = False
-try:
-    # do we have Python Imaging Library available?
-    import PIL.Image as PILimage
-    pil_resize = {
-        'nearest': PILimage.NEAREST,
-        'linear': PILimage.BILINEAR,
-        'area': PILimage.HAMMING,
-        'bicubic': PILimage.BICUBIC,
-        'lanczos': PILimage.LANCZOS,
-    }
-    have_pillow = True
-
-    if 'nearest' not in interpolation_methods:
-        interpolation_methods = list(set(['basic'] +
-                                         list(pil_resize.keys())))
-        interpolation_methods.sort()
+    interpolation_methods = list(set(['basic'] + list(cv2_resize.keys())))
+    interpolation_methods.sort()
 
 except ImportError:
     pass
 
 # For testing
 #have_opencv = False
-#have_pillow = False
 
 
 def get_center(data_np):
@@ -153,10 +137,10 @@ def rotate_clip(data_np, theta_deg, rotctr_x=None, rotctr_y=None,
             out[:, :, ...] = newdata
             newdata = out
 
-    elif dtype == np.uint8 and have_pillow and _use in (None, 'pillow'):
+    elif dtype == np.uint8 and _use in (None, 'pillow'):
         if logger is not None:
             logger.debug("rotating with pillow")
-        img = PILimage.fromarray(data_np)
+        img = Image.fromarray(data_np)
         img_rot = img.rotate(theta_deg, resample=False, expand=False,
                              center=(rotctr_x, rotctr_y))
         newdata = np.array(img_rot, dtype=data_np.dtype)
@@ -391,13 +375,13 @@ def get_scaled_cutout_wdht(data_np, x1, y1, x2, y2, new_wd, new_ht,
         ht, wd = newdata.shape[:2]
         scale_x, scale_y = float(wd) / old_wd, float(ht) / old_ht
 
-    elif data_np.dtype == np.uint8 and have_pillow and _use in (None, 'pillow'):
+    elif data_np.dtype == np.uint8 and _use in (None, 'pillow'):
         if logger is not None:
             logger.info("resizing with pillow")
         if interpolation == 'basic':
             interpolation = 'nearest'
         method = pil_resize[interpolation]
-        img = PILimage.fromarray(data_np[y1:y2 + 1, x1:x2 + 1])
+        img = Image.fromarray(data_np[y1:y2 + 1, x1:x2 + 1])
         img_siz = img.resize((new_wd, new_ht), resample=method)
         newdata = np.array(img_siz, dtype=dtype)
 
@@ -487,13 +471,13 @@ def get_scaled_cutout_basic(data_np, x1, y1, x2, y2, scale_x, scale_y,
         ht, wd = newdata.shape[:2]
         scale_x, scale_y = float(wd) / old_wd, float(ht) / old_ht
 
-    elif data_np.dtype == np.uint8 and have_pillow and _use in (None, 'pillow'):
+    elif data_np.dtype == np.uint8 and _use in (None, 'pillow'):
         if logger is not None:
             logger.info("resizing with pillow")
         if interpolation == 'basic':
             interpolation = 'nearest'
         method = pil_resize[interpolation]
-        img = PILimage.fromarray(data_np[y1:y2 + 1, x1:x2 + 1])
+        img = Image.fromarray(data_np[y1:y2 + 1, x1:x2 + 1])
         old_wd, old_ht = max(x2 - x1 + 1, 1), max(y2 - y1 + 1, 1)
         new_wd, new_ht = int(scale_x * old_wd), int(scale_y * old_ht)
         img_siz = img.resize((new_wd, new_ht), resample=method)
@@ -630,8 +614,8 @@ def overlay_image_2d_pil(dstarr, pos, srcarr, dst_order='RGBA',
 
     if dst_order != src_order:
         srcarr = reorder_image(dst_order, srcarr, src_order)
-    img_dst = PILimage.fromarray(dstarr)
-    img_src = PILimage.fromarray(srcarr)
+    img_dst = Image.fromarray(dstarr)
+    img_src = Image.fromarray(srcarr)
 
     mask = img_src
     if 'A' not in src_order:
@@ -748,10 +732,9 @@ def overlay_image_2d(dstarr, pos, srcarr, dst_order='RGBA',
                      src_order='RGBA',
                      alpha=1.0, copy=False, fill=False, flipy=False):
     # NOTE: not tested yet thoroughly enough to use
-    # if have_pillow:
-    #     return overlay_image_2d_pil(dstarr, pos, srcarr, dst_order=dst_order,
-    #                                 src_order=src_order, alpha=alpha,
-    #                                 copy=copy, fill=fill, flipy=flipy)
+    # return overlay_image_2d_pil(dstarr, pos, srcarr, dst_order=dst_order,
+    #                             src_order=src_order, alpha=alpha,
+    #                             copy=copy, fill=fill, flipy=flipy)
 
     return overlay_image_2d_np(dstarr, pos, srcarr, dst_order=dst_order,
                                src_order=src_order, alpha=alpha,

--- a/ginga/util/loader.py
+++ b/ginga/util/loader.py
@@ -170,9 +170,8 @@ if io_asdf.have_asdf:
 # because it supports higher bit depths.
 mimetypes = ['image/jpeg', 'image/png', 'image/tiff', 'image/gif',
              'image/ppm', 'image/pnm', 'image/pbm']
+add_opener(io_rgb.PillowFileHandler, mimetypes, priority=1,
+           note="For loading common RGB image formats (e.g. JPEG, etc)")
 if io_rgb.have_opencv:
     add_opener(io_rgb.OpenCvFileHandler, mimetypes, priority=0,
-               note="For loading common RGB image formats (e.g. JPEG, etc)")
-if io_rgb.have_pil:
-    add_opener(io_rgb.PillowFileHandler, mimetypes, priority=1,
                note="For loading common RGB image formats (e.g. JPEG, etc)")

--- a/ginga/util/rgb_cms.py
+++ b/ginga/util/rgb_cms.py
@@ -15,10 +15,10 @@ from ginga.misc import Bunch
 
 from . import paths
 
+from PIL import Image
 # How about color management (ICC profile) support?
 try:
     import PIL.ImageCms as ImageCms
-    from PIL import Image
     have_cms = True
 except ImportError:
     have_cms = False

--- a/ginga/util/stages/output.py
+++ b/ginga/util/stages/output.py
@@ -3,6 +3,8 @@
 #
 import os.path
 
+from PIL import Image
+
 from ginga.gw import Widgets
 from ginga.util.paths import ginga_home
 
@@ -159,8 +161,6 @@ class Output(Stage):
         self._save_as(path, data)
 
     def _save_as(self, path, data, format='jpeg', quality=90):
-        from PIL import Image
-
         # TEMP: need to get the color profile passed through the pipeline
         profile_file = os.path.join(ginga_home, "profiles", "AdobeRGB.icc")
         with open(profile_file, 'rb') as in_f:

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,16 +49,16 @@ install_requires =
     numpy>=1.14
     qtpy>=1.1
     astropy>=3.2
+    pillow>=3.2.0
     importlib-metadata ; python_version == '3.7'
 setup_requires = setuptools_scm
 
 [options.extras_require]
 recommended =
-    pillow>=3.2.0
     scipy>=0.18.1
     matplotlib>=2.1
     opencv-python>=4.5.4.58
-    piexif>=1.0.13
+    exifread>=2.3.2
     beautifulsoup4>=4.3.2
     astroquery>=0.3.5
     docutils


### PR DESCRIPTION
Since we are planning to deprecate the mock backend, and `pillow` is used in many places, as well as being a very common package, this adds `pillow` as a requirement.  It also changes the optional `piexif` package to `exifread`, which is a little less code verbose to use, a bit more popular and well maintained.

This also restores a couple of lines needed in the OpenCv RGB file handler to make auto-orientation of RGB images work correctly.