### PR TITLE
Remove imports of distutils

### DIFF
--- a/doc/WhatsNew.rst
+++ b/doc/WhatsNew.rst
@@ -7,6 +7,7 @@ Ver 5.1.0 (unreleased)
 - Fixed an issue where --modules option did not start a global plugin
   automatically
 - Improved error checking on contains_pts() method for canvas items
+- Removed references to distutils module, deprecated in python 3.12
 
 Ver 5.0.0 (2024-02-24)
 ======================

--- a/ginga/opengl/CanvasRenderGL.py
+++ b/ginga/opengl/CanvasRenderGL.py
@@ -9,7 +9,7 @@ import os.path
 import numpy as np
 import ctypes
 import threading
-from distutils.version import LooseVersion
+from packaging.version import parse as parse_version
 
 from OpenGL import GL as gl
 
@@ -26,7 +26,7 @@ from .glsl import __file__
 shader_dir, _ = os.path.split(__file__)
 
 # NOTE: we update the version later in gl_initialize()
-opengl_version = LooseVersion('3.0')
+opengl_version = parse_version('3.0')
 
 
 class RenderContext(render.RenderContextBase):
@@ -559,7 +559,7 @@ class CanvasRenderer(vec.VectorRenderMixin, render.StandardPipelineRenderer):
                          "Shader: '%(shader_version)s' "
                          "Max texture: '%(max_tex)s'" % d)
 
-        opengl_version = LooseVersion(d['opengl_version'].split(' ')[0])
+        opengl_version = parse_version(d['opengl_version'].split(' ')[0])
 
         if self.use_offscreen_fbo:
             self.create_offscreen_fbo()

--- a/ginga/rv/plugins/MultiDim.py
+++ b/ginga/rv/plugins/MultiDim.py
@@ -43,7 +43,7 @@ to step through the planes in that axis.
 import time
 import re
 import os
-from distutils import spawn
+from shutil import which
 from contextlib import contextmanager
 
 from ginga.gw import Widgets
@@ -55,7 +55,7 @@ from ginga.util.videosink import VideoSink
 import numpy as np
 
 have_mencoder = False
-if spawn.find_executable("mencoder"):
+if which("mencoder") is not None:
     have_mencoder = True
 
 __all__ = ['MultiDim']

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,7 @@ install_requires =
     pillow>=9.2
     pyyaml>=6.0
     tomli>=2.0.1; python_full_version < '3.11.0a7'
+    packaging>=23.1
 setup_requires = setuptools_scm
 
 [options.extras_require]


### PR DESCRIPTION
- fix #1095

for rationale, [see this](https://docs.python.org/3.10/whatsnew/3.10.html#distutils-deprecated)

This will be applied also to the 5.0.1 release.
