### PR TITLE
Add a confirmation dialog when the reference viewer is closed

### DIFF
--- a/doc/WhatsNew.rst
+++ b/doc/WhatsNew.rst
@@ -13,6 +13,8 @@ Ver 5.0.0 (unreleased)
 - Add support for VizieR catalog sources
 - Fixed an issue with programatically setting selections in TreeView
   (qt backend)
+- Added a quit confirmation dialog to the reference viewer
+  (can be overridden with a setting in general.cfg)
 
 Ver 4.1.0 (2022-06-30)
 ======================

--- a/ginga/examples/configs/general.cfg
+++ b/ginga/examples/configs/general.cfg
@@ -149,3 +149,6 @@ layout_file = 'layout.json'
 # Name of a file to configure the set of available plugins and where they
 # should appear
 plugin_file = 'plugins.json'
+
+# Confirm program exits with a dialog?
+confirm_shutdown = True

--- a/ginga/gtk3w/Widgets.py
+++ b/ginga/gtk3w/Widgets.py
@@ -2375,7 +2375,7 @@ class Application(Callback.Callbacks):
         GObject.threads_init()
         # self._time_save = time.time()
 
-        for name in ['close', 'shutdown']:
+        for name in ('close', 'shutdown'):
             self.enable_callback(name)
 
         # Set up Gtk style

--- a/ginga/gtk3w/Widgets.py
+++ b/ginga/gtk3w/Widgets.py
@@ -2375,7 +2375,7 @@ class Application(Callback.Callbacks):
         GObject.threads_init()
         # self._time_save = time.time()
 
-        for name in ('shutdown', ):
+        for name in ['close', 'shutdown']:
             self.enable_callback(name)
 
         # Set up Gtk style
@@ -2435,7 +2435,20 @@ class Application(Callback.Callbacks):
     def mainloop(self):
         Gtk.main()
 
+    def close(self):
+        """Called when someone is asking the application to close.
+        Can register for this callback if you want an application-wide
+        event to confirm closure.
+        """
+        self.make_callback('close')
+
     def quit(self):
+        """Called when someone is forcibly quitting the application.
+        Can register for this callback if you want an application-wide
+        event to clean up before shutdown.
+        """
+        self.make_callback('shutdown')
+
         Gtk.main_quit()
 
 

--- a/ginga/qtw/Widgets.py
+++ b/ginga/qtw/Widgets.py
@@ -2117,7 +2117,7 @@ class Application(Callback.Callbacks):
         ydpi = screen.physicalDotsPerInchY()
         self.screen_res = max(xdpi, ydpi)
 
-        for name in ('shutdown', ):
+        for name in ['close', 'shutdown']:
             self.enable_callback(name)
 
     def get_screen_size(self):
@@ -2159,7 +2159,20 @@ class Application(Callback.Callbacks):
     def mainloop(self):
         self._qtapp.exec()
 
+    def close(self):
+        """Called when someone is asking the application to close.
+        Can register for this callback if you want an application-wide
+        event to confirm closure.
+        """
+        self.make_callback('close')
+
     def quit(self):
+        """Called when someone is forcibly quitting the application.
+        Can register for this callback if you want an application-wide
+        event to clean up before shutdown.
+        """
+        self.make_callback('shutdown')
+
         self._qtapp.quit()
 
 

--- a/ginga/qtw/Widgets.py
+++ b/ginga/qtw/Widgets.py
@@ -2117,7 +2117,7 @@ class Application(Callback.Callbacks):
         ydpi = screen.physicalDotsPerInchY()
         self.screen_res = max(xdpi, ydpi)
 
-        for name in ['close', 'shutdown']:
+        for name in ('close', 'shutdown'):
             self.enable_callback(name)
 
     def get_screen_size(self):

--- a/ginga/web/pgw/Widgets.py
+++ b/ginga/web/pgw/Widgets.py
@@ -3312,7 +3312,7 @@ class Application(Callback.Callbacks):
         self.caller_id = 0
         self.callers = {}
 
-        for name in ('shutdown', ):
+        for name in ['close', 'shutdown']:
             self.enable_callback(name)
 
     def get_screen_size(self):
@@ -3497,7 +3497,20 @@ class Application(Callback.Callbacks):
         while not self.t_ioloop.is_closed():
             self.t_ioloop.run_forever()
 
+    def close(self):
+        """Called when someone is asking the application to close.
+        Can register for this callback if you want an application-wide
+        event to confirm closure.
+        """
+        self.make_callback('close')
+
     def quit(self):
+        """Called when someone is forcibly quitting the application.
+        Can register for this callback if you want an application-wide
+        event to clean up before shutdown.
+        """
+        self.make_callback('shutdown')
+
         self.stop()
 
 

--- a/ginga/web/pgw/Widgets.py
+++ b/ginga/web/pgw/Widgets.py
@@ -3312,7 +3312,7 @@ class Application(Callback.Callbacks):
         self.caller_id = 0
         self.callers = {}
 
-        for name in ['close', 'shutdown']:
+        for name in ('close', 'shutdown'):
             self.enable_callback(name)
 
     def get_screen_size(self):


### PR DESCRIPTION
- pops up a confirmation dialog that confirms you intend to quit
- adds support across backends
- can be overridden by adding a line to your general.cfg
- example general.cfg updated