### PR TITLE
DOC: Update RTD env

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,6 +2,13 @@
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 version: 2
 
+build:
+  os: ubuntu-20.04
+  apt_packages:
+    - graphviz
+  tools:
+    python: "3.9"
+
 sphinx:
   builder: html
   configuration: doc/conf.py
@@ -9,7 +16,6 @@ sphinx:
 
 # Set the version of Python and requirements required to build your docs
 python:
-  version: 3.8
   system_packages: false
   install:
     - method: pip


### PR DESCRIPTION
RTD has changed their way to specify Python version. We are using the same thing in `astropy`, so should be uncontroversial.