### PR TITLE
Add option to suppress FITS verify warnings from astropy.io.fits

### DIFF
--- a/doc/WhatsNew.rst
+++ b/doc/WhatsNew.rst
@@ -18,6 +18,8 @@ Ver 3.4.0 (unreleased)
   mosaicing using the 'warp' method
 - fixed an issue with numpy floats and drawing lines and ploygons with
   the Qt backend
+- add option for suppressing FITS verify warnings when opening files
+  using astropy.io.fits
 
 Ver 3.3.0 (2022-02-16)
 ======================

--- a/ginga/examples/configs/general.cfg
+++ b/ginga/examples/configs/general.cfg
@@ -83,6 +83,10 @@ FITSpkg = 'choose'
 #FITSpkg = 'astropy'
 #FITSpkg = 'fitsio'
 
+# set to True to suppress warnings from astropy.io.fits when verifying
+# FITS files
+suppress_fits_warnings = False
+
 # Set python recursion limit
 # NOTE: Python's default of 1000 causes problems for the standard logging
 # package that Ginga uses in certain situations.  Best to increase it a bit.

--- a/ginga/rv/main.py
+++ b/ginga/rv/main.py
@@ -286,6 +286,10 @@ class ReferenceViewer(object):
         add_argument("--sep", dest="separate_channels", default=False,
                      action="store_true",
                      help="Load files in separate channels")
+        add_argument("--suppress-fits-warnings",
+                     dest="suppress_fits_warnings", default=False,
+                     action="store_true",
+                     help="Suppress FITS verify warnings")
         add_argument("-t", "--toolkit", dest="toolkit", metavar="NAME",
                      default=None,
                      help="Prefer GUI toolkit (gtk|qt)")
@@ -329,6 +333,7 @@ class ReferenceViewer(object):
         settings.set_defaults(useMatplotlibColormaps=False,
                               widgetSet='choose',
                               WCSpkg='choose', FITSpkg='choose',
+                              suppress_fits_warnings=False,
                               recursion_limit=2000,
                               icc_working_profile=None,
                               font_scaling_factor=None,
@@ -429,10 +434,16 @@ class ReferenceViewer(object):
         else:
             fitspkg = settings.get('FITSpkg', 'choose')
 
+        if options.suppress_fits_warnings:
+            supp_warn = options.suppress_fits_warnings
+        else:
+            supp_warn = settings.get('suppress_fits_warnings', False)
+
         try:
             from ginga.util import io_fits, loader
             if fitspkg != 'choose':
-                assert io_fits.use(fitspkg) is True
+                assert io_fits.use(fitspkg,
+                                   suppress_verify_warnings=supp_warn) is True
                 # opener name is not necessarily the same
                 opener = loader.get_opener(io_fits.fitsLoaderClass.name)
                 # set this opener as the priority one

--- a/ginga/rv/main.py
+++ b/ginga/rv/main.py
@@ -302,7 +302,7 @@ class ReferenceViewer(object):
         """
         Main routine for running the reference viewer.
 
-        `options` is a OptionParser object that has been populated with
+        `options` is a ArgumentParser object that has been populated with
         values from parsing the command line.  It should at least include
         the options from add_default_options()
 
@@ -438,6 +438,10 @@ class ReferenceViewer(object):
             supp_warn = options.suppress_fits_warnings
         else:
             supp_warn = settings.get('suppress_fits_warnings', False)
+        if supp_warn:
+            import warnings
+            from astropy.io import fits
+            warnings.simplefilter('ignore', fits.verify.VerifyWarning)
 
         try:
             from ginga.util import io_fits, loader

--- a/ginga/util/io_fits.py
+++ b/ginga/util/io_fits.py
@@ -48,12 +48,14 @@ class FITSError(Exception):
     pass
 
 
-def use(fitspkg, raise_err=True):
+def use(fitspkg, raise_err=True, suppress_verify_warnings=False):
     global fits_configured, fitsLoaderClass
 
     if fitspkg == 'astropy':
         if have_astropy:
             fitsLoaderClass = AstropyFitsFileHandler
+            if suppress_verify_warnings:
+                warnings.simplefilter('ignore', pyfits.verify.VerifyWarning)
             fits_configured = True
             return True
 

--- a/ginga/util/io_fits.py
+++ b/ginga/util/io_fits.py
@@ -48,14 +48,12 @@ class FITSError(Exception):
     pass
 
 
-def use(fitspkg, raise_err=True, suppress_verify_warnings=False):
+def use(fitspkg, raise_err=True):
     global fits_configured, fitsLoaderClass
 
     if fitspkg == 'astropy':
         if have_astropy:
             fitsLoaderClass = AstropyFitsFileHandler
-            if suppress_verify_warnings:
-                warnings.simplefilter('ignore', pyfits.verify.VerifyWarning)
             fits_configured = True
             return True
 


### PR DESCRIPTION
This PR adds an option to suppress FITS verification warnings when using `astropy.io.fits` as the FITS file opener.
It is opt-in, and can be invoked by adding `--suppress-fits-warnings` to the command line, or by adding `suppress_fits_warnings = True` to the `general.cfg` configuration file in the user's `$HOME/.ginga` folder.

- fix #997