### PR TITLE
MNT: Replace deprecated PIL calls

### DIFF
--- a/ginga/rv/plugins/SaveImage.py
+++ b/ginga/rv/plugins/SaveImage.py
@@ -36,9 +36,7 @@ import os
 import shutil
 
 # THIRD-PARTY
-import astropy
 from astropy.io import fits
-from astropy.utils.introspection import minversion
 
 # GINGA
 from ginga.GingaPlugin import GlobalPlugin
@@ -412,10 +410,7 @@ class SaveImage(GlobalPlugin):
         self._write_history(key, hdu)
 
         # Write to file
-        if minversion(astropy, '1.3'):
-            hdu.writeto(outfile, overwrite=True)
-        else:
-            hdu.writeto(outfile, clobber=True)
+        hdu.writeto(outfile, overwrite=True)
 
     def _write_mef(self, key, extlist, outfile):
         """Write out regular multi-extension FITS data."""

--- a/ginga/tests/test_wcs.py
+++ b/ginga/tests/test_wcs.py
@@ -1,7 +1,6 @@
 import logging
 import warnings
 
-import astropy
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose

--- a/ginga/tests/test_wcs.py
+++ b/ginga/tests/test_wcs.py
@@ -4,7 +4,6 @@ import warnings
 import astropy
 import numpy as np
 import pytest
-from astropy.utils.introspection import minversion
 from numpy.testing import assert_allclose
 
 from ginga import AstroImage
@@ -231,15 +230,8 @@ def setup_module():
     """Create objects once and re-use throughout this module."""
     global img_dict
 
-    if minversion(astropy, '3.1'):
-        USE_APE14 = True
-    else:
-        USE_APE14 = False
-
     img_dict = {}
     for modname in _wcsmods:
-        if modname == 'astropy_ape14' and not USE_APE14:
-            continue
         if not wcsmod.use(modname, raise_err=False):
             continue
         img_dict[modname] = {}

--- a/ginga/trcalc.py
+++ b/ginga/trcalc.py
@@ -23,11 +23,11 @@ def use(pkgname):
 
 # Python Imaging Library
 from PIL import Image
-pil_resize = dict(nearest=Image.NEAREST,
-                  linear=Image.BILINEAR,
-                  area=Image.HAMMING,
-                  bicubic=Image.BICUBIC,
-                  lanczos=Image.LANCZOS)
+pil_resize = dict(nearest=Image.Resampling.NEAREST,
+                  linear=Image.Resampling.BILINEAR,
+                  area=Image.Resampling.HAMMING,
+                  bicubic=Image.Resampling.BICUBIC,
+                  lanczos=Image.Resampling.LANCZOS)
 
 interpolation_methods = sorted(set(['basic'] + list(pil_resize.keys())))
 

--- a/ginga/trcalc.py
+++ b/ginga/trcalc.py
@@ -8,6 +8,8 @@ import sys
 import math
 import numpy as np
 
+from ginga.util.toolbox import PIL_LT_9_1
+
 _use = None
 
 
@@ -23,11 +25,18 @@ def use(pkgname):
 
 # Python Imaging Library
 from PIL import Image
-pil_resize = dict(nearest=Image.Resampling.NEAREST,
-                  linear=Image.Resampling.BILINEAR,
-                  area=Image.Resampling.HAMMING,
-                  bicubic=Image.Resampling.BICUBIC,
-                  lanczos=Image.Resampling.LANCZOS)
+if PIL_LT_9_1:
+    pil_resize = dict(nearest=Image.NEAREST,
+                      linear=Image.BILINEAR,
+                      area=Image.HAMMING,
+                      bicubic=Image.BICUBIC,
+                      lanczos=Image.LANCZOS)
+else:
+    pil_resize = dict(nearest=Image.Resampling.NEAREST,
+                      linear=Image.Resampling.BILINEAR,
+                      area=Image.Resampling.HAMMING,
+                      bicubic=Image.Resampling.BICUBIC,
+                      lanczos=Image.Resampling.LANCZOS)
 
 interpolation_methods = sorted(set(['basic'] + list(pil_resize.keys())))
 

--- a/ginga/util/rgb_cms.py
+++ b/ginga/util/rgb_cms.py
@@ -12,6 +12,7 @@ import tempfile
 import numpy as np
 
 from ginga.misc import Bunch
+from ginga.util.toolbox import PIL_LT_9_1
 
 from . import paths
 
@@ -331,10 +332,16 @@ for path in glob.glob(glob_pat):
                                     path=os.path.abspath(path))
 
 if have_cms:
-    d = dict(absolute_colorimetric=ImageCms.Intent.ABSOLUTE_COLORIMETRIC,
-             perceptual=ImageCms.Intent.PERCEPTUAL,
-             relative_colorimetric=ImageCms.Intent.RELATIVE_COLORIMETRIC,
-             saturation=ImageCms.Intent.SATURATION)
+    if PIL_LT_9_1:
+        d = dict(absolute_colorimetric=ImageCms.INTENT_ABSOLUTE_COLORIMETRIC,
+                 perceptual=ImageCms.INTENT_PERCEPTUAL,
+                 relative_colorimetric=ImageCms.INTENT_RELATIVE_COLORIMETRIC,
+                 saturation=ImageCms.INTENT_SATURATION)
+    else:
+        d = dict(absolute_colorimetric=ImageCms.Intent.ABSOLUTE_COLORIMETRIC,
+                 perceptual=ImageCms.Intent.PERCEPTUAL,
+                 relative_colorimetric=ImageCms.Intent.RELATIVE_COLORIMETRIC,
+                 saturation=ImageCms.Intent.SATURATION)
     intents.update(d)
 
     # Build transforms for profile conversions for which we have profiles

--- a/ginga/util/rgb_cms.py
+++ b/ginga/util/rgb_cms.py
@@ -331,10 +331,10 @@ for path in glob.glob(glob_pat):
                                     path=os.path.abspath(path))
 
 if have_cms:
-    d = dict(absolute_colorimetric=ImageCms.INTENT_ABSOLUTE_COLORIMETRIC,
-             perceptual=ImageCms.INTENT_PERCEPTUAL,
-             relative_colorimetric=ImageCms.INTENT_RELATIVE_COLORIMETRIC,
-             saturation=ImageCms.INTENT_SATURATION)
+    d = dict(absolute_colorimetric=ImageCms.Intent.ABSOLUTE_COLORIMETRIC,
+             perceptual=ImageCms.Intent.PERCEPTUAL,
+             relative_colorimetric=ImageCms.Intent.RELATIVE_COLORIMETRIC,
+             saturation=ImageCms.Intent.SATURATION)
     intents.update(d)
 
     # Build transforms for profile conversions for which we have profiles

--- a/ginga/util/toolbox.py
+++ b/ginga/util/toolbox.py
@@ -12,18 +12,22 @@ import warnings
 
 # THIRD-PARTY
 import astropy
+import PIL
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.utils.introspection import minversion
 
 ASTROPY_LT_4_3 = not minversion(astropy, '4.3')
+PIL_LT_9_1 = not minversion(PIL, '9.1')
 
 if ASTROPY_LT_4_3:
     from astropy.utils.data import _find_pkg_data_path as get_pkg_data_path
 else:
     from astropy.utils.data import get_pkg_data_path
 
+__all__ = ['ModeIndicator', 'trim_prefix', 'generate_cfg_example', 'ASTROPY_LT_4_3', 'PIL_LT_9_1']
 
-class ModeIndicator(object):
+
+class ModeIndicator:
     """
     This class adds a mode status indicator to a viewer's lower right-hand
     corner.


### PR DESCRIPTION
This pull request is to get rid of these warnings in CI that appeared with Pillow 9.1.0 release:

`DeprecationWarning: XXX is deprecated and will be removed in Pillow 10 (2023-07-01). Use Resampling.XXX instead.`

` DeprecationWarning: XXX is deprecated and will be removed in Pillow 10 (2023-07-01). Use Intent.XXX instead.`