### PR TITLE
Fixed a bug with the implementation of Bresenham's line algorithm

### DIFF
--- a/ginga/BaseImage.py
+++ b/ginga/BaseImage.py
@@ -539,10 +539,10 @@ class BaseImage(ViewerObjectBase):
             if (x == x2) and (y == y2):
                 break
             e2 = 2 * err
-            if e2 > -dy:
+            if e2 >= -dy:
                 err = err - dy
                 x += sx
-            if e2 < dx:
+            if e2 <= dx:
                 err = err + dx
                 y += sy
 

--- a/ginga/util/vip.py
+++ b/ginga/util/vip.py
@@ -420,10 +420,10 @@ class ViewerImageProxy:
             if (x == x2) and (y == y2):
                 break
             e2 = 2 * err
-            if e2 > -dy:
+            if e2 >= -dy:
                 err = err - dy
                 x += sx
-            if e2 < dx:
+            if e2 <= dx:
                 err = err + dx
                 y += sy
 


### PR DESCRIPTION
The implementation of Bresenham's line algorithm used for `get_pixels_on_line()` has a bug because it uses `>` instead of `>=` and `<` instead of `<=`.  Compare against the final code example in this section on the Wikipedia article: https://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm#All_cases.  ~This bug means that the pixels other than the closest ones are occasionally chosen.~

Edit: After further investigation, it appears that the difference in comparison operator simply means a different choice is made when two pixels are equally close to the line.  After I confirm, I'll close this PR as an unnecessary change.