### PR TITLE
ENH: Compass N-E to be more robust

### DIFF
--- a/ginga/util/wcs.py
+++ b/ginga/util/wcs.py
@@ -760,18 +760,25 @@ def calc_compass(image, x, y, len_deg_e, len_deg_n):
 
 
 def calc_compass_radius(image, x, y, radius_px):
-    xe, ye = add_offset_xy(image, x, y, 1.0, 0.0)
-    xn, yn = add_offset_xy(image, x, y, 0.0, 1.0)
+    # Define an angular length we can use to determine the pixel scale
+    # along east and north - we want to make sure we use a small length so
+    # that the offset points still fall inside the image in case they have
+    # a bounding box set.
+
+    delta = 0.1 / 3600  # 0.1 arcsec
+
+    xe, ye = add_offset_xy(image, x, y, delta, 0.0)
+    xn, yn = add_offset_xy(image, x, y, 0.0, delta)
 
     # now calculate the length in pixels of those arcs
     # (planar geometry is good enough here)
-    px_per_deg_e = math.sqrt(math.fabs(ye - y)**2 + math.fabs(xe - x)**2)
-    px_per_deg_n = math.sqrt(math.fabs(yn - y)**2 + math.fabs(xn - x)**2)
+    px_per_delta_e = math.sqrt(math.fabs(ye - y)**2 + math.fabs(xe - x)**2)
+    px_per_delta_n = math.sqrt(math.fabs(yn - y)**2 + math.fabs(xn - x)**2)
 
     # now calculate the arm length in degrees for each arm
     # (this produces same-length arms)
-    len_deg_e = radius_px / px_per_deg_e
-    len_deg_n = radius_px / px_per_deg_n
+    len_deg_e = radius_px / px_per_delta_e * delta
+    len_deg_n = radius_px / px_per_delta_n * delta
 
     return calc_compass(image, x, y, len_deg_e, len_deg_n)
 


### PR DESCRIPTION
Compass N-E to be more robust by using small angular offsets when determining compass properties.

This is from https://github.com/spacetelescope/jdaviz/pull/2867 by @astrofrog on the same piece of algorithm we borrowed from Ginga (https://github.com/spacetelescope/jdaviz/blob/main/licenses/GINGA_LICENSE.txt).