### PR TITLE
TST: Update pin on conda job

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -123,7 +123,7 @@ jobs:
         # $CONDA is an environment variable pointing to the root of the miniconda directory
         $CONDA/bin/conda install pip setuptools setuptools_scm
         $CONDA/bin/conda install qtpy pyqt matplotlib
-        $CONDA/bin/conda install attrs "astropy>=4" pytest-astropy -c conda-forge
+        $CONDA/bin/conda install attrs "astropy>=5.2" pytest-astropy -c conda-forge
         $CONDA/bin/pip install -e .
     - name: Run tests
       run: $CONDA/bin/pytest --pyargs ginga doc -sv


### PR DESCRIPTION
Fix #1048 

Not sure why conda is pulling astropy 5.1 when astropy 5.2.2 is already available on conda-forge. Maybe forcing a pin update would do it?