### PR TITLE
Fix for future deprecation of datetime.datetime.utcnow()

### DIFF
--- a/ginga/examples/gw/clocks.py
+++ b/ginga/examples/gw/clocks.py
@@ -81,7 +81,7 @@ class Clock(object):
 
         self.clock_resized_cb(self.viewer, wd, ht)
 
-        dt = datetime.utcnow().replace(tzinfo=tz.UTC)
+        dt = datetime.now(tz=tz.UTC)
         self.update_clock(dt)
 
     def clock_resized_cb(self, viewer, width, height):
@@ -256,7 +256,7 @@ class ClockApp(object):
 
     def timer_cb(self, timer):
         """Timer callback.  Update all our clocks."""
-        dt_now = datetime.utcnow().replace(tzinfo=tz.UTC)
+        dt_now = datetime.now(tz=tz.UTC)
         self.logger.debug("timer fired. utc time is '%s'" % (str(dt_now)))
 
         for clock in self.clocks.values():

--- a/ginga/rv/plugins/ChangeHistory.py
+++ b/ginga/rv/plugins/ChangeHistory.py
@@ -33,7 +33,7 @@ by the calling plugin in the same method that issues the
         # This changes the data buffer
         image.set_data(new_data, ...)
         # Add description for ChangeHistory
-        info = dict(time_modified=datetime.utcnow(),
+        info = dict(time_modified=datetime.now(tz=tz.UTC),
                     reason_modified='Data has changed')
         self.fv.update_image_info(image, info)
 

--- a/ginga/rv/plugins/Drawing.py
+++ b/ginga/rv/plugins/Drawing.py
@@ -33,6 +33,7 @@ be saved, may be ignored or may cause errors trying to load the regions
 shapes in other software.
 """
 from datetime import datetime
+from dateutil import tz
 
 from ginga import GingaPlugin
 from ginga import colors
@@ -455,7 +456,7 @@ class Drawing(GingaPlugin.LocalPlugin):
         # Add description to ChangeHistory
         s = 'Mask created from {0} drawings ({1})'.format(
             ntags, ','.join(sorted(obj_kinds)))
-        info = dict(time_modified=datetime.utcnow(), reason_modified=s)
+        info = dict(time_modified=datetime.now(tz=tz.UTC), reason_modified=s)
         self.fv.update_image_info(image, info)
         self.logger.info(s)
 

--- a/ginga/rv/plugins/Mosaic.py
+++ b/ginga/rv/plugins/Mosaic.py
@@ -39,6 +39,7 @@ the other tiles.
 import math
 import time
 from datetime import datetime
+from dateutil import tz
 import threading
 
 import numpy as np
@@ -355,7 +356,7 @@ class Mosaic(GingaPlugin.LocalPlugin):
                                    suppress_callback=True)
 
         # Add description for ChangeHistory
-        info = dict(time_modified=datetime.utcnow(),
+        info = dict(time_modified=datetime.now(tz=tz.UTC),
                     reason_modified='Added {0}'.format(
             ','.join([im.get('name') for im in images])))
         self.fv.update_image_info(self.img_mosaic, info)


### PR DESCRIPTION
utcnow() will be deprecated in Python 3.12