### PR TITLE
Unleash dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: ".github/workflows" # Location of package manifests
+    target-branch: "main"
+    schedule:
+      interval: "monthly"
+      time: "02:10"
+    groups:
+      actions:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: pip
+    directory: "/"
+    target-branch: "main"
+    schedule:
+      interval: "monthly"
+      time: "02:00"
+    groups:
+      actions:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
There is no need to run CI here and you won't see the benefit until after merge. This would allow Dependabot to submit PRs to upgrade things like GitHub Actions versions as needed.

See https://docs.github.com/en/code-security/getting-started/dependabot-quickstart-guide