### PR TITLE
Remove preload

### DIFF
--- a/doc/WhatsNew.rst
+++ b/doc/WhatsNew.rst
@@ -13,6 +13,7 @@ Ver 4.1.0 (unreleased)
   samples when the image size is very small
 - removed old, deprecated StandardPixelRenderer
 - RGB mapping has been refactored to use a pipeline
+- Removed deprecated preload feature
 
 Ver 4.0.1 (2022-12-27)
 ======================

--- a/ginga/examples/configs/channel_Image.cfg
+++ b/ginga/examples/configs/channel_Image.cfg
@@ -144,13 +144,6 @@ auto_orient = True
 defer_redraw = True
 defer_lagtime = 0.025
 
-# To be deprecated
-image_overlays = True
-
-# anticipatory preloading of images may shorten wait time when
-# switching between adjacent images
-preload_images = False
-
 # create scroll bars in channel image viewer
 # acceptable values are: 'off', 'on' or 'auto' (as needed)
 scrollbars = 'auto'

--- a/ginga/rv/Channel.py
+++ b/ginga/rv/Channel.py
@@ -401,23 +401,6 @@ class Channel(Callback.Callbacks):
 
         self.fv.channel_image_updated(self, dataobj)
 
-        # Check for preloading any dataobjs into memory
-        preload = self.settings.get('preload_images', False)
-        if not preload:
-            return
-
-        # queue next and previous files for preloading
-        index = self.cursor
-        if index < len(self.history) - 1:
-            info = self.history[index + 1]
-            if info.path is not None:
-                self.fv.add_preload(self.name, info)
-
-        if index > 0:
-            info = self.history[index - 1]
-            if info.path is not None:
-                self.fv.add_preload(self.name, info)
-
     def switch_image(self, image):
 
         curimage = self.get_current_image()

--- a/ginga/rv/Control.py
+++ b/ginga/rv/Control.py
@@ -17,7 +17,7 @@ import atexit
 import shutil
 import inspect
 import warnings
-from collections import deque, OrderedDict
+from collections import OrderedDict
 
 # Local application imports
 from ginga import cmap, imap

--- a/ginga/rv/plugins/Preferences.py
+++ b/ginga/rv/plugins/Preferences.py
@@ -401,9 +401,6 @@ class Preferences(GingaPlugin.LocalPlugin):
         self.t_.add_defaults(numImages=4)
         self.t_.get_setting('numImages').add_callback('set', self.set_buflen_ext_cb)
 
-        # preload images
-        self.t_.add_defaults(preload_images=False)
-
         self.icc_profiles = list(rgb_cms.get_profiles())
         self.icc_profiles.insert(0, None)
         self.icc_intents = rgb_cms.get_intents()
@@ -832,8 +829,7 @@ class Preferences(GingaPlugin.LocalPlugin):
 
         captions = (('Num Images:', 'label', 'Num Images', 'entryset'),
                     ('Sort Order:', 'label', 'Sort Order', 'combobox'),
-                    ('Use scrollbars', 'checkbutton',
-                     'Preload Images', 'checkbutton'),
+                    ('Use scrollbars', 'checkbutton'),
                     )
         w, b = Widgets.build_info(captions, orientation=orientation)
         self.w.update(b)
@@ -859,12 +855,6 @@ class Preferences(GingaPlugin.LocalPlugin):
         self.w.use_scrollbars.set_state(scrollbars in ['on', 'auto'])
         self.w.use_scrollbars.add_callback('activated', self.set_scrollbars_cb)
         b.use_scrollbars.set_tooltip("Use scrollbars around viewer")
-
-        preload_images = self.t_.get('preload_images', False)
-        self.w.preload_images.set_state(preload_images)
-        self.w.preload_images.add_callback('activated', self.set_preload_cb)
-        b.preload_images.set_tooltip(
-            "Preload adjacent images to speed up access")
 
         fr = Widgets.Frame()
         fr.set_widget(w)
@@ -1320,11 +1310,6 @@ class Preferences(GingaPlugin.LocalPlugin):
         name = self.sort_options[index]
         self.t_.set(sort_order=name)
 
-    def set_preload_cb(self, w, tf):
-        """This callback is invoked when the user checks the preload images
-        box in the preferences pane."""
-        self.t_.set(preload_images=tf)
-
     def set_scrollbars_cb(self, w, tf):
         """This callback is invoked when the user checks the 'Use Scrollbars'
         box in the preferences pane."""
@@ -1589,8 +1574,6 @@ class Preferences(GingaPlugin.LocalPlugin):
 
         num_images = prefs.get('numImages', 0)
         self.w.num_images.set_text(str(num_images))
-        prefs.setdefault('preload_images', False)
-        self.w.preload_images.set_state(prefs['preload_images'])
 
         # profile settings
         prefs.setdefault('profile_use_scale', False)


### PR DESCRIPTION
Removes the image preload feature.

It is turned off by default and doesn't speed things up too much.
