### PR TITLE
Fix RTD build in v4.1.x

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -65,7 +65,7 @@ recommended =
     docutils
     photutils
 test = attrs>=19.2.0; pytest-astropy
-docs = sphinx-astropy; sphinx_rtd_theme
+docs = sphinx<7.0; sphinx-astropy; sphinx_rtd_theme
 gtk3 = pycairo; pygobject
 qt5 = PyQt5; QtPy>=1.1
 tk = aggdraw


### PR DESCRIPTION
I didn't know you have a release branch. Should have backported this. Your v4.1.1 doc did not build.