### PR TITLE
Fixed a longstanding issue for event handling on a ginga canvas

### DIFF
--- a/doc/WhatsNew.rst
+++ b/doc/WhatsNew.rst
@@ -6,6 +6,13 @@ Ver 4.0.0 (unreleased)
 ======================
 - fixed getattr functionality in Bunch
 - removed the "mock" backend; use "pil" backend for similar purposes
+- fixed a longstanding issue where events registered on a canvas could
+  be masked by default key/cursor bindings (not associated with a mode).
+  This meant, for example, that only certain keystrokes could be
+  captured by an event handler registered on a ginga canvas, because any
+  keystrokes that had a default binding would take precedence.
+  Now such bindings are only executed if the event is not handled by any
+  active canvas bindings.
 
 Ver 3.4.0 (2022-06-28)
 ======================

--- a/ginga/Bindings.py
+++ b/ginga/Bindings.py
@@ -2885,7 +2885,7 @@ class BindingMapper(Callback.Callbacks):
                     cbname = 'key-up-%s' % str(self._kbdmode).lower()
 
         res = viewer.make_ui_callback_viewer(viewer, cbname, event,
-                                                 last_x, last_y)
+                                             last_x, last_y)
 
         if not event.was_handled() and not res:
             # no response for this canvas or mode, try non-mode entry

--- a/ginga/ImageView.py
+++ b/ginga/ImageView.py
@@ -2311,8 +2311,8 @@ class ImageViewBase(Callback.Callbacks):
 
         """
         option = option.lower()
-        assert(option in self.autocenter_options), \
-            ImageViewError("Bad autocenter option '%s': must be one of %s" % (
+        if option not in self.autocenter_options:
+            raise ImageViewError("Bad autocenter option '%s': must be one of %s" % (
                 str(self.autocenter_options)))
         self.t_.set(autocenter=option)
 
@@ -2439,8 +2439,8 @@ class ImageViewBase(Callback.Callbacks):
 
         """
         option = option.lower()
-        assert(option in self.autocuts_options), \
-            ImageViewError("Bad autocuts option '%s': must be one of %s" % (
+        if option not in self.autocuts_options:
+            raise ImageViewError("Bad autocuts option '%s': must be one of %s" % (
                 str(self.autocuts_options)))
         self.t_.set(autocuts=option)
 

--- a/ginga/canvas/CanvasObject.py
+++ b/ginga/canvas/CanvasObject.py
@@ -286,7 +286,7 @@ class CanvasObjectBase(Callback.Callbacks):
         self.move_delta_pt(off_pt)
 
     def get_num_points(self):
-        return(len(self.points))
+        return len(self.points)
 
     def set_point_by_index(self, i, pt):
         #self.points[i] = self.crdmap.data_to(pt)

--- a/ginga/examples/gw/widgets.py
+++ b/ginga/examples/gw/widgets.py
@@ -265,7 +265,7 @@ def show_example(cbox, top, logger):
         _vbox.add_widget(value_label)
         # Test set_tracking
         b = Widgets.Button("Tracking on/off")
-        b.add_callback('activated', lambda r: w.set_tracking(not(w.track)))
+        b.add_callback('activated', lambda r: w.set_tracking(not w.track))
         _vbox.add_widget(b)
         # Test set_value dynamically
         hbox = Widgets.HBox()

--- a/ginga/gw/GwMain.py
+++ b/ginga/gw/GwMain.py
@@ -213,7 +213,7 @@ class GwMain(Callback.Callbacks):
             return task
         except Exception as e:
             self.logger.error("Error starting task: %s" % (str(e)))
-            raise(e)
+            raise e
 
     def is_gui_thread(self):
         my_id = threading.get_ident()

--- a/ginga/misc/Bunch.py
+++ b/ginga/misc/Bunch.py
@@ -71,7 +71,7 @@ class caselessDict(object):
     def __iter__(self):
         self.iterPosition = 0
         self.keyList = list(self.dict.keys())
-        return(self)
+        return self
 
     def __next__(self):
         if self.iterPosition >= len(self.keyList):

--- a/ginga/rv/Control.py
+++ b/ginga/rv/Control.py
@@ -2859,47 +2859,67 @@ class GingaShell(GwMain.GwMain, Widgets.Application):
         #   the desktop object
         if keyname == 'Z':
             self.ds.raise_tab('Zoom')
+            return True
         ## elif keyname == 'T':
         ##     self.ds.raise_tab('Thumbs')
         elif keyname == 'I':
             self.ds.raise_tab('Info')
+            return True
         elif keyname == 'H':
             self.ds.raise_tab('Header')
+            return True
         elif keyname == 'C':
             self.ds.raise_tab('Contents')
+            return True
         elif keyname == 'D':
             self.ds.raise_tab('Dialogs')
+            return True
         elif keyname == 'F':
             self.build_fullscreen()
+            return True
         elif keyname == 'f':
             self.toggle_fullscreen()
+            return True
         elif keyname == 'm':
             self.maximize()
+            return True
         elif keyname == '<':
             self.collapse_pane('left')
+            return True
         elif keyname == '>':
             self.collapse_pane('right')
+            return True
         elif keyname == 'n':
             self.next_channel()
+            return True
         elif keyname == 'J':
             self.cycle_workspace_type()
+            return True
         elif keyname == 'k':
             self.add_channel_auto()
+            return True
         elif keyname == 'K':
             self.remove_channel_auto()
+            return True
         elif keyname == 'f1':
             self.show_channel_names()
+            return True
         ## elif keyname == 'escape':
         ##     self.reset_viewer()
         elif keyname in ('up',):
             self.prev_img()
+            return True
         elif keyname in ('down',):
             self.next_img()
+            return True
         elif keyname in ('left',):
             self.prev_channel()
+            return True
         elif keyname in ('right',):
             self.next_channel()
-        return True
+            return True
+
+        return False
 
     def dragdrop(self, chviewer, uris):
         """Called when a drop operation is performed on a channel viewer.

--- a/ginga/rv/plugins/Cuts.py
+++ b/ginga/rv/plugins/Cuts.py
@@ -905,7 +905,7 @@ class Cuts(GingaPlugin.LocalPlugin):
         elif event.key == 'h':
             self.cut_at('horizontal')
             return True
-        elif event.key == 'j':
+        elif event.key in ('j', 'v'):
             self.cut_at('vertical')
             return True
         return False


### PR DESCRIPTION
Fixed a longstanding issue where events registered on a canvas could be masked by default key/cursor bindings (not associated with a mode). This meant, for example, that only certain keystrokes could be captured by an event handler registered on a ginga canvas, because any keystrokes that had a default binding would take precedence. Now such bindings are only executed if the event is not handled by any active canvas bindings.