### PR TITLE
Feature vizier catalogs

### DIFF
--- a/doc/WhatsNew.rst
+++ b/doc/WhatsNew.rst
@@ -10,6 +10,8 @@ Ver 5.0.0 (unreleased)
   - support pillow v10.0
   - now supports linewidth attribute
 
+- Add support for VizieR catalog sources
+
 Ver 4.1.0 (2022-06-30)
 ======================
 - change implementation of splash banner to a pop-up modal dialog

--- a/ginga/rv/plugins/Catalogs.py
+++ b/ginga/rv/plugins/Catalogs.py
@@ -893,7 +893,7 @@ class Catalogs(GingaPlugin.LocalPlugin):
         color = self.table.get_color(obj)
         point = self.dc.Point(x, y, radius, color=color)
         point.editable = False
-        #EBR: Set the radius to 0 in case the magnitude is NaN, hence only plotting the point and an invisible circle.
+        # Set the radius to 0 in case the magnitude is NaN, hence only plotting the point and an invisible circle.
         if math.isnan(mag):
             radius = 0
 
@@ -1058,7 +1058,7 @@ class Catalogs(GingaPlugin.LocalPlugin):
     def params_changed_cb(self, paramset):
         paramset.widgets_to_params()
 
-    # EBR: add if/elif to set parameter for vizier radius or box query
+    # add if/elif to set parameter for vizier radius or box query
     def set_drawtype_cb(self, tf, drawtype):
         if tf:
             self.drawtype = drawtype
@@ -1138,7 +1138,7 @@ class CatalogListing(object):
         else:
             point = 1.0
 
-        #EBR: added for mags = NaN in catalog
+        # added for mags = NaN in catalog
         if math.isnan(mag):
             point = 1.0
 
@@ -1235,7 +1235,7 @@ class CatalogListing(object):
         self.cbar.set_imap(im)
         self.replot_stars()
 
-    # EBR: handles now also color indices and deals with NaN magnitudes
+    # handles now also color indices and deals with NaN magnitudes
     def set_minmax(self, i, length):
         subset = self.get_subset_from_starlist(i, i + length)
         values = list(map(lambda star: float(star[self.mag_field]),

--- a/ginga/rv/plugins/Catalogs.py
+++ b/ginga/rv/plugins/Catalogs.py
@@ -180,6 +180,19 @@ class Catalogs(GingaPlugin.LocalPlugin):
                                                           d['source'],
                                                           d['mapping'],
                                                           description=d['fullname'])
+            elif typ == 'astroquery.vizier':
+                if catalog.have_astroquery:
+                    obj = catalog.AstroqueryVizierCatalogServer(self.logger,
+                                                          d['fullname'],
+                                                          d['shortname'],
+                                                          d['mapping'],
+                                                          description=d['fullname'])
+
+                    if 'cat_column_filter' in d:
+                        obj.set_cat_column_filters(d['cat_column_filters'])
+
+                    if 'cat_columns' in d:
+                        obj.set_cat_columns(d['cat_columns'])
             else:
                 self.logger.debug("Unknown type ({}) specified for catalog source--skipping".format(typ))
 

--- a/ginga/rv/plugins/Catalogs.py
+++ b/ginga/rv/plugins/Catalogs.py
@@ -183,10 +183,10 @@ class Catalogs(GingaPlugin.LocalPlugin):
             elif typ == 'astroquery.vizier':
                 if catalog.have_astroquery:
                     obj = catalog.AstroqueryVizierCatalogServer(self.logger,
-                                                          d['fullname'],
-                                                          d['shortname'],
-                                                          d['mapping'],
-                                                          description=d['fullname'])
+                                                                d['fullname'],
+                                                                d['shortname'],
+                                                                d['mapping'],
+                                                                description=d['fullname'])
 
                     if 'cat_column_filter' in d:
                         obj.set_cat_column_filters(d['cat_column_filters'])
@@ -1058,8 +1058,7 @@ class Catalogs(GingaPlugin.LocalPlugin):
     def params_changed_cb(self, paramset):
         paramset.widgets_to_params()
 
-
-    #EBR: add if/elif to set parameter for vizier radius or box query
+    # EBR: add if/elif to set parameter for vizier radius or box query
     def set_drawtype_cb(self, tf, drawtype):
         if tf:
             self.drawtype = drawtype
@@ -1236,13 +1235,13 @@ class CatalogListing(object):
         self.cbar.set_imap(im)
         self.replot_stars()
 
-    #EBR: handles now also color indices and deals with NaN magnitudes
+    # EBR: handles now also color indices and deals with NaN magnitudes
     def set_minmax(self, i, length):
         subset = self.get_subset_from_starlist(i, i + length)
         values = list(map(lambda star: float(star[self.mag_field]),
                           subset))
 
-        values_without_nan=[x for x in values if math.isnan(x) == False]
+        values_without_nan = [x for x in values if math.isnan(x) is False]
 
         if len(values_without_nan) > 0:
             self.mag_max = max(values_without_nan)

--- a/ginga/rv/plugins/Catalogs.py
+++ b/ginga/rv/plugins/Catalogs.py
@@ -121,7 +121,7 @@ class Catalogs(GingaPlugin.LocalPlugin):
 
         self.catalog_server_options = []
         self.catalog_server_params = None
-        self.catalog_params = Bunch.Bunch(dict(ra='', dec='', radius=1))
+        self.catalog_params = Bunch.Bunch(dict(ra='', dec='', radius=1, width=1, height=1))
 
         self.name_server_options = []
 
@@ -1054,11 +1054,17 @@ class Catalogs(GingaPlugin.LocalPlugin):
     def params_changed_cb(self, paramset):
         paramset.widgets_to_params()
 
+
+    #EBR: add if/elif to set parameter for vizier radius or box query
     def set_drawtype_cb(self, tf, drawtype):
         if tf:
             self.drawtype = drawtype
             self.canvas.set_drawtype(self.drawtype, color='cyan',
                                      linestyle='dash')
+            if drawtype == 'circle':
+                self.catalog_params.update(dict(box=0, radius=1))
+            elif drawtype == 'rectangle':
+                self.catalog_params.update(dict(box=1, radius=0))
 
     def __str__(self):
         return 'catalogs'

--- a/ginga/util/catalog.py
+++ b/ginga/util/catalog.py
@@ -21,6 +21,7 @@ from astropy import coordinates, units
 have_astroquery = False
 try:
     from astroquery.vo_conesearch import conesearch
+    from astroquery.vizier import Vizier #EBR: add astroquery.vizier to use vizier catalogs
 
     have_astroquery = True
 except ImportError:
@@ -31,6 +32,8 @@ default_image_sources = []
 default_catalog_sources = []
 default_name_sources = []
 
+#EBR: limit the number of rows in the vizier query to 5000
+Vizier.ROW_LIMIT= 5000
 
 class SourceError(Exception):
     """For exceptions raised by the `~ginga.util.catalog` module."""
@@ -75,7 +78,7 @@ class AstroqueryCatalogServer(object):
         ]
 
     def __init__(self, logger, full_name, key, querymod, mapping,
-                 description=None):
+                 description=None, cat_columns=None, cat_column_filters=None):
         super(AstroqueryCatalogServer, self).__init__()
         if not have_astroquery:
             raise ImportError("'astroquery' not found, please install it")
@@ -85,6 +88,9 @@ class AstroqueryCatalogServer(object):
         self.short_name = key
         self.mapping = mapping
         self.querymod = querymod
+        self.cat_columns = cat_columns                 #EBR: add for usage with the vizier catalog
+        self.cat_column_filters = cat_column_filters   #EBR: add for usage with the vizier catalog
+
         if description is None:
             description = full_name
         self.description = description
@@ -227,6 +233,146 @@ class AstroqueryVOCatalogServer(AstroqueryCatalogServer):
                                         return_astropy_table=True,
                                         use_names_over_ids=False)
         return results
+
+#EBR: add vizier catalog class
+class AstroqueryVizierCatalogServer(AstroqueryCatalogServer):
+    """For queries using the `astroquery.vizier` function."""
+
+    kind = 'astroquery.vizier'
+
+    @classmethod
+    def get_params_metadata(cls):
+        from ginga.misc.ParamSet import Param
+        return [
+            Param(name='ra', type=str, widget='entry',
+                  description="Right ascension component of center"),
+            Param(name='dec', type=str, widget='entry',
+                  description="Declination component of center"),
+            Param(name='r', type=float, default=5.0, widget='entry',
+                  description="Radius from center in arcmin"),
+        ]
+
+    #EBR add output colums and filters for vizier catalog
+    def __init__(self, logger, full_name, key, mapping, cat_columns=[], cat_column_filters={}, description=None):
+    #def __init__(self, logger, full_name, key, mapping, description=None):
+        super(AstroqueryVizierCatalogServer, self).__init__(logger, full_name,
+                                                        key, None, mapping,
+                                                        description=description, cat_columns=cat_columns, cat_column_filters=cat_column_filters)
+
+    def set_cat_column_filters(self, cat_filter):
+        self.cat_column_filters = cat_filter
+
+    def set_cat_columns(self, cat_columns):
+        self.cat_columns = cat_columns
+
+    def getParams(self):
+        return self.get_params_metadata()
+
+
+    def _search_radius(self, center, radius, catalog, columns, column_filters):
+        # override this method to pass some special kwargs to the search
+
+        if columns:
+            columns.insert(0,self.mapping['id'])
+            columns.insert(1,self.mapping['ra'])
+            columns.insert(2,self.mapping['dec'])
+
+        v=Vizier(columns=columns, column_filters=column_filters)
+        results = Vizier.query_region(center, radius, catalog=catalog)
+
+        return results[0]
+
+    def search(self, **params):
+        """
+        For compatibility with generic star catalog search.
+        """
+
+        self.logger.debug("search params=%s" % (str(params)))
+        ra, dec = params['ra'], params['dec']
+        if not (':' in ra):
+            # Assume RA and DEC are in degrees
+            ra_deg = float(ra)
+            dec_deg = float(dec)
+        else:
+            # Assume RA and DEC are in standard string notation
+            ra_deg = wcs.hmsStrToDeg(ra)
+            dec_deg = wcs.dmsStrToDeg(dec)
+
+        # Note requires astropy 0.3.x+
+        c = coordinates.SkyCoord(ra_deg * units.degree,
+                                 dec_deg * units.degree,
+                                 frame='icrs')
+        
+        self.logger.info("Querying catalog: %s" % (self.full_name))
+        time_start = time.time()
+        with warnings.catch_warnings():  # Ignore VO warnings
+            warnings.simplefilter('ignore')
+            # Convert to degrees for search radius
+            radius_deg = float(params['r']) / 60.0
+            # radius_deg = float(params['r'])
+            results = self._search_radius(c, radius_deg * units.degree,
+                                       self.full_name, columns=self.cat_columns, column_filters=self.cat_column_filters)
+
+        time_elapsed = time.time() - time_start
+        if results is None:
+            self.logger.info("Null result in %.2f sec" % (
+                time_elapsed))
+            raise SourceError("Null result from query")
+        else:
+            numsources = len(results)
+            self.logger.info("Found %d sources in %.2f sec" % (
+                numsources, time_elapsed))
+
+        # Scan the returned fields to find ones we need to extract
+        # particulars from (ra, dec, id, magnitude)
+        mags = []
+        ext = {} #{'id': 'recno', 'ra': 'RAJ2000', 'dec': 'DEJ2000'}
+        fields = results.colnames
+        #print("fields are", fields)
+        for name in fields:
+            if name == self.mapping['id']:
+                ext['id'] = name
+            elif name == self.mapping['ra']:
+                ext['ra'] = name
+            elif name == self.mapping['dec']:
+                ext['dec'] = name
+            if name in self.mapping.get('mag', []):
+                mags.append(name)
+
+        self.logger.debug("possible magnitude fields: %s" % str(mags))
+        if len(mags) > 0:
+            magfield = mags[0]
+        else:
+            magfield = None
+
+        # prepare the result list
+        starlist = []
+        for i in range(numsources):
+            source = dict(zip(fields, results[i]))
+            starlist.append(self.toStar(source, ext, magfield))
+
+        # metadata about the list
+        columns = [('Name', 'name'),
+                   ('RA', 'ra'),
+                   ('DEC', 'dec'),
+#                   ('Mag', 'mag'),
+#                   ('Preference', 'preference'),
+#                   ('Priority', 'priority'),
+#                   ('Description', 'description'),
+                   ]
+        # Append extra columns returned by search to table header
+        cols = list(fields)
+        #cols.remove(ext['ra'])
+        #cols.remove(ext['dec'])
+        cols.remove(ext['id'])
+        #cols.remove('Field')
+        columns.extend(zip(cols, cols))
+
+        # which column is the likely one to color source circles
+        colorCode = 'Mag'
+
+        info = Bunch.Bunch(columns=columns, color=colorCode)
+        return starlist, info
 
 
 class AstroqueryImageServer(object):
@@ -699,6 +845,10 @@ if have_astroquery:
          'type': 'astroquery.vo_conesearch',
          'mapping': {'id': 'htmID', 'ra': 'ra', 'dec': 'dec',
                      'mag': ['h_m', 'j_m', 'k_m']}},
+        {'shortname': "APASS DR9",
+         'fullname': "II/336/apass9",
+         'type': 'astroquery.vizier',
+         'mapping': {'id': 'recno', 'ra': 'RAJ2000', 'dec': 'DEJ2000', 'mag': ['Vmag', 'B-V', 'Bmag', 'g\'mag', 'r\'mag', 'i\'mag'] }},
     ])
 
     default_image_sources.extend([

--- a/ginga/util/catalog.py
+++ b/ginga/util/catalog.py
@@ -347,7 +347,7 @@ class AstroqueryVizierCatalogServer(AstroqueryCatalogServer):
                     radius_deg = float(params['r']) / 60.0
                     # radius_deg = float(params['r'])
                     results = self._search_radius(c, radius_deg * units.degree,
-                                              self.full_name)
+                                                  self.full_name)
             except Exception as e:
                 self.logger.error(f"vizier query raised an exception: {e}", exc_info=True)
                 results = None

--- a/ginga/util/catalog.py
+++ b/ginga/util/catalog.py
@@ -21,7 +21,7 @@ from astropy import coordinates, units
 have_astroquery = False
 try:
     from astroquery.vo_conesearch import conesearch
-    from astroquery.vizier import Vizier          # EBR: add astroquery.vizier to use vizier catalogs
+    from astroquery.vizier import Vizier          # added astroquery.vizier to use vizier catalogs
 
     have_astroquery = True
 except ImportError:
@@ -32,7 +32,7 @@ default_image_sources = []
 default_catalog_sources = []
 default_name_sources = []
 
-# EBR: limit the number of rows in the vizier query to 5000
+# limit the number of rows in the vizier query to 5000
 Vizier.ROW_LIMIT = 5000
 
 
@@ -89,8 +89,8 @@ class AstroqueryCatalogServer(object):
         self.short_name = key
         self.mapping = mapping
         self.querymod = querymod
-        self.cat_columns = cat_columns                 # EBR: add for usage with the vizier catalog
-        self.cat_column_filters = cat_column_filters   # EBR: add for usage with the vizier catalog
+        self.cat_columns = cat_columns                 # added for usage with the vizier catalog
+        self.cat_column_filters = cat_column_filters   # added for usage with the vizier catalog
 
         if description is None:
             description = full_name
@@ -235,7 +235,7 @@ class AstroqueryVOCatalogServer(AstroqueryCatalogServer):
         return results
 
 
-# EBR: add vizier catalog class
+# add vizier catalog class
 class AstroqueryVizierCatalogServer(AstroqueryCatalogServer):
     """For queries using the `astroquery.vizier` function."""
 
@@ -257,7 +257,7 @@ class AstroqueryVizierCatalogServer(AstroqueryCatalogServer):
                   description="Radius from center in arcmin"),
         ]
 
-    # EBR add output colums and filters for vizier catalog
+    # add output colums and filters for vizier catalog
     def __init__(self, logger, full_name, key, mapping, cat_columns=[], cat_column_filters={}, description=None):
         super(AstroqueryVizierCatalogServer, self).__init__(logger, full_name,
                                                             key, None, mapping,

--- a/ginga/util/catalog.py
+++ b/ginga/util/catalog.py
@@ -21,7 +21,7 @@ from astropy import coordinates, units
 have_astroquery = False
 try:
     from astroquery.vo_conesearch import conesearch
-    from astroquery.vizier import Vizier #EBR: add astroquery.vizier to use vizier catalogs
+    from astroquery.vizier import Vizier          # EBR: add astroquery.vizier to use vizier catalogs
 
     have_astroquery = True
 except ImportError:
@@ -32,8 +32,9 @@ default_image_sources = []
 default_catalog_sources = []
 default_name_sources = []
 
-#EBR: limit the number of rows in the vizier query to 5000
-Vizier.ROW_LIMIT= 5000
+# EBR: limit the number of rows in the vizier query to 5000
+Vizier.ROW_LIMIT = 5000
+
 
 class SourceError(Exception):
     """For exceptions raised by the `~ginga.util.catalog` module."""
@@ -88,8 +89,8 @@ class AstroqueryCatalogServer(object):
         self.short_name = key
         self.mapping = mapping
         self.querymod = querymod
-        self.cat_columns = cat_columns                 #EBR: add for usage with the vizier catalog
-        self.cat_column_filters = cat_column_filters   #EBR: add for usage with the vizier catalog
+        self.cat_columns = cat_columns                 # EBR: add for usage with the vizier catalog
+        self.cat_column_filters = cat_column_filters   # EBR: add for usage with the vizier catalog
 
         if description is None:
             description = full_name
@@ -171,7 +172,6 @@ class AstroqueryCatalogServer(object):
         mags = []
         ext = {}
         fields = results.colnames
-        #print("fields are", fields)
         for name in fields:
             if name == self.mapping['id']:
                 ext['id'] = name
@@ -234,7 +234,8 @@ class AstroqueryVOCatalogServer(AstroqueryCatalogServer):
                                         use_names_over_ids=False)
         return results
 
-#EBR: add vizier catalog class
+
+# EBR: add vizier catalog class
 class AstroqueryVizierCatalogServer(AstroqueryCatalogServer):
     """For queries using the `astroquery.vizier` function."""
 
@@ -256,12 +257,11 @@ class AstroqueryVizierCatalogServer(AstroqueryCatalogServer):
                   description="Radius from center in arcmin"),
         ]
 
-    #EBR add output colums and filters for vizier catalog
+    # EBR add output colums and filters for vizier catalog
     def __init__(self, logger, full_name, key, mapping, cat_columns=[], cat_column_filters={}, description=None):
-    #def __init__(self, logger, full_name, key, mapping, description=None):
         super(AstroqueryVizierCatalogServer, self).__init__(logger, full_name,
-                                                        key, None, mapping,
-                                                        description=description, cat_columns=cat_columns, cat_column_filters=cat_column_filters)
+                                                            key, None, mapping,
+                                                            description=description, cat_columns=cat_columns, cat_column_filters=cat_column_filters)
 
     def set_cat_column_filters(self, cat_filter):
         self.cat_column_filters = cat_filter
@@ -272,16 +272,15 @@ class AstroqueryVizierCatalogServer(AstroqueryCatalogServer):
     def getParams(self):
         return self.get_params_metadata()
 
-
     def _search_radius(self, center, radius, catalog, columns, column_filters):
         # override this method to pass some special kwargs to the search
 
         if columns:
-            columns.insert(0,self.mapping['id'])
-            columns.insert(1,self.mapping['ra'])
-            columns.insert(2,self.mapping['dec'])
+            columns.insert(0, self.mapping['id'])
+            columns.insert(1, self.mapping['ra'])
+            columns.insert(2, self.mapping['dec'])
 
-        v=Vizier(columns=columns, column_filters=column_filters)
+        v = Vizier(columns=columns, column_filters=column_filters)
         results = Vizier.query_region(center, radius, catalog=catalog)
 
         return results[0]
@@ -289,11 +288,11 @@ class AstroqueryVizierCatalogServer(AstroqueryCatalogServer):
     def _search_box(self, center, width, height, catalog, columns, column_filters):
         # override this method to pass some special kwargs to the search
         if columns:
-            columns.insert(0,self.mapping['id'])
-            columns.insert(1,self.mapping['ra'])
-            columns.insert(2,self.mapping['dec'])
+            columns.insert(0, self.mapping['id'])
+            columns.insert(1, self.mapping['ra'])
+            columns.insert(2, self.mapping['dec'])
 
-        v=Vizier(columns=columns, column_filters=column_filters)
+        v = Vizier(columns=columns, column_filters=column_filters)
         v.ROW_LIMIT = 500
         results = v.query_region(center, width=width, height=height, catalog=catalog)
 
@@ -319,7 +318,7 @@ class AstroqueryVizierCatalogServer(AstroqueryCatalogServer):
         c = coordinates.SkyCoord(ra_deg * units.degree,
                                  dec_deg * units.degree,
                                  frame='icrs')
-        
+
         self.logger.info("Querying catalog: %s" % (self.full_name))
         time_start = time.time()
         with warnings.catch_warnings():  # Ignore VO warnings
@@ -329,21 +328,21 @@ class AstroqueryVizierCatalogServer(AstroqueryCatalogServer):
                 radius_deg = float(params['r']) / 60.0
                 # radius_deg = float(params['r'])
                 results = self._search_radius(c, radius_deg * units.degree,
-                                       self.full_name, columns=self.cat_columns, column_filters=self.cat_column_filters)
+                                              self.full_name, columns=self.cat_columns, column_filters=self.cat_column_filters)
             elif params['box'] == 1:
                 # Convert to degrees for search width
                 width_deg = float(params['width']) / 60.0
                 # Convert to degrees for search height
                 height_deg = float(params['height']) / 60.0
                 results = self._search_box(c, width_deg * units.degree, height_deg * units.degree,
-                                   self.full_name, columns=self.cat_columns, column_filters=self.cat_column_filters)
+                                           self.full_name, columns=self.cat_columns, column_filters=self.cat_column_filters)
             else:
                 #attempt to use the radius, this shouldn't happen
                 # Convert to degrees for search radius
                 radius_deg = float(params['r']) / 60.0
                 # radius_deg = float(params['r'])
                 results = self._search_radius(c, radius_deg * units.degree,
-                                       self.full_name)
+                                              self.full_name)
 
         time_elapsed = time.time() - time_start
         if results is None:
@@ -358,9 +357,8 @@ class AstroqueryVizierCatalogServer(AstroqueryCatalogServer):
         # Scan the returned fields to find ones we need to extract
         # particulars from (ra, dec, id, magnitude)
         mags = []
-        ext = {} #{'id': 'recno', 'ra': 'RAJ2000', 'dec': 'DEJ2000'}
+        ext = {}        # {'id': 'recno', 'ra': 'RAJ2000', 'dec': 'DEJ2000'}
         fields = results.colnames
-        #print("fields are", fields)
         for name in fields:
             if name == self.mapping['id']:
                 ext['id'] = name
@@ -387,17 +385,10 @@ class AstroqueryVizierCatalogServer(AstroqueryCatalogServer):
         columns = [('Name', 'name'),
                    ('RA', 'ra'),
                    ('DEC', 'dec'),
-#                   ('Mag', 'mag'),
-#                   ('Preference', 'preference'),
-#                   ('Priority', 'priority'),
-#                   ('Description', 'description'),
                    ]
         # Append extra columns returned by search to table header
         cols = list(fields)
-        #cols.remove(ext['ra'])
-        #cols.remove(ext['dec'])
         cols.remove(ext['id'])
-        #cols.remove('Field')
         columns.extend(zip(cols, cols))
 
         # which column is the likely one to color source circles
@@ -729,7 +720,6 @@ class CatalogServer(URLServer):
         offset = 0
         while offset < len(lines):
             line = lines[offset].strip()
-            # print(line)
             offset += 1
             if line.startswith('-'):
                 break
@@ -740,7 +730,6 @@ class CatalogServer(URLServer):
 
         for line in lines[offset:]:
             line = line.strip()
-            # print(line)
             if (len(line) == 0) or line.startswith('#'):
                 continue
             elts = line.split()
@@ -753,7 +742,6 @@ class CatalogServer(URLServer):
                 ra = elts[self.index['ra']]
                 dec = elts[self.index['dec']]
                 mag = float(elts[self.index['mag']])
-                # print(name)
 
                 if (self.format == 'deg') or not (':' in ra):
                     # Assume RA and DEC are in degrees
@@ -880,7 +868,7 @@ if have_astroquery:
         {'shortname': "APASS DR9",
          'fullname': "II/336/apass9",
          'type': 'astroquery.vizier',
-         'mapping': {'id': 'recno', 'ra': 'RAJ2000', 'dec': 'DEJ2000', 'mag': ['Vmag', 'B-V', 'Bmag', 'g\'mag', 'r\'mag', 'i\'mag'] }},
+         'mapping': {'id': 'recno', 'ra': 'RAJ2000', 'dec': 'DEJ2000', 'mag': ['Vmag', 'B-V', 'Bmag', 'g\'mag', 'r\'mag', 'i\'mag']}},
     ])
 
     default_image_sources.extend([


### PR DESCRIPTION
Dear Dr. Jeschke,

I have added support for vizier catalogs, with APASS DR9 as the default catalog source.
It includes:
- the possibility to do a box query limited to the image, hence no need to use the "limit stars to area" option and no obsolete data returned in the query
- the possibility to return only specific catalog columns of interest
- vizier catalogs can have NaN values for magnitudes, for these only a point is plotted and no circle. NaN values are not taken into account for the color coding range.

Would be great if you could merge this feature.

Thanks,
Eric Broens
 