### PR TITLE
Remove deprecated dump data types

### DIFF
--- a/ginga/canvas/CompoundMixin.py
+++ b/ginga/canvas/CompoundMixin.py
@@ -51,7 +51,7 @@ class CompoundMixin(object):
     def contains_pts(self, pts):
         if len(self.objects) == 0:
             x_arr, y_arr = np.asarray(pts).T
-            return np.full(x_arr.shape, False, dtype=np.bool)
+            return np.full(x_arr.shape, False, dtype='bool')
 
         return reduce(self._contains_reduce,
                       map(lambda obj: obj.contains_pts(pts), self.objects))

--- a/ginga/canvas/transform.py
+++ b/ginga/canvas/transform.py
@@ -686,7 +686,7 @@ class ScaleOffsetTransform(BaseTransform):
         if has_z:
             add_pt.append(0.0)
 
-        ntv_pts = np.add(np.multiply(ntv_pts, mpy_pt), add_pt).astype(np.int)
+        ntv_pts = np.add(np.multiply(ntv_pts, mpy_pt), add_pt).astype('int')
 
         return ntv_pts
 

--- a/ginga/canvas/types/mixins.py
+++ b/ginga/canvas/types/mixins.py
@@ -326,7 +326,7 @@ class PolygonMixin(object):
                         y_arr.astype(float, copy=False))
         xa, ya = x_arr, y_arr
 
-        result = np.empty(y_arr.shape, dtype=np.bool)
+        result = np.empty(y_arr.shape, dtype='bool')
         result.fill(False)
 
         points = self.get_data_points()

--- a/ginga/canvas/types/plots.py
+++ b/ginga/canvas/types/plots.py
@@ -810,7 +810,7 @@ class CalcPlot(XYPlot):
 
         wd, ht = self.viewer.get_window_size()
 
-        x_pts = self.x_fn(np.linspace(start_x, stop_x, wd, dtype=np.float))
+        x_pts = self.x_fn(np.linspace(start_x, stop_x, wd, dtype='float'))
         y_pts = self.y_fn(x_pts)
         points = np.array((x_pts, y_pts)).T
         self.path.points = points

--- a/ginga/rv/plugins/PlotTable.py
+++ b/ginga/rv/plugins/PlotTable.py
@@ -313,12 +313,12 @@ class PlotTable(LocalPlugin):
 
         if self.tab.masked:
             if self.x_col == self._idxname:
-                x_mask = np.ones_like(self._idx, dtype=np.bool)
+                x_mask = np.ones_like(self._idx, dtype='bool')
             else:
                 x_mask = ~self.tab[self.x_col].mask
 
             if self.y_col == self._idxname:
-                y_mask = np.ones_like(self._idx, dtype=np.bool)
+                y_mask = np.ones_like(self._idx, dtype='bool')
             else:
                 y_mask = ~self.tab[self.y_col].mask
 

--- a/ginga/rv/plugins/TVMask.py
+++ b/ginga/rv/plugins/TVMask.py
@@ -269,7 +269,7 @@ class TVMask(LocalPlugin):
 
         try:
             # 0=False, everything else True
-            dat = fits.getdata(filename).astype(np.bool)
+            dat = fits.getdata(filename).astype('bool')
         except Exception as e:
             self.logger.error('{0}: {1}'.format(e.__class__.__name__, str(e)))
             return
@@ -318,7 +318,7 @@ class TVMask(LocalPlugin):
     def _rgbtomask(self, obj):
         """Convert RGB arrays from mask canvas object back to boolean mask."""
         dat = obj.get_image().get_data()  # RGB arrays
-        return dat.sum(axis=2).astype(np.bool)  # Convert to 2D mask
+        return dat.sum(axis=2).astype('bool')  # Convert to 2D mask
 
     def hl_table2canvas(self, w, res_dict):
         """Highlight mask on canvas when user click on table."""


### PR DESCRIPTION
Fixes #1051 

NumPy v1.24.0 [removed deprecated data types](https://numpy.org/doc/stable/release/1.24.0-notes.html) `np.object`, `np.bool`, `np.float`, `np.complex`, `np.str`, and `np.int`, meaning Ginga could no longer be used with the latest NumPy versions.

This PR removes these data types from Ginga in favour of the Python data types `float`, `int`, `bool` etc. According to the raised error in NumPy:

```
`np.bool` was a deprecated alias for the builtin `bool`. To avoid this error in existing code, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```
  