### PR TITLE
TST: Fix Astropy minversion for Lorentz1D result change

### DIFF
--- a/ginga/tests/test_iqcalc.py
+++ b/ginga/tests/test_iqcalc.py
@@ -10,7 +10,7 @@ from ginga.util import iqcalc, iqcalc_astropy
 from ginga.util.iqcalc import have_scipy  # noqa
 from ginga.util.iqcalc_astropy import have_photutils  # noqa
 
-ASTROPY_LT_7_0 = not minversion("astropy", "7.0.dev")
+ASTROPY_LT_6_1_3 = not minversion("astropy", "6.1.3")
 
 
 @pytest.mark.parametrize(
@@ -287,7 +287,7 @@ class TestIQCalcFWHMAstropy(TestIQCalcFWHM):
         self.fwhm_funcs = (self.iqcalc.calc_fwhm_gaussian,
                            self.iqcalc.calc_fwhm_moffat,
                            self.iqcalc.calc_fwhm_lorentz)
-        if ASTROPY_LT_7_0:
+        if ASTROPY_LT_6_1_3:
             lorentz_ans = (1.9570, 1.8113)
         else:
             # https://github.com/astropy/astropy/pull/16794


### PR DESCRIPTION
The patch was backported and is now in Astropy ~~6.3.1~~ 6.1.3, which should be the minversion. That is a trivial fix to https://github.com/ejeschke/ginga/pull/1106#discussion_r1739880234.